### PR TITLE
Fix: User.name 속성 기입 문제 및 TbtiQuestionTest 컴파일 문제 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
 
 	testImplementation 'com.jayway.jsonpath:json-path'
 	testImplementation 'org.springframework:spring-test'
+	
+	testAnnotationProcessor 'org.projectlombok:lombok'
 
 
 }

--- a/src/main/java/com/se/Tlog/domain/User/Entity/User.java
+++ b/src/main/java/com/se/Tlog/domain/User/Entity/User.java
@@ -42,6 +42,6 @@ public class User {
         this.role = Role.USER;
     }
     public static User create(SsoUserInfo ssoUserInfo){
-        return new User(ssoUserInfo.email(), ssoUserInfo.provider(),ssoUserInfo.providerId(), ssoUserInfo.email());
+        return new User(ssoUserInfo.nickname(), ssoUserInfo.provider(),ssoUserInfo.providerId(), ssoUserInfo.email());
     }
 }

--- a/src/test/java/com/se/Tlog/domain/tlog/TbtiQuestionTest.java
+++ b/src/test/java/com/se/Tlog/domain/tlog/TbtiQuestionTest.java
@@ -4,6 +4,8 @@ import com.se.Tlog.domain.Tbti.Entity.TbtiAnswer;
 import com.se.Tlog.domain.Tbti.Entity.TbtiQuestion;
 import com.se.Tlog.domain.Tbti.Entity.TraitCategory;
 import com.se.Tlog.domain.User.Entity.User;
+import com.se.Tlog.domain.User.dto.SsoUserInfo;
+
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,12 +37,17 @@ public class TbtiQuestionTest {
     @Test
     @DisplayName("질문 응답 테스트")
     void tbtiAnswerTest() {
-        User user = User.builder()
-                .userId("test1")
-                .email("aaa@naver.com")
-                .name("강진후")
-                .telephoneNumber("010-2222-2222")
-                .build();
+    	// User 객체의 생성 로직 설계중임에 따라,
+    	// 임시로 로직 변경
+    	// -> (소셜 로그인 형태로 User 생성하도록 임시조치)
+    	User user = User.create(
+    			new SsoUserInfo(
+    					"TEST_PROVIDER_ID", 
+		    			"aaa@naver.com", 
+		    			"강진후",
+		    			"TEST_PROVIDER"));
+    	// phoneNumber : "010-2222-2222"
+    	
         int score = 3;
         TbtiAnswer tbtiAnswer = TbtiAnswer.createAnswer(user,tbtiQuestion,score);
         log.info("creation answer with score: '{}' and question content: '{}'", score, tbtiQuestion.getContent());


### PR DESCRIPTION
## 작업 동기 및 이슈
- #35 
- #36 

## 추가 및 변경사항
- #35
  - User.create() 로직에서 name 속성이 올바르게 기입되도록 수정
- #36
  - **build.gradle** : test환경에서도 컴파일시 lombok을 활용한 어노테이션 처리를 사용하도록 설정 추가
  - **TbtiQuestionTest** : 변경된 User 객체 생성 방식에 맞추어 생성 로직 수정

## 테스트 결과
- User 생성시 name 속성 이상 무
- TbtiQuestionTest 테스트 실행시 통과

## 📌 기타
