### PR TITLE
Feature: TbtiQuestion API 작성 

### DIFF
--- a/src/main/java/com/se/Tlog/domain/Tbti/Entity/TbtiQuestion.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/Entity/TbtiQuestion.java
@@ -23,18 +23,15 @@ public class TbtiQuestion {
     @Enumerated(EnumType.STRING)
     private TraitCategory traitCategory;
 
-    @Builder
     public TbtiQuestion(String content, TraitCategory traitCategory) {
+        validateContent(content);
         this.content = content;
         this.traitCategory = traitCategory;
     }
 
     // 질문 생성 메서드
-    public static TbtiQuestion creation(String content, TraitCategory traitCategory) {
-        return TbtiQuestion.builder()
-                .content(content)
-                .traitCategory(traitCategory)
-                .build();
+    public static TbtiQuestion create(String content, TraitCategory traitCategory) {
+        return new TbtiQuestion(content, traitCategory);
     }
 
     // 유효성 검사 메서드

--- a/src/main/java/com/se/Tlog/domain/Tbti/Entity/TbtiQuestion.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/Entity/TbtiQuestion.java
@@ -3,11 +3,11 @@ package com.se.Tlog.domain.Tbti.Entity;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import jakarta.persistence.*;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static jakarta.persistence.GenerationType.IDENTITY;
+import java.util.UUID;
+
 import static lombok.AccessLevel.*;
 
 @Entity
@@ -15,8 +15,8 @@ import static lombok.AccessLevel.*;
 @NoArgsConstructor(access = PROTECTED)
 public class TbtiQuestion {
     @Id
-    @GeneratedValue(strategy = IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
 
     private String content;
 
@@ -41,6 +41,11 @@ public class TbtiQuestion {
         }
         // 필요한 검사가 있다면 지속적으로 추가할 예정!
     }
+
+    public void delete(){
+
+    }
+
 
 
 }

--- a/src/main/java/com/se/Tlog/domain/Tbti/Entity/TraitCategory.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/Entity/TraitCategory.java
@@ -1,8 +1,19 @@
 package com.se.Tlog.domain.Tbti.Entity;
 
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
 public enum TraitCategory {
     ACTIVITY_LEVEL, // 활동적 ↔ 여유로움
     LOCATION_PREFERENCE, // 자연 ↔ 도시
     PLANNING_STYLE, // 계획적 ↔ 즉흥적
-    RISK_TAKING // 개척적 ↔ 안정적
+    RISK_TAKING; // 개척적 ↔ 안정적
+
+    public static TraitCategory fromString(String traitCategory) {
+        try {
+            return TraitCategory.valueOf(traitCategory.toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new CustomException(ErrorType.INVALID_TBTI_CATEGORY);
+        }
+    }
 }

--- a/src/main/java/com/se/Tlog/domain/Tbti/Entity/repository/TbtiQuestionRepository.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/Entity/repository/TbtiQuestionRepository.java
@@ -1,0 +1,11 @@
+package com.se.Tlog.domain.Tbti.Entity.repository;
+
+import com.se.Tlog.domain.Tbti.Entity.TbtiQuestion;
+import com.se.Tlog.domain.Tbti.Entity.TraitCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TbtiQuestionRepository extends JpaRepository<TbtiQuestion,Long> {
+    Page<TbtiQuestion> findByTraitCategory(TraitCategory traitCategory, Pageable pageable);
+}

--- a/src/main/java/com/se/Tlog/domain/Tbti/Entity/repository/TbtiQuestionRepository.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/Entity/repository/TbtiQuestionRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TbtiQuestionRepository extends JpaRepository<TbtiQuestion,Long> {
+import java.util.UUID;
+
+public interface TbtiQuestionRepository extends JpaRepository<TbtiQuestion, UUID> {
     Page<TbtiQuestion> findByTraitCategory(TraitCategory traitCategory, Pageable pageable);
 }

--- a/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiController.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiController.java
@@ -10,6 +10,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 
 @RestController
 @RequestMapping("/api/tbti")
@@ -35,4 +37,13 @@ public class TbtiController {
         return ResponseEntity.ok()
                 .body(SuccessRes.from(SuccessType.OK));
     }
+    @DeleteMapping("/{tbtiQuestionId}")
+    public ResponseEntity<?> deleteTbtiQuestion(@PathVariable(name = "tbtiQuestionId") UUID tbtiQuestionId) {
+        tbtiService.deleteTbtiQuestion(tbtiQuestionId);
+        return ResponseEntity.ok()
+                .body(SuccessRes.from(SuccessType.OK));
+    }
+
+
+
 }

--- a/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiController.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiController.java
@@ -1,0 +1,38 @@
+package com.se.Tlog.domain.Tbti.controller;
+
+import com.se.Tlog.domain.Tbti.dto.TbtiQuestionReq;
+import com.se.Tlog.domain.Tbti.service.TbtiService;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/tbti")
+@RequiredArgsConstructor
+public class TbtiController {
+
+    final TbtiService tbtiService;
+
+    @GetMapping
+    public ResponseEntity<?> getAllTbtiQuestion(
+            @RequestParam(name = "categories", required = false) String traitCategory,
+            @PageableDefault(size = 10) Pageable pageable
+    ){
+        if (traitCategory == null || traitCategory.isEmpty())
+            return ResponseEntity.ok().body(SuccessRes.from(tbtiService.getAllTbtiQuestion(pageable)));
+        return ResponseEntity.ok().body(SuccessRes.from(tbtiService.getAllTbtiQuestionByTraitCategory(traitCategory, pageable)));
+    }
+
+    @PostMapping
+    public ResponseEntity<?> createTbtiQuestion(@RequestBody TbtiQuestionReq tbtiQuestionReq){
+        tbtiService.createTbtiQuestion(tbtiQuestionReq);
+
+        return ResponseEntity.ok()
+                .body(SuccessRes.from(SuccessType.OK));
+    }
+}

--- a/src/main/java/com/se/Tlog/domain/Tbti/dto/TbtiQuestionReq.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/dto/TbtiQuestionReq.java
@@ -1,0 +1,18 @@
+package com.se.Tlog.domain.Tbti.dto;
+
+import com.se.Tlog.domain.Tbti.Entity.TbtiQuestion;
+import com.se.Tlog.domain.Tbti.Entity.TraitCategory;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TbtiQuestionReq {
+
+    String content;
+    TraitCategory traitCategory;
+
+    public static TbtiQuestion toEntity(TbtiQuestionReq tbtiQuestionReq){
+        return TbtiQuestion.create(tbtiQuestionReq.getContent(), tbtiQuestionReq.getTraitCategory());
+    }
+}

--- a/src/main/java/com/se/Tlog/domain/Tbti/dto/TbtiQuestionRes.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/dto/TbtiQuestionRes.java
@@ -3,15 +3,17 @@ package com.se.Tlog.domain.Tbti.dto;
 import com.se.Tlog.domain.Tbti.Entity.TbtiQuestion;
 import com.se.Tlog.domain.Tbti.Entity.TraitCategory;
 
-
+import java.util.UUID;
 
 
 public record TbtiQuestionRes(
+        UUID id,
         String content,
         TraitCategory traitCategory
 ) {
     public static TbtiQuestionRes from(TbtiQuestion tbtiQuestion) {
         return new TbtiQuestionRes(
+                tbtiQuestion.getId(),
                 tbtiQuestion.getContent(),
                 tbtiQuestion.getTraitCategory()
         );

--- a/src/main/java/com/se/Tlog/domain/Tbti/dto/TbtiQuestionRes.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/dto/TbtiQuestionRes.java
@@ -1,0 +1,19 @@
+package com.se.Tlog.domain.Tbti.dto;
+
+import com.se.Tlog.domain.Tbti.Entity.TbtiQuestion;
+import com.se.Tlog.domain.Tbti.Entity.TraitCategory;
+
+
+
+
+public record TbtiQuestionRes(
+        String content,
+        TraitCategory traitCategory
+) {
+    public static TbtiQuestionRes from(TbtiQuestion tbtiQuestion) {
+        return new TbtiQuestionRes(
+                tbtiQuestion.getContent(),
+                tbtiQuestion.getTraitCategory()
+        );
+    }
+}

--- a/src/main/java/com/se/Tlog/domain/Tbti/service/TbtiService.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/service/TbtiService.java
@@ -5,11 +5,15 @@ import com.se.Tlog.domain.Tbti.Entity.TraitCategory;
 import com.se.Tlog.domain.Tbti.Entity.repository.TbtiQuestionRepository;
 import com.se.Tlog.domain.Tbti.dto.TbtiQuestionReq;
 import com.se.Tlog.domain.Tbti.dto.TbtiQuestionRes;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -36,5 +40,13 @@ public class TbtiService {
         TraitCategory traitCategoryEnum = TraitCategory.fromString(traitCategory);
         return tbtiQuestionRepository.findByTraitCategory(traitCategoryEnum, pageable)
                 .map(TbtiQuestionRes::from);
+    }
+
+    @Transactional
+    public void deleteTbtiQuestion(UUID tbtiQuestionId) {
+        TbtiQuestion tbtiQuestion = tbtiQuestionRepository.findById(tbtiQuestionId)
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+
+        tbtiQuestionRepository.delete(tbtiQuestion);
     }
 }

--- a/src/main/java/com/se/Tlog/domain/Tbti/service/TbtiService.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/service/TbtiService.java
@@ -1,0 +1,40 @@
+package com.se.Tlog.domain.Tbti.service;
+
+import com.se.Tlog.domain.Tbti.Entity.TbtiQuestion;
+import com.se.Tlog.domain.Tbti.Entity.TraitCategory;
+import com.se.Tlog.domain.Tbti.Entity.repository.TbtiQuestionRepository;
+import com.se.Tlog.domain.Tbti.dto.TbtiQuestionReq;
+import com.se.Tlog.domain.Tbti.dto.TbtiQuestionRes;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TbtiService {
+
+    final TbtiQuestionRepository tbtiQuestionRepository;
+
+    @Transactional
+    public void createTbtiQuestion(TbtiQuestionReq tbtiQuestionReq) {
+        TbtiQuestion tbtiQuestion = TbtiQuestion.create(
+                tbtiQuestionReq.getContent(),
+                tbtiQuestionReq.getTraitCategory()
+        );
+
+        tbtiQuestionRepository.save(tbtiQuestion);
+    }
+
+    public Page<TbtiQuestionRes> getAllTbtiQuestion(Pageable pageable) {
+        return tbtiQuestionRepository.findAll(pageable).map(TbtiQuestionRes::from);
+    }
+
+    public Page<TbtiQuestionRes> getAllTbtiQuestionByTraitCategory(String traitCategory, Pageable pageable) {
+
+        TraitCategory traitCategoryEnum = TraitCategory.fromString(traitCategory);
+        return tbtiQuestionRepository.findByTraitCategory(traitCategoryEnum, pageable)
+                .map(TbtiQuestionRes::from);
+    }
+}

--- a/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -28,6 +28,7 @@ public enum ErrorType {
     NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 데이터 입니다."),
     NOT_FOUND_TAG(HttpStatus.NOT_FOUND, "존재하지 않는 태그 입니다."),
     ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "역할이 존재하지 않습니다."),
+    INVALID_TBTI_CATEGORY(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리 입니다."),
     //데이터 충돌
     ALREADY_EXISTS_TAG(HttpStatus.CONFLICT, "이미 존재하는 태그입니다."),
     ALREADY_EXISTS_DESTINATION(HttpStatus.CONFLICT, "이미 존재하는 여행지입니다."),

--- a/src/test/java/com/se/Tlog/domain/tlog/TbtiQuestionTest.java
+++ b/src/test/java/com/se/Tlog/domain/tlog/TbtiQuestionTest.java
@@ -19,7 +19,7 @@ public class TbtiQuestionTest {
 
     String content = "너는 여행을 계획할 때 활동적인게 좋아?";
     TraitCategory traitCategory = TraitCategory.ACTIVITY_LEVEL;
-    TbtiQuestion tbtiQuestion = TbtiQuestion.creation(content, traitCategory);
+    TbtiQuestion tbtiQuestion = TbtiQuestion.create(content, traitCategory);
 
 
     @Test


### PR DESCRIPTION
## 작업 동기 및 이슈
- #25 

## 추가 및 변경사항
- Tbti 질문 생성 및 요청 API 작성
- TbtiQuestion 엔티티 생성 메소드 변경(무결성을 위해 리팩토링)

## 테스트 결과

### 질문 요청 API

<img width="1312" alt="질문 요청 API" src="https://github.com/user-attachments/assets/8817f539-0004-463e-8f63-6cb872cf76cb" />

- 질문 전체 요청, 특정 카테고리 질문 요청, 질문 개수등 원하는 대로 요청 가능합니다.

### 질문 생성 API

<img width="1068" alt="질문 생성 API" src="https://github.com/user-attachments/assets/45144160-e808-4560-a914-f3a683b23a88" />

### 질문 삭제 API
<img width="1059" alt="질문 삭제 API" src="https://github.com/user-attachments/assets/a971b2cf-40cf-448d-8e21-1adf18ceadc8" />
- db에서 삭제 잘 되는지 확인했습니다!

## 📌 기타
- 추후에 관리자만 질문 생성 할 수 있도록 권한 제한 해야합니다!
