### PR TITLE
Feature: API 문서화 라이브러리 도입 (Swagger UI)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/src/main/java/com/se/Tlog/config/OpenApiConfig.java
+++ b/src/main/java/com/se/Tlog/config/OpenApiConfig.java
@@ -1,0 +1,32 @@
+package com.se.Tlog.config;
+
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+
+@OpenAPIDefinition( // Swagger UI 페이지 설정
+        info = @Info(
+                title = "Tlog API 명세",
+                version = "v0.0",
+                description = "Tlog 백엔드 서버의 API 명세를 기록한 문서입니다."
+                // license = @License(name = "Apache 2.0", url = "http://foo.bar"),
+                // contact = @Contact(url = "http://myserver.com", name = "name", email = "name@email.com")
+        )
+)
+@SecurityScheme ( // Swagger UI 페이지 내 인증 기능 설정
+		name = "JwtAuthScheme",
+		description = "AccessToken을 설정합니다.",
+		// paramName = "KeyName", // ApiKey 타입일 경우 설정
+		bearerFormat = "JWT",
+		scheme = "bearer",
+		type = SecuritySchemeType.HTTP,
+		in = SecuritySchemeIn.HEADER
+)
+@Configuration
+public class OpenApiConfig {
+	
+}

--- a/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiController.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiController.java
@@ -1,9 +1,16 @@
 package com.se.Tlog.domain.Tbti.controller;
 
 import com.se.Tlog.domain.Tbti.dto.TbtiQuestionReq;
