### PR TITLE
Feature: Travle 도메인 - Destination 엔티티 및 Tag 엔티티 작성

### DIFF
--- a/src/main/java/com/se/Tlog/domain/Travle/Entity/Destination.java
+++ b/src/main/java/com/se/Tlog/domain/Travle/Entity/Destination.java
@@ -1,0 +1,56 @@
+package com.se.Tlog.domain.Travle.Entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.ColumnDefault;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Destination {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private int id;
+	
+	private String name;
+	
+	private String location;
+
+	@OneToMany(mappedBy = "destination")
+	private List<DestinationTag> tagList = new ArrayList<>();
+	
+	private int rating;
+	
+	@ColumnDefault("false")
+	private boolean verified;
+	
+	public void addTag(Tag tag) {
+		tagList.add(
+				DestinationTag.builder()
+				.destination(this)
+				.tag(tag)
+				.build());
+	}
+	
+	public void verify() {
+		this.verified = true;
+	}
+	
+	@Builder
+	public Destination(String name, String location, int rating) {
+		this.name = name;
+		this.location = location;
+		this.rating = rating;
+	}
+}

--- a/src/main/java/com/se/Tlog/domain/Travle/Entity/DestinationRepository.java
+++ b/src/main/java/com/se/Tlog/domain/Travle/Entity/DestinationRepository.java
@@ -1,0 +1,9 @@
+package com.se.Tlog.domain.Travle.Entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DestinationRepository extends JpaRepository<Destination, Integer> {
+
+}

--- a/src/main/java/com/se/Tlog/domain/Travle/Entity/DestinationTag.java
+++ b/src/main/java/com/se/Tlog/domain/Travle/Entity/DestinationTag.java
@@ -1,0 +1,37 @@
+package com.se.Tlog.domain.Travle.Entity;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DestinationTag {
+	@EmbeddedId
+	private DestinationTagPK id;
+
+	@ManyToOne
+	@MapsId("destination_id")
+	@JoinColumn
+	private Destination destination;
+	
+	@ManyToOne
+	@MapsId("tag_id")
+	@JoinColumn
+	private Tag tag;
+	
+	@Builder
+	public DestinationTag(Destination destination, Tag tag) {
+		this.destination = destination;
+		this.tag = tag;
+		this.id = new DestinationTagPK(destination.getId(), tag.getId());
+	}
+}

--- a/src/main/java/com/se/Tlog/domain/Travle/Entity/DestinationTagPK.java
+++ b/src/main/java/com/se/Tlog/domain/Travle/Entity/DestinationTagPK.java
@@ -1,0 +1,14 @@
+package com.se.Tlog.domain.Travle.Entity;
+
+import java.io.Serializable;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+public class DestinationTagPK implements Serializable {
+	private int destination_id;
+	private int tag_id;
+}

--- a/src/main/java/com/se/Tlog/domain/Travle/Entity/DestinationTagRepository.java
+++ b/src/main/java/com/se/Tlog/domain/Travle/Entity/DestinationTagRepository.java
@@ -1,0 +1,9 @@
+package com.se.Tlog.domain.Travle.Entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DestinationTagRepository extends JpaRepository<DestinationTag, DestinationTagPK> {
+
+}

--- a/src/main/java/com/se/Tlog/domain/Travle/Entity/Tag.java
+++ b/src/main/java/com/se/Tlog/domain/Travle/Entity/Tag.java
@@ -1,0 +1,33 @@
+package com.se.Tlog.domain.Travle.Entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private int id;
+	
+	private String name;
+	
+	@OneToMany(mappedBy = "tag")
+	private List<DestinationTag> destinationList = new ArrayList<>();
+	
+	@Builder
+	public Tag(String name) {
+		this.name = name;
+	}
+}

--- a/src/main/java/com/se/Tlog/domain/Travle/Entity/TagRepository.java
+++ b/src/main/java/com/se/Tlog/domain/Travle/Entity/TagRepository.java
@@ -1,0 +1,9 @@
+package com.se.Tlog.domain.Travle.Entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Integer> {
+
+}

--- a/src/test/java/com/se/Tlog/domain/Travle/Entity/DestinationTest.java
+++ b/src/test/java/com/se/Tlog/domain/Travle/Entity/DestinationTest.java
@@ -1,0 +1,74 @@
+package com.se.Tlog.domain.Travle.Entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@Transactional
+class DestinationTest {
+	@Autowired
+	private JpaRepository<Destination, Integer> destinationRepository;
+
+	@Autowired
+	private JpaRepository<DestinationTag, DestinationTagPK> desTagRepository;
+
+	@Autowired
+	private JpaRepository<Tag, Integer> tagRepository;
+	
+	@DisplayName("여행지 등록 테스트")
+	@Test
+	void destinationGenerate() {
+		// Given
+		Destination destination = Destination.builder()
+				.location("여행지 주소")
+				.name("여행지 이름")
+				.rating(5)
+				.build();
+		Tag tag1 = Tag.builder().name("테스트 태그1").build();
+		Tag tag2 = Tag.builder().name("테스트 태그2").build();
+		Tag tag3 = Tag.builder().name("테스트 태그3").build();
+		
+		// When
+		destination.addTag(tag1);
+		destination.addTag(tag2);
+		destination.addTag(tag3);
+
+		tagRepository.save(tag1);
+		tagRepository.save(tag2);
+		tagRepository.save(tag3);
+		
+		destinationRepository.save(destination);
+		
+		desTagRepository.saveAll(destination.getTagList());
+		
+		// Then
+		assertThat(tagRepository.findById(tag1.getId())).isNotNull();
+		assertThat(tagRepository.findById(tag2.getId())).isNotNull();
+		assertThat(tagRepository.findById(tag3.getId())).isNotNull();
+		
+		assertThat(destinationRepository.findById(destination.getId())).isNotNull();
+		
+		assertThat(desTagRepository.findById(
+				new DestinationTagPK(
+						destination.getId(),
+						tag1.getId()))
+				).isNotNull();
+		assertThat(desTagRepository.findById(
+				new DestinationTagPK(
+						destination.getId(),
+						tag2.getId()))
+				).isNotNull();
+		assertThat(desTagRepository.findById(
+				new DestinationTagPK(
+						destination.getId(),
+						tag3.getId()))
+				).isNotNull();
+	}
+}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #10

## 추가 및 변경사항
- Destination 엔티티 작성
  - **여행지별 여러 태그 지원을 위해 Tag와의 N:M 관계 도입 :**
   Tag 엔티티 작성
   DestinationTag 엔티티 작성 _: N:M 관계 매핑 테이블의 역할을 맡습니다._
  - **DestinationTag 엔티티의 키를 복합키로 설정 :**
   DestinationTagPK
- 각 엔티티별 리포지토리 작성
  - DestinationRepository
  - TagRepository
  - DestinationTagRepository
   
- 태그를 포함한 여행지 등록 상황 테스트
  - DestinationTest 작성

## 테스트 결과
  - 여행지 등록 기능 이상 무

## 📌 기타
