### PR TITLE
Feature/search auto complete

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/application/SearchService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/application/SearchService.java
@@ -1,0 +1,19 @@
+package com.se.Tlog.domain.Search.application;
+
+import java.util.List;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Search.repository.DestinationRawData;
+import com.se.Tlog.domain.Search.repository.mongo.DestinationSearchRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class SearchService {
+	private final DestinationSearchRepository searchRepository;
+	
+	public List<DestinationRawData> autoComplete(String searchText) {
+		return searchRepository.autoCompleteBy(searchText);
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/controller/SearchController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/controller/SearchController.java
@@ -1,0 +1,50 @@
+package com.se.Tlog.domain.Search.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.se.Tlog.domain.Search.application.SearchService;
+import com.se.Tlog.domain.Search.controller.dto.SearchResultDto;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.success.SuccessRes;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/api/search")
+@RequiredArgsConstructor
+public class SearchController {
+	private final SearchService searchService;
+	
+	@GetMapping("/destination")
+	@Operation (
+			summary = "여행지 이름, 주소 자동완성 검색",
+    		description = "여행지 이름, 주소에 대한 자동완성 검색 결과를 반환합니다.",
+			tags = {"검색"},
+			parameters = { @Parameter(name = "searchText", description = "자동 완성을 요청할 미완성 문구입니다.") },
+			security = @SecurityRequirement(
+					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+					scopes = {"scope1", "scope2"}),
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공, 검색된 결과를 리스트로 반환합니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류. 조회에 실패했습니다.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<List<SearchResultDto>>> searchDestinationUsingAutoComplete(@RequestParam String searchText) {
+		List<SearchResultDto> result = searchService.autoComplete(searchText)
+				.stream().map((entity) -> new SearchResultDto(entity.getId(), entity.getName(), entity.getAddress()))
+				.toList();
+		return ResponseEntity.ok(SuccessRes.from(result));
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/controller/dto/SearchResultDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/controller/dto/SearchResultDto.java
@@ -1,0 +1,16 @@
+package com.se.Tlog.domain.Search.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "여행지 검색 결과를 나타내는 DTO입니다.")
+public record SearchResultDto(
+		@Schema(description = "여행지 id")
+		String id,
+		
+		@Schema(description = "여행지 이름")
+		String name,
+		
+		@Schema(description = "여행지 주소")
+		String address
+		) {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/repository/DestinationRawData.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/repository/DestinationRawData.java
@@ -1,0 +1,18 @@
+package com.se.Tlog.domain.Search.repository;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "destinations")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DestinationRawData {
+	@Id
+	private String id;
+	private String name;
+	private String address;
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/repository/mongo/DestinationSearchRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/repository/mongo/DestinationSearchRepository.java
@@ -1,0 +1,40 @@
+package com.se.Tlog.domain.Search.repository.mongo;
+
+import java.util.List;
+
+import org.springframework.data.mongodb.repository.Aggregation;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import com.se.Tlog.domain.Search.repository.DestinationRawData;
+
+@Repository
+public interface DestinationSearchRepository extends MongoRepository<DestinationRawData, String> {
+	// Atlas Search를 위한 Json 쿼리
+	@Aggregation(pipeline = {
+    		"""
+    		{ 
+	    		$search: {
+	    			'index' : 'destination_index', 
+	    			'compound': {
+    		 			'should': [
+    		 		 		{
+		 		 		 		'autocomplete': {
+    				 		 		'query': ?0,
+    				 		 		'path': 'name'
+				 		 		}
+			 		 		},
+			 		 		{
+			 		 			'autocomplete': {
+			 		 				'query': ?0,
+    				 				'path': 'address'
+				 				}
+			 				}
+		 				]
+					}
+				}
+			}
+    		"""
+    })
+    List<DestinationRawData> autoCompleteBy(String searchText);
+}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #50 
- 검색 기능 개발에 앞서 Atlas Search 사용환경을 구성하기 위해
  간단한 자동완성 기능을 구현합니다.

## 추가 및 변경사항
- 자동완성 기능 추가 (현재 이름과 주소로 검색이 가능합니다.)
### MongoDB Atlas 변경사항 :
- tlog.destinations 컬렉션에 name 및 address 필드를 기준으로 인덱싱을 적용시킨 상태입니다.
- 자동 검색 지원을 위해 AutoComplete 타입의 인덱싱을 적용했습니다.
  <img src="https://github.com/user-attachments/assets/432753df-8484-4f98-9daa-6f912df225c8" height="200"/>

### 현재 기능 구현 형태 :
- Search 도메인에서 별도의 MongoDB 접근 리포지토리를 구성합니다.

- 기초 검색 기능에 대해서는 DB단에서부터 지원되는 검색 기능을 활용해
  데이터를 바로 읽어오도록 구성되었습니다.

## 테스트 결과
- 현재 존재하는 데이터 범위에서 검색에 이상 무.
<img src="https://github.com/user-attachments/assets/82e6ae6d-a7b6-4364-8cc5-61c172a10b86" height="800"/>

## 📌 기타
