### PR TITLE
Feature : 소셜 통합 유저 로그인 로직 작성

### DIFF
--- a/src/main/java/com/se/Tlog/config/SsoServiceConfig.java
+++ b/src/main/java/com/se/Tlog/config/SsoServiceConfig.java
@@ -1,0 +1,20 @@
+package com.se.Tlog.config;
+
+import com.se.Tlog.domain.User.Service.SsoService;
+import com.se.Tlog.domain.User.SsoType;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Configuration
+public class SsoServiceConfig {
+    @Bean
+    public Map<SsoType, SsoService> ssoServiceMap(List<SsoService> ssoServices) {
+        return ssoServices.stream()
+                .collect(Collectors.toMap(SsoService::getType, Function.identity()));
+    }
+}

--- a/src/main/java/com/se/Tlog/domain/User/Entity/User.java
+++ b/src/main/java/com/se/Tlog/domain/User/Entity/User.java
@@ -1,11 +1,8 @@
 package com.se.Tlog.domain.User.Entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.se.Tlog.domain.User.dto.SsoUserInfo;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,26 +17,30 @@ public class User {
     @GeneratedValue(strategy = GenerationType.UUID)
     UUID id;
 
-    private String userId;
-    private String password;
+    String providerUserInfo;
 
     private String name;
     private String email;
-    private String telephoneNumber;
+    //private String telephoneNumber; 사용자가 동의하지 않은 경우 못받을 수 있음 nullable 하게 관리
+
+    @Enumerated(EnumType.STRING)
     private Role role;
 
-    @Builder
-    public User(
+    private User(
             String name,
-            String userId,
-            String email,
-            String telephoneNumber
+            String provider,
+            String providerId,
+            String email
+
     ) {
         this.name = name;
-        this.userId = userId;
-        //this.providerUserInfo = provider + " " + providerId;
+        this.providerUserInfo = provider + " " + providerId;
         this.email = email;
-        this.telephoneNumber = telephoneNumber;
+//        this.telephoneNumber = telephoneNumber;
         this.role = Role.USER;
     }
+    public static User create(SsoUserInfo ssoUserInfo){
+        return new User(ssoUserInfo.email(), ssoUserInfo.provider(),ssoUserInfo.providerId(), ssoUserInfo.email());
+    }
+
 }

--- a/src/main/java/com/se/Tlog/domain/User/Service/GoogleSsoService.java
+++ b/src/main/java/com/se/Tlog/domain/User/Service/GoogleSsoService.java
@@ -2,6 +2,7 @@ package com.se.Tlog.domain.User.Service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.se.Tlog.domain.User.SsoType;
 import com.se.Tlog.domain.User.dto.SsoUserInfo;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
@@ -32,5 +33,10 @@ public class GoogleSsoService implements SsoService{
         } catch (Exception e) {
             throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    @Override
+    public SsoType getType() {
+        return SsoType.GOOGLE;
     }
 }

--- a/src/main/java/com/se/Tlog/domain/User/Service/GoogleSsoService.java
+++ b/src/main/java/com/se/Tlog/domain/User/Service/GoogleSsoService.java
@@ -1,0 +1,36 @@
+package com.se.Tlog.domain.User.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.se.Tlog.domain.User.dto.SsoUserInfo;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+@Service
+public class GoogleSsoService implements SsoService{
+    private final String GOOGLE_USER_INFO_API = "https://www.googleapis.com/oauth2/v3/userinfo";
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public SsoUserInfo getUserInfo(String accessToken) {
+        try {
+            ResponseEntity<String> response = RestClient.create().get()
+                    .uri(GOOGLE_USER_INFO_API)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .toEntity(String.class);
+
+            JsonNode jsonNode = objectMapper.readTree(response.getBody());
+            return SsoUserInfo.from(jsonNode, "google");
+        } catch (RestClientResponseException e) {
+            throw new CustomException(ErrorType.GOOGLE_AUTH_FAIL);
+        } catch (Exception e) {
+            throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/se/Tlog/domain/User/Service/KakaoSsoService.java
+++ b/src/main/java/com/se/Tlog/domain/User/Service/KakaoSsoService.java
@@ -1,0 +1,45 @@
+package com.se.Tlog.domain.User.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.se.Tlog.domain.User.dto.SsoUserInfo;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+@Service
+public class KakaoSsoService implements SsoService {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String KAKAO_USER_INFO_API = "https://kapi.kakao.com/v2/user/me";
+
+    @Override
+    public SsoUserInfo getUserInfo(String accessToken) {
+            try{
+                System.out.println("🔹 [DEBUG] Access Token: " + accessToken);
+
+                ResponseEntity<String> response = RestClient.create().get()
+                        .uri(KAKAO_USER_INFO_API)
+                        .header(HttpHeaders.AUTHORIZATION,"Bearer " + accessToken)
+                        .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded;charset=utf-8")
+                        .retrieve()
+                        .toEntity(String.class);
+
+                System.out.println("🔹 [DEBUG] Kakao API Response: " + response.getBody());
+
+                JsonNode jsonNode = objectMapper.readTree(response.getBody());
+                // 전화번호 정보 가져오기 (사용자가 동의했을 경우에만 존재)
+                // String phoneNumber = jsonNode.path("kakao_account").path("phone_number").asText(null);
+
+                return SsoUserInfo.from(jsonNode,"kakao");
+            } catch (RestClientResponseException e){
+                System.err.println("❌ [ERROR] Kakao API 호출 실패: " + e.getStatusCode() + " / " + e.getResponseBodyAsString());
+                throw new CustomException(ErrorType.KAKAO_AUTH_FAIL);
+            } catch (Exception e) {
+                throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
+            }
+    }
+}

--- a/src/main/java/com/se/Tlog/domain/User/Service/KakaoSsoService.java
+++ b/src/main/java/com/se/Tlog/domain/User/Service/KakaoSsoService.java
@@ -2,6 +2,7 @@ package com.se.Tlog.domain.User.Service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.se.Tlog.domain.User.SsoType;
 import com.se.Tlog.domain.User.dto.SsoUserInfo;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
@@ -41,5 +42,10 @@ public class KakaoSsoService implements SsoService {
             } catch (Exception e) {
                 throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
             }
+    }
+
+    @Override
+    public SsoType getType() {
+        return SsoType.KAKAO;
     }
 }

--- a/src/main/java/com/se/Tlog/domain/User/Service/SsoAuthService.java
+++ b/src/main/java/com/se/Tlog/domain/User/Service/SsoAuthService.java
@@ -1,0 +1,46 @@
+package com.se.Tlog.domain.User.Service;
+
+import com.se.Tlog.domain.User.Entity.User;
+import com.se.Tlog.domain.User.SsoType;
+import com.se.Tlog.domain.User.dto.LoginRequest;
+import com.se.Tlog.domain.User.dto.SsoUserInfo;
+import com.se.Tlog.domain.User.dto.TokenDto;
+import com.se.Tlog.domain.User.repository.UserRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import com.se.Tlog.global.util.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SsoAuthService {
+    private final KakaoSsoService kakaoSsoService;
+    private final GoogleSsoService googleSsoService;
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    public TokenDto login(LoginRequest loginRequest){
+        String ssoAccessToken = loginRequest.accessToken();
+        SsoType type = loginRequest.type();
+
+        SsoUserInfo ssoUserInfo = switch (type){
+            case KAKAO -> kakaoSsoService.getUserInfo(ssoAccessToken);
+            case GOOGLE -> googleSsoService.getUserInfo(ssoAccessToken);
+            default -> throw new CustomException(ErrorType.UNSUPPORTED_SSO_LOGIN);
+        };
+        System.out.println("ssoUserInfo = " + ssoUserInfo);
+        String providerUserInfo = ssoUserInfo.provider() + " " + ssoUserInfo.providerId();
+
+        User user = userRepository.findByProviderUserInfo(providerUserInfo)
+                .orElseGet(() -> userRepository.save(User.create(ssoUserInfo)));
+
+        String accessToken = jwtUtil.generateAccessToken(user.getId().toString(), user.getRole().getValue());
+        String refreshToken = jwtUtil.generateRefreshToken(user.getId().toString(), user.getRole().getValue());
+
+        return TokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/se/Tlog/domain/User/Service/SsoAuthService.java
+++ b/src/main/java/com/se/Tlog/domain/User/Service/SsoAuthService.java
@@ -12,23 +12,21 @@ import com.se.Tlog.global.util.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class SsoAuthService {
-    private final KakaoSsoService kakaoSsoService;
-    private final GoogleSsoService googleSsoService;
+    private final Map<SsoType, SsoService> ssoServiceMap;
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
 
     public TokenDto login(LoginRequest loginRequest){
-        String ssoAccessToken = loginRequest.accessToken();
-        SsoType type = loginRequest.type();
+        SsoService ssoService = Optional.ofNullable(ssoServiceMap.get(loginRequest.type()))
+                .orElseThrow(() -> new CustomException(ErrorType.UNSUPPORTED_SSO_LOGIN));
 
-        SsoUserInfo ssoUserInfo = switch (type){
-            case KAKAO -> kakaoSsoService.getUserInfo(ssoAccessToken);
-            case GOOGLE -> googleSsoService.getUserInfo(ssoAccessToken);
-            default -> throw new CustomException(ErrorType.UNSUPPORTED_SSO_LOGIN);
-        };
+        SsoUserInfo ssoUserInfo = ssoService.getUserInfo(loginRequest.accessToken());
         System.out.println("ssoUserInfo = " + ssoUserInfo);
         String providerUserInfo = ssoUserInfo.provider() + " " + ssoUserInfo.providerId();
 

--- a/src/main/java/com/se/Tlog/domain/User/Service/SsoService.java
+++ b/src/main/java/com/se/Tlog/domain/User/Service/SsoService.java
@@ -1,7 +1,9 @@
 package com.se.Tlog.domain.User.Service;
 
+import com.se.Tlog.domain.User.SsoType;
 import com.se.Tlog.domain.User.dto.SsoUserInfo;
 
 public interface SsoService {
     SsoUserInfo getUserInfo(String accessToken);
+    SsoType getType();
 }

--- a/src/main/java/com/se/Tlog/domain/User/Service/SsoService.java
+++ b/src/main/java/com/se/Tlog/domain/User/Service/SsoService.java
@@ -1,0 +1,7 @@
+package com.se.Tlog.domain.User.Service;
+
+import com.se.Tlog.domain.User.dto.SsoUserInfo;
+
+public interface SsoService {
+    SsoUserInfo getUserInfo(String accessToken);
+}

--- a/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
+++ b/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
@@ -1,11 +1,10 @@
 package com.se.Tlog.domain.User.controller;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import com.se.Tlog.domain.User.Service.SsoAuthService;
+import com.se.Tlog.domain.User.dto.LoginRequest;
+import com.se.Tlog.domain.User.dto.TokenDto;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.se.Tlog.domain.User.SsoType;
 import com.se.Tlog.domain.User.Service.AuthenticationService;
@@ -21,9 +20,10 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
-	@Autowired
+
 	private final AuthenticationService authService;
-	
+	private final SsoAuthService ssoService;
+
 	@GetMapping("/sso/login/kakao")
 	public ResponseEntity<SsoLoginRequest> getSsoLoginByKakao() {
 		return ResponseEntity.ok(authService.getSsoLoginRequest(SsoType.KAKAO));
@@ -58,5 +58,16 @@ public class AuthController {
 		return ResponseEntity
                 .status(SuccessType.LOGIN_SSO_SUCCESS.getStatus())
                 .body(SuccessRes.from(SuccessType.LOGIN_SSO_SUCCESS));
+	}
+
+	@PostMapping("login/user")
+	public ResponseEntity<?> login(@RequestBody LoginRequest request){
+
+		TokenDto tokenDto = ssoService.login(request);
+
+		return ResponseEntity.ok()
+				.header("Authorization",tokenDto.accessToken())
+				.header("Set-Cookie",tokenDto.refreshToken())
+				.body(SuccessRes.from(SuccessType.LOGIN_SSO_SUCCESS));
 	}
 }

--- a/src/main/java/com/se/Tlog/domain/User/dto/LoginRequest.java
+++ b/src/main/java/com/se/Tlog/domain/User/dto/LoginRequest.java
@@ -1,0 +1,10 @@
+package com.se.Tlog.domain.User.dto;
+
+import com.se.Tlog.domain.User.SsoType;
+
+
+public record LoginRequest(
+        SsoType type,
+        String accessToken
+) {
+}

--- a/src/main/java/com/se/Tlog/domain/User/dto/SsoUserInfo.java
+++ b/src/main/java/com/se/Tlog/domain/User/dto/SsoUserInfo.java
@@ -1,0 +1,18 @@
+package com.se.Tlog.domain.User.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record SsoUserInfo(
+        String providerId,
+        String email,
+        String nickname,
+        String provider
+) {
+    public static SsoUserInfo from(JsonNode jsonNode, String provider) {
+        String providerId = jsonNode.path("id").asText();
+        String email = jsonNode.path("email").asText();
+        String nickname = jsonNode.path("nickname").asText();
+
+        return new SsoUserInfo(providerId, email, nickname, provider);
+    }
+}

--- a/src/main/java/com/se/Tlog/domain/User/dto/TokenDto.java
+++ b/src/main/java/com/se/Tlog/domain/User/dto/TokenDto.java
@@ -1,0 +1,9 @@
+package com.se.Tlog.domain.User.dto;
+
+import lombok.Builder;
+
+@Builder
+public record TokenDto(
+        String accessToken,
+        String refreshToken
+) { }

--- a/src/main/java/com/se/Tlog/domain/User/repository/UserRepository.java
+++ b/src/main/java/com/se/Tlog/domain/User/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.se.Tlog.domain.User.repository;
+
+import com.se.Tlog.domain.User.Entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    Optional<User> findByProviderUserInfo(String providerUserInfo);
+
+}

--- a/src/main/java/com/se/Tlog/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/se/Tlog/global/exception/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<?> handleCustomException(CustomException e) {
         ErrorType errorType = e.getErrorType();
         ErrorRes error = ErrorRes.of(errorType.getStatusCode(), errorType.getMessage());
-        log.error("Error occurred : [errorCode={}, message={}]",e.getClass(), e.getMessage());;
+        log.error("Error occurred : [errorCode={}, message={}]",e.getClass(), e.getMessage(),e);;
         return ResponseEntity.status(error.status()).body(error);
     }
 

--- a/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -19,7 +19,8 @@ public enum ErrorType {
     // 401
     UN_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "인증이 실패되었습니다."),
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "로그인 실패입니다."),
-
+    KAKAO_AUTH_FAIL(HttpStatus.UNAUTHORIZED, "카카오 인증이 실패되었습니다."),
+    GOOGLE_AUTH_FAIL(HttpStatus.UNAUTHORIZED, "구글 인증이 실패되었습니다."),
     // 인가
     // 403
     UN_AUTHORIZATION(HttpStatus.FORBIDDEN, "허용되지 않은 접근입니다."),


### PR DESCRIPTION
## 작업 동기 및 이슈
- #27 

## 추가 및 변경사항
- 통합 소셜 로그인 로직 작성 
- 확장성을 고려한 로그인 로직 리팩터링 
- DDD 패턴과 무결성 보장을 위해 user 엔티티 메소드 리팩터링
-  로그인시 accessToken , refreshToken 발급 로직 작성 
## 테스트 결과

### 로그인 성공시 토큰 발급
<img width="1270" alt="로그인 성공시 토큰 발급 테스트" src="https://github.com/user-attachments/assets/64b28707-d5b9-46fc-ae23-6feadc0ce74b" />

- 쿠키와 헤더에 백엔드에서 발급하는 accessToken 과 refreshToken 이 잘 들어간 것을 확인 할 수 있습니다. 


### 로그인 성공시 로그 및 사용자 정보
<img width="1110" alt="로그인 성공시 로그 및 사용자 정보" src="https://github.com/user-attachments/assets/31202bfb-9670-403c-b213-9643571c717a" />

### 사용자 정보 DB 반영 테스트 
<img width="702" alt="사용자 정보 DB 반영 테스트 " src="https://github.com/user-attachments/assets/696d454d-ea7f-4d97-8980-c87333c08659" />


## 📌 기타
- 토큰 저장 및 처리방식을 추후에 정할 예정입니다.
- kakao 만 우선 테스트 했는데 google 도 테스트 해야합니다!
- 닉네임과 이메일은 사용자의 동의 처리를 해야 볼 수 있어서 나중에 동의 처리 작업 후 테스트 해야 합니다.

