### PR TITLE
Feature: Redis Pub/Sub 기반 채팅 메시지 처리 구현

### DIFF
--- a/tlog-was/build.gradle
+++ b/tlog-was/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
 	implementation 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -57,6 +58,7 @@ dependencies {
 	
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
 }
 

--- a/tlog-was/src/main/java/com/se/Tlog/config/RedisConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/RedisConfig.java
@@ -1,11 +1,17 @@
 package com.se.Tlog.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.se.Tlog.domain.Social.Chat.service.RedisSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -24,13 +30,33 @@ public class RedisConfig {
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule()); // LocalDateTime 대응
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO 포맷 사용
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setValueSerializer(serializer); // 👈 여기 변경됨
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(serializer);
 
         return redisTemplate;
     }
 
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            RedisSubscriber redisSubscriber // MessageListener 구현체
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
 
+        // 구독할 채널 설정
+        container.addMessageListener(redisSubscriber, new ChannelTopic("chat"));
+
+        return container;
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/config/WebSocketConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/WebSocketConfig.java
@@ -1,0 +1,33 @@
+package com.se.Tlog.config;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        System.out.println("웹 소켓 endpoint registered"); // /ws-stomp를 웹 소켓 엔드포인트로 등록하여 통신 연결한다.
+        registry.addEndpoint("/ws-stomp")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+        //.addInterceptors(new HttpSessionHandshakeInterceptor())
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    //추후 InboundChannel 작성
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/ChatController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/ChatController.java
@@ -1,0 +1,33 @@
+package com.se.Tlog.domain.Social.Chat.controller;
+
+import com.se.Tlog.domain.Social.Chat.controller.dto.ChatMessageRequestDto;
+import com.se.Tlog.domain.Social.Chat.domain.ChatMessage;
+import com.se.Tlog.domain.Social.Chat.service.ChatService;
+import com.se.Tlog.domain.Social.Chat.service.RedisPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+public class ChatController {
+
+    private final ChatService chatService;
+    private final RedisPublisher redisPublisher;
+
+    @MessageMapping("/chat/message")
+    public void message(@Payload ChatMessageRequestDto chatMessageRequestDto) {
+        if (chatMessageRequestDto.senderId() == null || chatMessageRequestDto.chatRoomId() == null) {
+            log.warn("Invalid message payload: {}", chatMessageRequestDto);
+            throw new IllegalArgumentException("senderId와 chatRoomId는 필수입니다.");
+        }
+
+        ChatMessage message = chatService.createMessage(chatMessageRequestDto);
+        redisPublisher.publish(new ChannelTopic("chat"),message);
+    }
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/ChatRoomController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/ChatRoomController.java
@@ -1,0 +1,23 @@
+package com.se.Tlog.domain.Social.Chat.controller;
+
+import com.se.Tlog.domain.Social.Chat.controller.dto.ChatRoomResponseDto;
+import com.se.Tlog.domain.Social.Chat.domain.ChatRoom;
+import com.se.Tlog.domain.Social.Chat.service.ChatRoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+    @PostMapping("/room/{hostId}")
+    public ResponseEntity<?> createRoom(@PathVariable(name = "hostId") UUID hostId) {
+        ChatRoom chatRoom = chatRoomService.create(hostId);
+        return ResponseEntity.ok().body(ChatRoomResponseDto.from(chatRoom.getId(),chatRoom.getHostId()));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatMessageRequestDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatMessageRequestDto.java
@@ -1,0 +1,11 @@
+package com.se.Tlog.domain.Social.Chat.controller.dto;
+
+
+import java.util.UUID;
+
+public record ChatMessageRequestDto(
+        UUID senderId,
+        Long chatRoomId,
+        String content
+) {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatRoomResponseDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatRoomResponseDto.java
@@ -1,0 +1,12 @@
+package com.se.Tlog.domain.Social.Chat.controller.dto;
+
+import java.util.UUID;
+
+public record ChatRoomResponseDto(
+        Long roomId,
+        UUID hostId
+) {
+    public static ChatRoomResponseDto from(Long roomId, UUID hostId) {
+        return new ChatRoomResponseDto(roomId, hostId);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/domain/ChatMessage.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/domain/ChatMessage.java
@@ -1,0 +1,42 @@
+package com.se.Tlog.domain.Social.Chat.domain;
+
+import com.se.Tlog.domain.User.domain.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class ChatMessage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User sender;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "chatRoom_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    private String content;
+    private boolean isChecked;  // 메시지 확인여부
+
+    private LocalDateTime sendAt;
+
+    private ChatMessage(User sender, ChatRoom chatRoom, String content) {
+        this.sender = sender;
+        this.chatRoom = chatRoom;
+        this.content = content;
+        this.sendAt = LocalDateTime.now();
+    }
+
+    public static ChatMessage create(User sender, ChatRoom chatRoom, String content) {
+        return new ChatMessage(sender, chatRoom, content);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/domain/ChatRoom.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/domain/ChatRoom.java
@@ -1,0 +1,45 @@
+package com.se.Tlog.domain.Social.Chat.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ChatRoom {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private UUID hostId; //채팅방 생성한 유저
+
+    private Long lastChatId;
+
+    private LocalDateTime createAt = LocalDateTime.now();
+    private LocalDateTime deleteAt;
+
+
+    private ChatRoom(UUID hostId){
+        this.hostId = hostId;
+    }
+
+    public static ChatRoom create(UUID hostId) {
+        return new ChatRoom(hostId);
+    }
+
+    public void modifyLashMessage(Long lastChatId) {
+        this.lastChatId = lastChatId;
+    }
+
+    public void deleteChatRoom() {
+        this.deleteAt = LocalDateTime.now();
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/domain/ChatRoomUser.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/domain/ChatRoomUser.java
@@ -1,0 +1,40 @@
+package com.se.Tlog.domain.Social.Chat.domain;
+
+import com.se.Tlog.domain.User.domain.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class ChatRoomUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "chatRoom_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private LocalDateTime joinedAt;
+
+
+    public ChatRoomUser(ChatRoom chatRoom, User user) {
+        this.chatRoom = chatRoom;
+        this.user = user;
+        this.joinedAt = LocalDateTime.now();
+    }
+
+    public static ChatRoomUser join(ChatRoom chatRoom, User user) {
+        return new ChatRoomUser(chatRoom, user);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatRoomRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.se.Tlog.domain.Social.Chat.repository.jpa;
+
+import com.se.Tlog.domain.Social.Chat.domain.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom,Long> {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatRoomUserRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatRoomUserRepository.java
@@ -1,0 +1,9 @@
+package com.se.Tlog.domain.Social.Chat.repository.jpa;
+
+import com.se.Tlog.domain.Social.Chat.domain.ChatRoomUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, UUID> {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatRoomService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatRoomService.java
@@ -1,0 +1,35 @@
+package com.se.Tlog.domain.Social.Chat.service;
+
+import com.se.Tlog.domain.Social.Chat.domain.ChatRoom;
+import com.se.Tlog.domain.Social.Chat.domain.ChatRoomUser;
+import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatRoomRepository;
+import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatRoomUserRepository;
+import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+    private final ChatRoomUserRepository chatRoomUserRepository;
+
+    public ChatRoom create(UUID hostId) {
+        ChatRoom chatRoom = ChatRoom.create(hostId);
+        chatRoomRepository.save(chatRoom);
+        User host = userRepository.findById(hostId)
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+
+        ChatRoomUser chatRoomUser = ChatRoomUser.join(chatRoom,host);
+        chatRoomUserRepository.save(chatRoomUser);
+
+        return chatRoom;
+    }
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatService.java
@@ -1,0 +1,30 @@
+package com.se.Tlog.domain.Social.Chat.service;
+
+import com.se.Tlog.domain.Social.Chat.controller.dto.ChatMessageRequestDto;
+import com.se.Tlog.domain.Social.Chat.domain.ChatMessage;
+import com.se.Tlog.domain.Social.Chat.domain.ChatRoom;
+import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatRoomRepository;
+import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ChatService {
+    private final UserRepository userRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    public ChatMessage createMessage(ChatMessageRequestDto chatMessageRequestDto) {
+        User sender = userRepository.findById(chatMessageRequestDto.senderId())
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+        ChatRoom chatRoom = chatRoomRepository.findById(chatMessageRequestDto.chatRoomId())
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+
+        return ChatMessage.create(sender, chatRoom, chatMessageRequestDto.content());
+    }
+
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/RedisPublisher.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/RedisPublisher.java
@@ -1,0 +1,20 @@
+package com.se.Tlog.domain.Social.Chat.service;
+
+import com.se.Tlog.domain.Social.Chat.domain.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RedisPublisher {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // 채팅방에 입장하여 메시지를 작성하면 해당 메시지를 Redis Topic에 발행하는 기능
+    public void publish(ChannelTopic topic, ChatMessage message) {
+        System.out.println("topic = " + topic);
+        System.out.println("message = " + message);
+        redisTemplate.convertAndSend(topic.getTopic(), message);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/RedisSubscriber.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/RedisSubscriber.java
@@ -1,0 +1,36 @@
+package com.se.Tlog.domain.Social.Chat.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.se.Tlog.domain.Social.Chat.domain.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RedisSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+    private final RedisTemplate redisTemplate;
+    private final SimpMessageSendingOperations messagingTemplate;
+
+    /*
+    * Redis에서 메시지가 발행 되면 대기하고 있던 onMessage가 메시지를 받아 처리한다.
+    * */
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try{
+            String publishMessage = (String)redisTemplate.getStringSerializer().deserialize(message.getBody());
+            System.out.println("publishMessage = " + publishMessage);
+            ChatMessage roomMessage = objectMapper.readValue(publishMessage, ChatMessage.class);
+            messagingTemplate.convertAndSend("/sub/chat/room/" + roomMessage.getChatRoom().getId(),roomMessage);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/application/FollowService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/application/FollowService.java
@@ -1,10 +1,10 @@
-package com.se.Tlog.domain.Social.application;
+package com.se.Tlog.domain.Social.Follow.application;
 
 import com.se.Tlog.domain.ApplicationService;
-import com.se.Tlog.domain.Social.controller.dto.FollowDto;
-import com.se.Tlog.domain.Social.controller.dto.FollowStatusDto;
-import com.se.Tlog.domain.Social.domain.Follow;
-import com.se.Tlog.domain.Social.repository.jpa.FollowRepository;
+import com.se.Tlog.domain.Social.Follow.controller.dto.FollowDto;
+import com.se.Tlog.domain.Social.Follow.controller.dto.FollowStatusDto;
+import com.se.Tlog.domain.Social.Follow.domain.Follow;
+import com.se.Tlog.domain.Social.Follow.repository.jpa.FollowRepository;
 import com.se.Tlog.domain.User.controller.dto.UserSummaryDto;
 import com.se.Tlog.domain.User.domain.service.UserDomainService;
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/controller/FollowController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/controller/FollowController.java
@@ -1,8 +1,8 @@
-package com.se.Tlog.domain.Social.controller;
+package com.se.Tlog.domain.Social.Follow.controller;
 
-import com.se.Tlog.domain.Social.application.FollowService;
-import com.se.Tlog.domain.Social.controller.dto.FollowDto;
-import com.se.Tlog.domain.Social.controller.dto.FollowStatusDto;
+import com.se.Tlog.domain.Social.Follow.application.FollowService;
+import com.se.Tlog.domain.Social.Follow.controller.dto.FollowDto;
+import com.se.Tlog.domain.Social.Follow.controller.dto.FollowStatusDto;
 import com.se.Tlog.global.response.success.SuccessRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/controller/dto/FollowDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/controller/dto/FollowDto.java
@@ -1,4 +1,4 @@
-package com.se.Tlog.domain.Social.controller.dto;
+package com.se.Tlog.domain.Social.Follow.controller.dto;
 
 import java.util.UUID;
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/controller/dto/FollowStatusDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/controller/dto/FollowStatusDto.java
@@ -1,4 +1,4 @@
-package com.se.Tlog.domain.Social.controller.dto;
+package com.se.Tlog.domain.Social.Follow.controller.dto;
 
 public record FollowStatusDto(
         boolean status,

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/domain/Follow.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/domain/Follow.java
@@ -1,4 +1,4 @@
-package com.se.Tlog.domain.Social.domain;
+package com.se.Tlog.domain.Social.Follow.domain;
 
 
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/repository/jpa/FollowRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/repository/jpa/FollowRepository.java
@@ -1,6 +1,6 @@
-package com.se.Tlog.domain.Social.repository.jpa;
+package com.se.Tlog.domain.Social.Follow.repository.jpa;
 
-import com.se.Tlog.domain.Social.domain.Follow;
+import com.se.Tlog.domain.Social.Follow.domain.Follow;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;


### PR DESCRIPTION
## 작업 동기 및 이슈
- #49 

## 추가 및 변경사항
- 웹소켓 및 STOMP, PUB/SUB 모델 활용으로 인한 config 설정 추가 작성(WebSocketConfig,RedisConfig)
- 채팅 관련 엔티티 작성
- 채팅 관련 컨트롤러 및 서비스 작성 
- RedisPublisher , RedisSubscriber 작성
## 테스트 결과

### 서로 다른 두 유저가 한 채팅방에서 대화하는 상황 테스트
<img width="918" src="https://github.com/user-attachments/assets/75130256-7ce2-419c-b6ea-0715f8d1e09b" />
<img width="871" src="https://github.com/user-attachments/assets/527d980d-0bc1-4dd5-8be7-e508831879d7" />

### 대화 나눈 사용자 스프링 로그 확인
![스크린샷 2025-03-20 오후 3 16 01](https://github.com/user-attachments/assets/a19b2e21-141d-4f7a-ba11-78a3515f29eb)

### Redis PUB 로그 확인
![스크린샷 2025-03-20 오후 3 16 11](https://github.com/user-attachments/assets/a2e29048-fb37-4954-ad8d-ec05f07fe307)

## 📌 기타
- 현재는 RedisSubscriber가 하나의 채널 "chat" 만 구독중이라 모든 채팅이 해당 채널에서 전부 처리중인데 팀당 하나의 채널로 수정할 것입니다!
- 현재 해당 도메인 구조가 DDD스럽지 않아서 chat 도메인에 기능 추가하며 리팩토링 하겠습니다!
- 인바운드 채널에 추후 인터셉터를 추가하여 검증 로직도 추가 작성 하겠습니다!
