### PR TITLE
Setup: Spring의 개발환경과 배포환경 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 
 ## env ##
 .env.*
+*.env
 
 ### STS ###
 .apt_generated

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ LABEL authors="gojungsu"
 ARG JAR_FILE=../tlog-was/build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE}", "-jar", "/app.jar"]

--- a/tlog-docker/docker-compose.yml
+++ b/tlog-docker/docker-compose.yml
@@ -38,9 +38,9 @@ services:
       - "3306:3306"
     environment:
       MYSQL_DATABASE: tlog
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_USER: tloguser
-      MYSQL_PASSWORD: tlogpw
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_USER: ${MYSQL_USERNAME}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
     healthcheck:
       test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
       interval: 10s

--- a/tlog-docker/docker-compose.yml
+++ b/tlog-docker/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       - redis
       - mysql
     environment:
-      #SPRING_PROFILES_ACTIVE: dev
+      # prod / dev 모드 설정
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
       MYSQL_URL: ${MYSQL_URL}
       MYSQL_USERNAME: ${MYSQL_USERNAME}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}

--- a/tlog-was/src/main/resources/application.yml
+++ b/tlog-was/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
       prod: prod-env, common
     
     # 실행 모드 설정 (dev 또는 prod로 설정)
-    active: dev
+    active: ${SPRING_PROFILES_ACTIVE}
     
 ---
 

--- a/tlog-was/src/main/resources/application.yml
+++ b/tlog-was/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 
 # 실행환경 세팅
 spring:
+  config:
+    # 로컬 환경변수 파일 사용 (단, OS 환경변수보다 우선순위 낮음, 로컬에서만 적용됨, 빌드파일엔 포함 안됨)
+    import: optional:file:spring.env[.properties]
   profiles:
     group:
       # 개발모드 프로파일

--- a/tlog-was/src/main/resources/application.yml
+++ b/tlog-was/src/main/resources/application.yml
@@ -1,4 +1,50 @@
+
+# 실행환경 세팅
 spring:
+  profiles:
+    group:
+      # 개발모드 프로파일
+      dev: dev-env, common 
+      # 배포모드 프로파일
+      prod: prod-env, common
+    
+    # 실행 모드 설정 (dev 또는 prod로 설정)
+    active: dev
+    
+---
+
+# 개발 전용 프로파일
+spring:
+  config:
+    activate:
+      on-profile: dev-env
+    
+  # JPA 테이블은 항상 삭제 후 새로 생성
+  jpa:
+    hibernate:
+      ddl-auto: create
+    
+---
+
+# 배포 전용 프로파일
+spring:
+  config:
+    activate:
+      on-profile: prod-env
+  
+  # JPA 테이블 삭제 안함
+  jpa:
+    hibernate:
+      ddl-auto: update
+
+---
+
+# 공통 프로파일
+spring:
+  config:
+    activate:
+      on-profile: common
+  
   datasource:
     # MySQL
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -20,7 +66,6 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     open-in-view: false
     hibernate:
-     ddl-auto: create
      naming:
        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 


### PR DESCRIPTION
## 작업 동기 및 이슈
- #52 
- **기존 방식의 문제점 :**
  - Docker에서 실행할 때와 로컬에서 실행할 때의 환경변수 분리가 쉽지 않습니다.
  - 개발환경과 배포환경의 Spring 앱 설정 분리가 되어있지 않습니다.

## 추가 및 변경사항
### 1. 변경된 동작 방식 :

>   - **[Spring 설정 분리]** : 
>     - Spring의 실행모드가 **dev모드, prod모드 두 가지로 분리**되었습니다.
>     - 현재 분리한 영역은, ddl-auto를 create로 쓸지, update로 쓸지 정도로만 분리되었습니다.
>     
>   - **[Spring 환경변수 파일로 분리]** : 
>     - [기본적으로 OS 환경변수를 읽어오기] + [`spring.env` 파일이 있으면 그걸 읽어오기] 방식으로 세팅되었습니다.
>     - 그러나 `spring.env`는 빌드에 포함되지 않으므로 **로컬 IDE에서만 적용됩니다.**
>     -> Docker에서 실행한다면, **Docker의 환경변수로 자동 덮어쓰기**가 되는 셈!
> 
>   - **[Docker에서 Spring의 실행 모드 설정]** :
>     - Docker는 이전과 대부분 유사합니다.
>     - 그러나 이제 Spring의 실행 모드(dev/prod 등)를 지정할 수 있습니다.
>     - **이를 위해 환경변수 `SPRING_PROFILES_ACTIVE`가 별도로 추가되었습니다!**

### 2. 기타 변경사항 :

>   - 보안상의 문제를 위해 `docker-compose.yml`의 MySQL 관련 환경설정값이 숨겨지도록 수정되었습니다.
>     참고사항 : (81545c9988aa0b0706e9551a4c23c034cde29083)
>   - **이를 위해 환경변수 `MYSQL_ROOT_PASSWORD`가 별도로 추가되었습니다!**

### 3. 구체적인 수정 필요 사항 :

>   - **(필수) 환경변수 값이 추가되었습니다**
>     - Docker 환경변수(.env 등)에 다음 값을 추가해주세요!
>       - **MYSQL_ROOT_PASSWORD** : 하단 팀 공지 참고
>       - **SPRING_PROFILES_ACTIVE** : dev 또는 prod, 용도에 맞게 설정
>     - 로컬 환경변수에 다음 값을 추가해주세요!
>       - **SPRING_PROFILES_ACTIVE** : dev 또는 prod, 용도에 맞게 설정
>     
>   - **(권장) docker volume 삭제**
>     -  사유 : `docker-compose.yml` 내 mysql 환경설정값이 변경될 경우, 이를 적용하기 위해서는 볼륨 내용의 삭제가 권장됩니다.
>     - 필요하다면 `docker-compose down -v` 명령어를 사용해주세요.
>     -  **(단, mysql 컨테이너에 저장된 데이터가 사라질 수 있음!!)**
>    
>   - **(옵션) Spring 환경변수를 env파일로 사용하기**
>     - 현재 세팅 상태는, tlog-was 디렉토리의 `spring.env` 파일을 감지해 환경변수를 읽어오도록 되어있습니다.
>       (없으면 OS 환경변수값 활용) 
>     - 해당 위치에 세팅한 이유는, 빌드 파일에 환경변수 값이 포함되지 않도록 하기 위함입니다!
>       - src/main/resources와 같은 위치에 세팅할 경우,
>          jar 파일에 그대로 포함되어 노출에 취약하다는 점이 고려되었습니다.
>
>   - 구체적인 환경변수 변경사항 참고를 위해 팀 공지 노트 참고해주세요!
>     [Notion - Docker](https://www.notion.so/Docker-1b5c8b877abb805aa956c3e57bad7a7d?pvs=4#1bbc8b877abb80238f95eb9290fae9f5)

## 테스트 결과
- 로컬 실행 환경 이상 무.
  - 환경변수 **SPRING_PROFILES_ACTIVE**를 추가
  - 로컬 환경에서 OS 환경변수 및 spring.env 환경변수로 모두 테스트
  - 이상 무.
- Docker 실행 환경 이상 무.
```
  docker-compose down -v
  docker-compose up --build
```

## 📌 기타
