### PR TITLE
Feature: 소셜 로그인 기반 로직 추가 (#23)

### DIFF
--- a/src/main/java/com/se/Tlog/domain/User/Service/AuthenticationService.java
+++ b/src/main/java/com/se/Tlog/domain/User/Service/AuthenticationService.java
@@ -1,0 +1,38 @@
+package com.se.Tlog.domain.User.Service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.se.Tlog.domain.User.SsoApiWrapper;
+import com.se.Tlog.domain.User.SsoType;
+import com.se.Tlog.domain.User.dto.SsoLoginRequest;
+import com.se.Tlog.global.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthenticationService {
+	@Autowired
+	private final SsoApiWrapper apiWrapper;
+	
+	/**
+	 * 사용자에게 외부 소셜 로그인을 요청하는 데이터를 반환합니다.
+	 * @param type
+	 * @return
+	 */
+	public SsoLoginRequest getSsoLoginRequest(SsoType type) {
+		return new SsoLoginRequest(apiWrapper.getAuthLoginUrl(type));
+	}
+	
+	/**
+	 * 사용자 응답 후 소셜 로그인 결과를 처리합니다.
+	 * @param type
+	 * @param code
+	 * @exception CustomException 로그인 처리가 실패할 경우 발생.
+	 */
+	public void checkSsoAuthCode(SsoType type, String code) {
+		String token = apiWrapper.getAccessToken(type, code);
+		// 토큰 확인시 로그인, 회원가입 등등 처리
+	}
+}

--- a/src/main/java/com/se/Tlog/domain/User/SsoApiWrapper.java
+++ b/src/main/java/com/se/Tlog/domain/User/SsoApiWrapper.java
@@ -1,0 +1,125 @@
+package com.se.Tlog.domain.User;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+@Component
+public class SsoApiWrapper {
+	// 각 SSO Auth 제공 서버별 인증 요청 API 규격입니다.
+	// (GET 프로토콜)
+	private final String KAKAO_REQUEST_API = "https://kauth.kakao.com/oauth/authorize";
+	private final String GOOGLE_REQUEST_API = "https://accounts.google.com/o/oauth2/v2/auth";
+
+	// 각 SSO Auth 제공 서버별 AccessToken 요청 API 규격입니다.
+	// (POST 프로토콜)
+	private final String KAKAO_AUTHORIZATION_API = "https://kauth.kakao.com/oauth/token";
+	private final String GOOGLE_AUTHORIZATION_API = "https://oauth2.googleapis.com/token";
+	
+	// Auth 서비스 연결을 위한 애플리케이션 등록 id 
+	@Value("${sso.clientId.kakao}")
+	private String KAKAO_CLIENT_ID;
+	@Value("${sso.clientId.google}")
+	private String GOOGLE_CLIENT_ID;
+
+	// Auth 서비스 연결을 위한 애플리케이션 등록 secret key
+	@Value("${sso.clientSecret.google}")
+	private String GOOGLE_CLIENT_SECRET;
+	
+	// 로그인 요청시 callback(redirect)받을 url
+	@Value("${sso.callback.kakao}")
+	private String KAKAO_CALLBACK;
+	@Value("${sso.callback.google}")
+	private String GOOGLE_CALLBACK;
+	
+	
+	public String getAuthLoginUrl(SsoType type) {
+		if (type == SsoType.KAKAO) {
+			return getKakaoLoginUrl();
+		}
+		if (type == SsoType.GOOGLE) {
+			return getGoogleLoginUrl();
+		}
+		
+		throw new CustomException(ErrorType.UNSUPPORTED_SSO_LOGIN);
+	}
+	
+	/**
+	 * 지정된 SSO Auth 제공 서버로부터 accessToken 획득을 요청합니다.
+	 * @param type
+	 * @param code
+	 * @return
+	 * @exception CustomException 액세스 토큰 취득에 실패할 경우 발생.
+	 */
+	public String getAccessToken(SsoType type, String code) {
+		if (type == SsoType.KAKAO) {
+			return getKakaoAccessToken(code);
+		}
+		if (type == SsoType.GOOGLE) {
+			return getGoogleAccessToken(code);
+		}
+		
+		throw new CustomException(ErrorType.UNSUPPORTED_SSO_LOGIN);
+	}
+	
+	private String getKakaoLoginUrl() {
+		return KAKAO_REQUEST_API +
+				"?client_id=" + KAKAO_CLIENT_ID
+				+ "&redirect_uri=" + KAKAO_CALLBACK
+				+ "&response_type=code";
+	}
+
+	private String getGoogleLoginUrl() {
+		return GOOGLE_REQUEST_API +
+				"?client_id=" + GOOGLE_CLIENT_ID
+				+ "&redirect_uri=" + GOOGLE_CALLBACK
+				+ "&scope=" + "email"
+				+ "&response_type=code";
+	}
+	
+	private String getKakaoAccessToken(String code) {
+		try {
+			return RestClient.create().post()
+					.uri(KAKAO_AUTHORIZATION_API)
+					.header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+					.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+					.body(
+							"grant_type=authorization_code"
+							+ "&client_id=" + KAKAO_CLIENT_ID
+							+ "&redirect_uri=" + KAKAO_CALLBACK
+							+ "&code=" + code)
+					.retrieve()
+					.toEntity(String.class)
+					.getBody();
+		}
+		catch (RestClientResponseException e) {
+			throw new CustomException(ErrorType.SSO_ACCESSTOKEN_FAIL);
+		}
+	}
+	
+	private String getGoogleAccessToken(String code) {
+		try {
+			return RestClient.create().post()
+					.uri(GOOGLE_AUTHORIZATION_API)
+					.header("Content-Type", "application/x-www-form-urlencoded")
+					.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+					.body(
+							"grant_type=authorization_code"
+							+ "&client_id=" + GOOGLE_CLIENT_ID
+							+ "&client_secret=" + GOOGLE_CLIENT_SECRET
+							+ "&code=" + code
+							+ "&redirect_uri=" + GOOGLE_CALLBACK)
+					.retrieve()
+					.toEntity(String.class)
+					.getBody();
+		}
+		catch (RestClientResponseException e) {
+			throw new CustomException(ErrorType.SSO_ACCESSTOKEN_FAIL);
+		}
+	}
+}

--- a/src/main/java/com/se/Tlog/domain/User/SsoType.java
+++ b/src/main/java/com/se/Tlog/domain/User/SsoType.java
@@ -1,0 +1,6 @@
+package com.se.Tlog.domain.User;
+
+public enum SsoType {
+	KAKAO,
+	GOOGLE
+}

--- a/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
+++ b/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
@@ -1,0 +1,62 @@
+package com.se.Tlog.domain.User.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.se.Tlog.domain.User.SsoType;
+import com.se.Tlog.domain.User.Service.AuthenticationService;
+import com.se.Tlog.domain.User.dto.SsoLoginRequest;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+	@Autowired
+	private final AuthenticationService authService;
+	
+	@GetMapping("/sso/login/kakao")
+	public ResponseEntity<SsoLoginRequest> getSsoLoginByKakao() {
+		return ResponseEntity.ok(authService.getSsoLoginRequest(SsoType.KAKAO));
+	}
+
+	@GetMapping("/sso/login/google")
+	public ResponseEntity<SsoLoginRequest> getSsoLoginByGoogle() {
+		return ResponseEntity.ok(authService.getSsoLoginRequest(SsoType.GOOGLE));
+	}
+
+	@GetMapping("/sso/callback/kakao")
+	public ResponseEntity<?> getSsoCallbackByKakao(
+			@RequestParam(name = "code", required = false) String code,
+			@RequestParam(name = "error", required = false) String error) {
+		if (error != null)
+			throw new CustomException(ErrorType.SSO_LOGIN_FAIL);
+		
+		authService.checkSsoAuthCode(SsoType.KAKAO, code);
+		return ResponseEntity
+                .status(SuccessType.LOGIN_SSO_SUCCESS.getStatus())
+                .body(SuccessRes.from(SuccessType.LOGIN_SSO_SUCCESS));
+	}
+
+	@GetMapping("/sso/callback/google")
+	public ResponseEntity<?> getSsoCallbackByGoogle(
+			@RequestParam(name = "code", required = false) String code,
+			@RequestParam(name = "error", required = false) String error) {
+		if (error != null)
+			throw new CustomException(ErrorType.SSO_LOGIN_FAIL);
+		
+		authService.checkSsoAuthCode(SsoType.GOOGLE, code);
+		return ResponseEntity
+                .status(SuccessType.LOGIN_SSO_SUCCESS.getStatus())
+                .body(SuccessRes.from(SuccessType.LOGIN_SSO_SUCCESS));
+	}
+}

