### PR TITLE
Feature: TravelCourse 엔티티 작성

### DIFF
--- a/src/main/java/com/se/Tlog/domain/Travle/Entity/TravelCourse.java
+++ b/src/main/java/com/se/Tlog/domain/Travle/Entity/TravelCourse.java
@@ -28,10 +28,14 @@ public class TravelCourse {
 	private User user;
 	
 	@OneToMany
-	private List<Destination> course = new ArrayList<Destination>();
+	private List<TravelCourseDestination> course = new ArrayList<TravelCourseDestination>();
 	
 	public void addDestination(Destination destination) {
-		course.add(destination);
+		course.add(
+				TravelCourseDestination.builder()
+				.travelCourse(this)
+				.destination(destination)
+				.build());
 	}
 	
 	@Builder

--- a/src/main/java/com/se/Tlog/domain/Travle/Entity/TravelCourse.java
+++ b/src/main/java/com/se/Tlog/domain/Travle/Entity/TravelCourse.java
@@ -1,0 +1,41 @@
+package com.se.Tlog.domain.Travle.Entity;
+
+import java.util.ArrayList;
+import java.util.List;
+import com.se.Tlog.domain.User.Entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TravelCourse {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private int id;
+
+	@ManyToOne
+	@JoinColumn(name = "userId")
+	private User user;
+	
+	@OneToMany
+	private List<Destination> course = new ArrayList<Destination>();
+	
+	public void addDestination(Destination destination) {
+		course.add(destination);
+	}
+	
+	@Builder
+	public TravelCourse(User user) {
+		this.user = user;
+	}
+}

--- a/src/main/java/com/se/Tlog/domain/Travle/Entity/TravelCourseDestination.java
+++ b/src/main/java/com/se/Tlog/domain/Travle/Entity/TravelCourseDestination.java
@@ -1,0 +1,48 @@
+package com.se.Tlog.domain.Travle.Entity;
+
+import io.micrometer.common.lang.NonNull;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+public class TravelCourseDestination {
+	@Embeddable
+	@EqualsAndHashCode
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	@AllArgsConstructor
+	@Getter
+	public static class PK {
+		private int travelCourseId;
+		private int destinationId;
+	}
+	
+	@EmbeddedId
+	private PK id;
+	
+	@ManyToOne
+	@JoinColumn
+	@MapsId("travelCourseId")
+	private TravelCourse travelCourse;
+
+	@ManyToOne
+	@JoinColumn
+	@MapsId("destinationId")
+	private Destination destination;
+	
+	@Builder
+	public TravelCourseDestination(@NonNull TravelCourse travelCourse, @NonNull Destination destination) {
+		this.travelCourse = travelCourse;
+		this.destination = destination;
+		this.id = new PK(travelCourse.getId(), destination.getId());
+	}
+}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #16

## 추가 및 변경사항
- TravelCourse 엔티티 작성
- **여행 코스 내 여러 여행지(Destination)를 표시하기 위해
  N:M 관계 도입**
  - 관계 테이블을 위해 TravelCourseDestination 엔티티 작성