+import com.se.Tlog.domain.Tbti.dto.TbtiQuestionResponse;
 import com.se.Tlog.domain.Tbti.service.TbtiService;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -21,6 +28,25 @@ public class TbtiController {
     final TbtiService tbtiService;
 
     @GetMapping
+    @Operation (
+    		summary = "전체 TBTI 질문 가져오기",
+    		description = "모든 TBTI 질문을 반환합니다.",
+			tags = {"TBTI 도메인"},
+			security = @SecurityRequirement(
+					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+					scopes = {"scope1", "scope2"}),
+			parameters = {
+					@Parameter(name = "categories", description = "TBTI 특성 카테고리입니다."),
+					@Parameter(name = "pageable", description = "Page 정보")
+    		},
+			responses = {
+					@ApiResponse( responseCode = "200", description = "처리 성공시 반환되는 TBTI 질문 Page입니다.",
+							content = @Content(
+									mediaType = "application/json",
+									schema = @Schema(implementation = TbtiQuestionResponse.class)) // Generic 반환의 경우, 정확한 표시를 위해서는 별도의 class로 재정의 필요
+					), 
+					@ApiResponse(responseCode = "505", description = "서버 내부 오류")}
+	)
     public ResponseEntity<?> getAllTbtiQuestion(
             @RequestParam(name = "categories", required = false) String traitCategory,
             @PageableDefault(size = 10) Pageable pageable
@@ -31,13 +57,37 @@ public class TbtiController {
     }
 
     @PostMapping
+    @Operation (
+    		summary = "새 TBTI 질문 등록하기",
+    		description = "새 TBTI 질문을 등록합니다.",
+			tags = {"TBTI 도메인"},
+			security = @SecurityRequirement(
+					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+					scopes = {"scope1", "scope2"}),
+			responses = {
+					@ApiResponse( responseCode = "200", description = "성공"), 
+					@ApiResponse(responseCode = "505", description = "서버 내부 오류")}
+	)
     public ResponseEntity<?> createTbtiQuestion(@RequestBody TbtiQuestionReq tbtiQuestionReq){
         tbtiService.createTbtiQuestion(tbtiQuestionReq);
 
         return ResponseEntity.ok()
                 .body(SuccessRes.from(SuccessType.OK));
     }
+    
     @DeleteMapping("/{tbtiQuestionId}")
+    @Operation (
+    		summary = "TBTI 질문 삭제하기",
+    		description = "TBTI 질문을 삭제합니다.",
+			tags = {"TBTI 도메인"},
+			security = @SecurityRequirement(
+					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+					scopes = {"scope1", "scope2"}),
+			parameters = {@Parameter(name = "tbtiQuestionId", description = "삭제할 TBTI 질문의 UUID입니다.")},
+			responses = {
+					@ApiResponse( responseCode = "200", description = "성공"), 
+					@ApiResponse(responseCode = "505", description = "서버 내부 오류")}
+	)
     public ResponseEntity<?> deleteTbtiQuestion(@PathVariable(name = "tbtiQuestionId") UUID tbtiQuestionId) {
         tbtiService.deleteTbtiQuestion(tbtiQuestionId);
         return ResponseEntity.ok()

--- a/src/main/java/com/se/Tlog/domain/Tbti/dto/TbtiQuestionReq.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/dto/TbtiQuestionReq.java
@@ -2,14 +2,19 @@ package com.se.Tlog.domain.Tbti.dto;
 
 import com.se.Tlog.domain.Tbti.Entity.TbtiQuestion;
 import com.se.Tlog.domain.Tbti.Entity.TraitCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "TBTI 질문 요청 DTO")
 public class TbtiQuestionReq {
 
+	@Schema(description = "질문의 내용입니다.")
     String content;
+	
+	@Schema(description = "TBTI 유형입니다.")
     TraitCategory traitCategory;
 
     public static TbtiQuestion toEntity(TbtiQuestionReq tbtiQuestionReq){

--- a/src/main/java/com/se/Tlog/domain/Tbti/dto/TbtiQuestionRes.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/dto/TbtiQuestionRes.java
@@ -3,12 +3,20 @@ package com.se.Tlog.domain.Tbti.dto;
 import com.se.Tlog.domain.Tbti.Entity.TbtiQuestion;
 import com.se.Tlog.domain.Tbti.Entity.TraitCategory;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.UUID;
 
-
+@Schema(description = "TBTI 질문 응답 DTO")
 public record TbtiQuestionRes(
+		
+		@Schema(description = "TBTI 질문의 고유 UUID")
         UUID id,
+        
+        @Schema(description = "TBTI 질문의 표시 내용")
         String content,
+        
+        @Schema(description = "질문지의 TBTI 영역")
         TraitCategory traitCategory
 ) {
     public static TbtiQuestionRes from(TbtiQuestion tbtiQuestion) {

--- a/src/main/java/com/se/Tlog/domain/Tbti/dto/TbtiQuestionResponse.java
+++ b/src/main/java/com/se/Tlog/domain/Tbti/dto/TbtiQuestionResponse.java
@@ -1,0 +1,10 @@
+package com.se.Tlog.domain.Tbti.dto;
+
+import org.springframework.data.domain.Page;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "응답된 TBTI 질문을 담는 Page 객체입니다.")
+public abstract class TbtiQuestionResponse implements Page<TbtiQuestionRes> {
+	
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,3 +48,12 @@ sso:
     google: ${SSO_CALLBACK_URL}/google
   clientSecret:
     google: ${SSO_GOOGLE_SECRET}
+    
+# springdoc swagger
+springdoc:
+  api-docs:
+    # false : Disabling the /v3/api-docs endpoint
+    enabled: true
+  swagger-ui:
+    # false : Disabling the swagger-ui
+    enabled: true


### PR DESCRIPTION
## 작업 동기 및 이슈
- #31 
- 추후 프론트엔드 팀과의 협업을 용이하게 하기 위함.
- API 명세 문서화를 코드로 관리하여 문서 관리에 용이함.

## 추가 및 변경사항
### 1) 라이브러리 도입
  - SpringDoc의존성 추가 : Swagger UI 및 OpenAPI 등 필요 의존성을 모두 포함
  - application.yml 내 속성 추가 : **Swagger UI 활성화 속성 포함 - 실제 운영시 비활성화 하는 것이 바람직함**

- 기본 Swagger UI 명세 작성
  - OpenApiConfig 작성
    - Swagger UI 페이지 제목, 버전, 설명
    - Swagger 내에서 사용할 인증 방식 설정
  ![스크린샷 2025-03-08 105504](https://github.com/user-attachments/assets/a849e6d0-2410-40d1-aff6-39abac32130b)

### 2) 예제 겸 API 명세 작성
   TBTI Question과 관련된 API 명세 작성
  - DTO 및 데이터 교환 형식 적용 (a36a908e1804315c0b4612133a3bfdc2af879047)
    - **주의 : Generic이 포함된 타입은 별도의 클래스로 타입을 재정의해야 Swagger UI에서 올바르게 표시됨** (ba4e3786aaa321105f32976804703249a7e54041)
    - 좌측 : 별도 타입으로 재정의한 경우   /   우측 : 타입 재정의 생략한 경우
    ![제목 없음](https://github.com/user-attachments/assets/ac61642a-7ea2-476c-928d-35b2330c6586)
  - API 별 명세 작성 (18a811ff5e856d90fae10f70ff48c6f4064e66f8)

## 테스트 결과

### 1) 테스트 환경
- Swagger UI 페이지는 서버에서 자동으로 생성되는 페이지입니다.
  ->  http://localhost:8080/swagger-ui/index.html 에서 확인

### 2) 기본 페이지 표시
- OpenApiConfig에서 작성
- 페이지 제목, 버전, 설명, 그 외 연락처 등등의 정보 작성 가능
- 문서 내에서 전역으로 적용할 인증 방식 설정 가능 (하단에 추가 설명 작성)
   <img src="https://github.com/user-attachments/assets/a849e6d0-2410-40d1-aff6-39abac32130b" height="300">

### 3) 페이지 전역 인증 적용
- OpenApiConfig에서 작성
- 각 API별로 적용될 인증값을 미리 설정하는 기능
- Http Header를 이용한 bearer 토큰 방식 외에도
   ApiKey, Basic 방식 등을 지원
   <img src="https://github.com/user-attachments/assets/e2252acc-ee0d-4f4f-bd47-e9d6ba0fedcf" height="300">

### 4) 데이터 교환 형식 표시
- 각 DTO에서 작성
- 설명, 기본값, 필수여부 등 명세 작성 가능
     <img src="https://github.com/user-attachments/assets/8ec787ae-2c68-4768-93a1-70d14588798c" height="300">


### 5) 각 API 별 명세 표시
- 각 컨트롤러 및 API 메소드에서 작성
- API 태그로 묶기 가능 ("TBTI 도메인" 등)
- API 기본 설명 작성 가능
- API 인증 정보 (인증방식, scope 등) 설정 가능
- API Parameter / RequestBody 관련 명세 작성 가능
- API 응답 유형 작성 가능

    <img src="https://github.com/user-attachments/assets/551306e1-ed76-4c41-89fc-eed754d733a8" height="300">
    <img src="https://github.com/user-attachments/assets/271c0a36-70c5-4f43-9823-47b2fac89607" height="300">

## 📌 기타
참고 : 
- 관련 팀 문서 : https://www.notion.so/Swagger-API-1afc8b877abb80ad85e5fe7a4ab332e7?pvs=4
- 기타 기능 공식문서 : https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Annotations