--- a/src/main/java/com/se/Tlog/domain/User/dto/SsoLoginRequest.java
+++ b/src/main/java/com/se/Tlog/domain/User/dto/SsoLoginRequest.java
@@ -1,0 +1,15 @@
+package com.se.Tlog.domain.User.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SsoLoginRequest {
+	/**
+	 * 사용자에게 외부 소셜 로그인을 요청할 url입니다.
+	 */
+	private String ssoLoginUrl;
+}

--- a/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -11,6 +11,9 @@ public enum ErrorType {
     // 400 잘못된 요청
     CONTENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "Content 내용이 비어있습니다."),
     ROLE_MISMATCH(HttpStatus.BAD_REQUEST,"Role 값을 잘못 입력하였습니다."),
+    
+    // 사용자로부터 소셜 로그인 인증 실패
+    SSO_LOGIN_FAIL(HttpStatus.BAD_REQUEST,"외부 소셜 로그인이 취소되거나 실패했습니다."),
 
     // 인증
     // 401
@@ -30,7 +33,13 @@ public enum ErrorType {
     ALREADY_EXISTS_DESTINATION(HttpStatus.CONFLICT, "이미 존재하는 여행지입니다."),
     // 서버 에러
     // 500
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. 서버 팀으로 연락주시기 바랍니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. 서버 팀으로 연락주시기 바랍니다."),
+    
+    // 외부 소셜 로그인 처리 중 에러
+    SSO_ACCESSTOKEN_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "외부 인증 서버로부터 인증을 받는데 실패했습니다."),
+
+    // 501 구현되지 않은 기능
+    UNSUPPORTED_SSO_LOGIN(HttpStatus.NOT_IMPLEMENTED, "현재 해당 소셜 로그인 방식은 아직 지원되지 않습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/se/Tlog/global/response/success/SuccessType.java
+++ b/src/main/java/com/se/Tlog/global/response/success/SuccessType.java
@@ -11,6 +11,7 @@ public enum SuccessType {
     // 200
     OK(HttpStatus.OK, "요청이 성공했습니다."),
     LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공하였습니다."),
+    LOGIN_SSO_SUCCESS(HttpStatus.OK, "소셜 로그인에 성공하였습니다."),
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공하였습니다."),
     REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급에 성공하였습니다."),
     AVAILABLE_ID(HttpStatus.OK, "사용가능한 아이디입니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,3 +33,13 @@ jwt:
   issuer: ${JWT_ISSUER}
   access-expiration: ${JWT_ACCESS_EXPIRATION}
   refresh-expiration: ${JWT_REFRESH_EXPIRATION}
+  
+sso:
+  clientId:
+    kakao: ${SSO_KAKAO_CLIENT_ID}
+    google: ${SSO_GOOGLE_CLIENT_ID}
+  callback:
+    kakao: ${SSO_CALLBACK_URL}/kakao
+    google: ${SSO_CALLBACK_URL}/google
+  clientSecret:
+    google: ${SSO_GOOGLE_SECRET}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #23
- 소셜 로그인 기능을 포함하기 위해 기본 설계 도입

## 추가 및 변경사항
- **kakao, google 소셜 로그인 api가 추가되었습니다.**
  `{host}/api/auth/sso/login/{service}`
  현재 지원되는 `{service}`는 다음과 같습니다 :
    - `kakao`
    - `google`
- **외부로부터 소셜 로그인 api를 요청하면 다음과 같은 규격으로 로그인 url를 반환합니다.**
`{ "ssoLoginUrl": "${LOGIN_URL}" }`

## 테스트 결과
- **로그인 요청**
  소셜로그인 url를 반환합니다.
  <img src="https://github.com/user-attachments/assets/d28c5a67-d009-4e29-9cb5-d724d391e216" height="400">

- **사용자의 로그인 동작 후 처리 결과**
  1. 로그인 성공
  ![응답 성공](https://github.com/user-attachments/assets/c9cbf1d3-9df2-40af-9403-a59352fd2f11)
  2. 로그인 취소/실패
  ![로그인 취소](https://github.com/user-attachments/assets/70fa3878-c381-4c2a-9fe5-5190f860c4ee)
  3. 인증 서버에서의 실패
  ![인증 실패](https://github.com/user-attachments/assets/86a218de-1bbf-4b74-b516-0e324be72ace)

## 📌 기타
- **고려사항**
  단순 웹 응답 형태 외에도, 모바일 자체 앱 내부에서 로그인 처리를 진행하는 방식도 있으므로,
  해당 방식과 어떻게 연계할지가 해결과제.