### PR TITLE
Feature: getChatList 기능 작성 및 읽음 처리 로직 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/ChatController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/ChatController.java
@@ -1,5 +1,6 @@
 package com.se.Tlog.domain.Social.Chat.controller;
 
+import com.se.Tlog.domain.Social.Chat.controller.dto.ChatMessageReadDto;
 import com.se.Tlog.domain.Social.Chat.controller.dto.ChatMessageRequestDto;
 import com.se.Tlog.domain.Social.Chat.domain.ChatMessage;
 import com.se.Tlog.domain.Social.Chat.service.ChatService;
@@ -10,6 +11,8 @@ import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -26,8 +29,15 @@ public class ChatController {
             throw new IllegalArgumentException("senderId와 chatRoomId는 필수입니다.");
         }
 
-        ChatMessage message = chatService.createMessage(chatMessageRequestDto);
+        ChatMessage message = chatService.sendChatMessage(chatMessageRequestDto);
         redisPublisher.publish(new ChannelTopic("chat"),message);
     }
+
+    @PatchMapping("/chat/room/{roomId}/message")
+    public void checkMessage(@RequestBody ChatMessageReadDto chatMessageCheckDto) {
+
+        chatService.checkMessage(chatMessageCheckDto);
+    }
+
 
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/ChatRoomController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/ChatRoomController.java
@@ -1,7 +1,6 @@
 package com.se.Tlog.domain.Social.Chat.controller;
 
 import com.se.Tlog.domain.Social.Chat.controller.dto.ChatRoomResponseDto;
-import com.se.Tlog.domain.Social.Chat.domain.ChatRoom;
 import com.se.Tlog.domain.Social.Chat.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +16,12 @@ public class ChatRoomController {
     private final ChatRoomService chatRoomService;
     @PostMapping("/room/{hostId}")
     public ResponseEntity<?> createRoom(@PathVariable(name = "hostId") UUID hostId) {
-        ChatRoom chatRoom = chatRoomService.create(hostId);
-        return ResponseEntity.ok().body(ChatRoomResponseDto.from(chatRoom.getId(),chatRoom.getHostId()));
+        ChatRoomResponseDto chatRoomResponseDto = chatRoomService.create(hostId);
+        return ResponseEntity.ok().body(chatRoomResponseDto);
+    }
+
+    @GetMapping("/room/{hostId}")
+    public ResponseEntity<?> getRoomList(@PathVariable(name = "hostId") UUID hostId){
+        return ResponseEntity.ok().body(chatRoomService.getRoomList(hostId));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatMessageCheckDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatMessageCheckDto.java
@@ -1,0 +1,9 @@
+package com.se.Tlog.domain.Social.Chat.controller.dto;
+
+import java.util.UUID;
+
+public record ChatMessageCheckDto(
+        UUID readerId,
+        Long messageId
+) {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatMessageReadDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatMessageReadDto.java
@@ -2,8 +2,8 @@ package com.se.Tlog.domain.Social.Chat.controller.dto;
 
 import java.util.UUID;
 
-public record ChatMessageCheckDto(
+public record ChatMessageReadDto(
         UUID readerId,
-        Long messageId
+        Long lastReadMessageId
 ) {
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatRoomListResponseDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatRoomListResponseDto.java
@@ -1,0 +1,20 @@
+package com.se.Tlog.domain.Social.Chat.controller.dto;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomListResponseDto(
+        Long chatRoomId,
+        String lastMessageContent,
+        LocalDateTime lastMessageSentAt,
+        int countChatRoomUsers,
+        int unreadCount
+) {
+    public static ChatRoomListResponseDto from(Long chatRoomId, String lastMessageContent,
+                                               LocalDateTime lastMessageSentAt,
+                                               int countChatRoomUsers,int unreadCount) {
+        return new ChatRoomListResponseDto(
+                chatRoomId, lastMessageContent,
+                lastMessageSentAt,countChatRoomUsers,
+                unreadCount);
+        }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/domain/ChatReadStatus.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/domain/ChatReadStatus.java
@@ -1,0 +1,50 @@
+package com.se.Tlog.domain.Social.Chat.domain;
+
+import com.se.Tlog.domain.User.domain.User;
+import jakarta.persistence.*;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ChatReadStatus { // 유저가 마지막으로 읽은 메시지 상태 관리
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "chatRoom_id")
+    private ChatRoom chatRoom;
+
+    private Long lastReadMessageId;
+
+    private LocalDateTime updatedAt;
+
+    private ChatReadStatus(User user, ChatRoom chatRoom, Long lastReadMessageId, LocalDateTime updatedAt) {
+        this.user = user;
+        this.chatRoom = chatRoom;
+        this.lastReadMessageId = lastReadMessageId;
+        this.updatedAt = updatedAt;
+    }
+
+    public static ChatReadStatus create(User user, ChatRoom room, Long messageId) {
+        return new ChatReadStatus(user, room, messageId, LocalDateTime.now());
+    }
+
+    public void updateRead(Long messageId) {
+        this.lastReadMessageId = messageId;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/domain/ChatReadUsers.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/domain/ChatReadUsers.java
@@ -1,0 +1,43 @@
+package com.se.Tlog.domain.Social.Chat.domain;
+
+import com.se.Tlog.domain.User.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ChatReadUsers {//단체 채팅방에서 몇 명이 읽었는지
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "message_id")
+    private ChatMessage message;
+
+    private LocalDateTime readAt;
+
+    private ChatReadUsers(User user, ChatMessage message) {
+        this.user = user;
+        this.message = message;
+        this.readAt = LocalDateTime.now();
+    }
+
+    public static ChatReadUsers create(User user, ChatMessage message){
+        return new ChatReadUsers(user, message);
+    }
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/domain/ChatRoom.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/domain/ChatRoom.java
@@ -35,7 +35,7 @@ public class ChatRoom {
         return new ChatRoom(hostId);
     }
 
-    public void modifyLashMessage(Long lastChatId) {
+    public void modifyLastMessage(Long lastChatId) {
         this.lastChatId = lastChatId;
     }
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatMessageRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatMessageRepository.java
@@ -2,8 +2,12 @@ package com.se.Tlog.domain.Social.Chat.repository.jpa;
 
 import com.se.Tlog.domain.Social.Chat.domain.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage,Long> {
+    @Query("SELECT count(cm) from ChatMessage cm where cm.chatRoom.id = :roomId and cm.id > :lastReadMessageId")
+    int countUnreadMessages(@Param("roomId") Long roomId, @Param("lastReadMessageId") Long lastReadMessageId);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatMessageRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatMessageRepository.java
@@ -1,0 +1,9 @@
+package com.se.Tlog.domain.Social.Chat.repository.jpa;
+
+import com.se.Tlog.domain.Social.Chat.domain.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatMessageRepository extends JpaRepository<ChatMessage,Long> {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatReadStatusRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatReadStatusRepository.java
@@ -1,0 +1,20 @@
+package com.se.Tlog.domain.Social.Chat.repository.jpa;
+
+import com.se.Tlog.domain.Social.Chat.domain.ChatReadStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface ChatReadStatusRepository extends JpaRepository<ChatReadStatus,Long> {
+
+
+    @Query("select crs from ChatReadStatus crs join fetch crs.chatRoom " +
+            "where crs.user.id = :userId and crs.chatRoom.id IN :chatRoomIds")
+    List<ChatReadStatus> findByUserIdAndChatRoomIds(@Param("userId") UUID userId,
+                                                    @Param("chatRoomIds") List<Long> chatRoomIds);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatReadUsersRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatReadUsersRepository.java
@@ -1,9 +1,14 @@
 package com.se.Tlog.domain.Social.Chat.repository.jpa;
 
+import com.se.Tlog.domain.Social.Chat.domain.ChatMessage;
 import com.se.Tlog.domain.Social.Chat.domain.ChatReadUsers;
+import com.se.Tlog.domain.User.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.UUID;
+
 @Repository
 public interface ChatReadUsersRepository extends JpaRepository<ChatReadUsers,Long> {
+    Boolean existsByUserAndMessage(User user, ChatMessage message);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatReadUsersRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatReadUsersRepository.java
@@ -1,0 +1,9 @@
+package com.se.Tlog.domain.Social.Chat.repository.jpa;
+
+import com.se.Tlog.domain.Social.Chat.domain.ChatReadUsers;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatReadUsersRepository extends JpaRepository<ChatReadUsers,Long> {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatRoomRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatRoomRepository.java
@@ -2,6 +2,8 @@ package com.se.Tlog.domain.Social.Chat.repository.jpa;
 
 import com.se.Tlog.domain.Social.Chat.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom,Long> {
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatRoomUserRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatRoomUserRepository.java
@@ -1,10 +1,17 @@
 package com.se.Tlog.domain.Social.Chat.repository.jpa;
 
+import com.se.Tlog.domain.Social.Chat.domain.ChatRoom;
 import com.se.Tlog.domain.Social.Chat.domain.ChatRoomUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 @Repository
 public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, UUID> {
+
+    @Query("SELECT cru.chatRoom from ChatRoomUser cru join fetch cru.chatRoom where cru.user.id = :userId")
+    List<ChatRoom> findChatRoomByUserId(@Param("userId") UUID hostId);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatRoomUserRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatRoomUserRepository.java
@@ -2,8 +2,9 @@ package com.se.Tlog.domain.Social.Chat.repository.jpa;
 
 import com.se.Tlog.domain.Social.Chat.domain.ChatRoomUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
-
+@Repository
 public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, UUID> {
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatRoomUserRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatRoomUserRepository.java
@@ -1,6 +1,6 @@
 package com.se.Tlog.domain.Social.Chat.repository.jpa;
 
-import com.se.Tlog.domain.Social.Chat.domain.ChatRoom;
+
 import com.se.Tlog.domain.Social.Chat.domain.ChatRoomUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,6 +12,9 @@ import java.util.UUID;
 @Repository
 public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, UUID> {
 
-    @Query("SELECT cru.chatRoom from ChatRoomUser cru join fetch cru.chatRoom where cru.user.id = :userId")
-    List<ChatRoom> findChatRoomByUserId(@Param("userId") UUID hostId);
+    @Query("SELECT cru from ChatRoomUser cru join fetch cru.chatRoom where cru.user.id = :userId")
+    List<ChatRoomUser> findChatRoomByUserId(@Param("userId") UUID hostId);
+
+    @Query("select count(cru) from ChatRoomUser cru where cru.chatRoom.id = :roomId")
+    int countChatRoomJoinUsers(@Param("roomId") Long roomId);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatReadStatusService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatReadStatusService.java
@@ -1,0 +1,44 @@
+package com.se.Tlog.domain.Social.Chat.service;
+
+import com.se.Tlog.domain.Social.Chat.domain.ChatReadStatus;
+import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatMessageRepository;
+import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatReadStatusRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ChatReadStatusService {
+
+    private final ChatReadStatusRepository chatReadStatusRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    // 추후 작성
+    public void updateReadStatus(UUID userId, Long roomId, Long lastReadMessageId) {
+
+    }
+
+    public Map<Long, Integer> unreadMessagesCount(UUID userId, List<Long> roomIds) {
+
+        // user가 채팅방마다 마지막으로 읽은 메시지 status 리스트
+        List<ChatReadStatus> statuses = chatReadStatusRepository.findByUserIdAndChatRoomIds(userId, roomIds);
+
+        Map<Long, Integer> unreadCountMap = new HashMap<>();
+
+        for (ChatReadStatus status : statuses) {
+            Long roomId = status.getChatRoom().getId();
+            Long lastReadMessageId = status.getLastReadMessageId();
+
+            int countUnreadMessages = chatMessageRepository.countUnreadMessages(roomId,lastReadMessageId);
+
+            unreadCountMap.put(roomId, countUnreadMessages);
+        }
+        return unreadCountMap;
+
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatRoomService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatRoomService.java
@@ -1,16 +1,25 @@
 package com.se.Tlog.domain.Social.Chat.service;
 
+import com.se.Tlog.domain.Social.Chat.controller.dto.ChatRoomListResponseDto;
+import com.se.Tlog.domain.Social.Chat.controller.dto.ChatRoomResponseDto;
+import com.se.Tlog.domain.Social.Chat.domain.ChatMessage;
+import com.se.Tlog.domain.Social.Chat.domain.ChatReadUsers;
 import com.se.Tlog.domain.Social.Chat.domain.ChatRoom;
 import com.se.Tlog.domain.Social.Chat.domain.ChatRoomUser;
+import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatMessageRepository;
 import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatRoomRepository;
 import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatRoomUserRepository;
 import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.domain.User.domain.service.UserDomainService;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -19,8 +28,12 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final UserRepository userRepository;
     private final ChatRoomUserRepository chatRoomUserRepository;
+    private final UserDomainService userDomainService;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatReadStatusService chatReadStatusService;
 
-    public ChatRoom create(UUID hostId) {
+
+    public ChatRoomResponseDto create(UUID hostId) {
         ChatRoom chatRoom = ChatRoom.create(hostId);
         chatRoomRepository.save(chatRoom);
         User host = userRepository.findById(hostId)
@@ -29,7 +42,30 @@ public class ChatRoomService {
         ChatRoomUser chatRoomUser = ChatRoomUser.join(chatRoom,host);
         chatRoomUserRepository.save(chatRoomUser);
 
-        return chatRoom;
+        return ChatRoomResponseDto.from(chatRoom.getId(),chatRoom.getHostId());
     }
 
+    public List<ChatRoomListResponseDto> getRoomList(UUID userId) {
+
+        userDomainService.validateExists(userId);
+        List<ChatRoomUser> chatRoomUserList = chatRoomUserRepository.findChatRoomByUserId(userId); // 유저가 참여중인 ChatRoomList
+        List<ChatRoom> rooms = chatRoomUserList.stream().map(ChatRoomUser::getChatRoom).toList();
+
+        List<Long> roomIds = rooms.stream().map(ChatRoom::getId).toList();
+
+        Map<Long, Integer> unreadCountMap = chatReadStatusService.unreadMessagesCount(userId, roomIds);
+
+        return rooms.stream().map(room -> toChatRoomListDto(room, unreadCountMap)).toList();
+    }
+
+    private ChatRoomListResponseDto toChatRoomListDto(ChatRoom room, Map<Long, Integer> unreadCountMap) {
+        ChatMessage lastMessage = room.getLastChatId() != null ?
+                chatMessageRepository.findById(room.getLastChatId()).orElse(null) : null;
+        String content = lastMessage != null ? lastMessage.getContent() : null;
+        LocalDateTime lastMessageSentAt = lastMessage != null ? lastMessage.getSendAt() : null;
+        int unreadCount = unreadCountMap.getOrDefault(room.getId(), 0);
+        int countChatRoomJoinUsers = chatRoomUserRepository.countChatRoomJoinUsers(room.getId());
+
+        return ChatRoomListResponseDto.from(room.getId(), content, lastMessageSentAt,countChatRoomJoinUsers,unreadCount);
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatService.java
@@ -1,13 +1,18 @@
 package com.se.Tlog.domain.Social.Chat.service;
 
+import com.se.Tlog.domain.Social.Chat.controller.dto.ChatMessageReadDto;
 import com.se.Tlog.domain.Social.Chat.controller.dto.ChatMessageRequestDto;
 import com.se.Tlog.domain.Social.Chat.domain.ChatMessage;
+import com.se.Tlog.domain.Social.Chat.domain.ChatReadUsers;
 import com.se.Tlog.domain.Social.Chat.domain.ChatRoom;
+import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatMessageRepository;
+import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatReadUsersRepository;
 import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatRoomRepository;
 import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,15 +21,35 @@ import org.springframework.stereotype.Service;
 public class ChatService {
     private final UserRepository userRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatReadUsersRepository chatReadUsersRepository;
 
-    public ChatMessage createMessage(ChatMessageRequestDto chatMessageRequestDto) {
+    @Transactional
+    public ChatMessage sendChatMessage(ChatMessageRequestDto chatMessageRequestDto) {
         User sender = userRepository.findById(chatMessageRequestDto.senderId())
-                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
         ChatRoom chatRoom = chatRoomRepository.findById(chatMessageRequestDto.chatRoomId())
                 .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
 
-        return ChatMessage.create(sender, chatRoom, chatMessageRequestDto.content());
+        ChatMessage chatMessage = ChatMessage.create(sender, chatRoom, chatMessageRequestDto.content());
+        chatMessageRepository.save(chatMessage);
+
+        chatRoom.modifyLastMessage(chatMessage.getId());
+
+        return chatMessage;
     }
 
+    @Transactional
+    public void checkMessage(ChatMessageReadDto chatMessageCheckDto) {
+        User user = userRepository.findById(chatMessageCheckDto.readerId())
+                .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
+        ChatMessage chatMessage = chatMessageRepository.findById(chatMessageCheckDto.lastReadMessageId())
+                .orElseThrow(() -> new CustomException(ErrorType.MESSAGE_NOT_FOUND));
 
+        Boolean alreadyRead = chatReadUsersRepository.existsByUserAndMessage(user, chatMessage);
+        if(!alreadyRead){
+            ChatReadUsers chatReadUsers = ChatReadUsers.create(user, chatMessage);
+            chatReadUsersRepository.save(chatReadUsers);
+        }
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/RedisSubscriber.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/RedisSubscriber.java
@@ -26,7 +26,6 @@ public class RedisSubscriber implements MessageListener {
     public void onMessage(Message message, byte[] pattern) {
         try{
             String publishMessage = (String)redisTemplate.getStringSerializer().deserialize(message.getBody());
-            System.out.println("publishMessage = " + publishMessage);
             ChatMessage roomMessage = objectMapper.readValue(publishMessage, ChatMessage.class);
             messagingTemplate.convertAndSend("/sub/chat/room/" + roomMessage.getChatRoom().getId(),roomMessage);
         } catch (Exception e) {

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -37,6 +37,7 @@ public enum ErrorType {
     INVALID_TBTI_CATEGORY(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리 입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 사용자 입니다."),
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 관리자 입니다."),
+    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 채팅방 입니다."),
     //데이터 충돌
     ALREADY_EXISTS_TAG(HttpStatus.CONFLICT, "이미 존재하는 태그입니다."),
     ALREADY_EXISTS_DESTINATION(HttpStatus.CONFLICT, "이미 존재하는 여행지입니다."),

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -38,6 +38,7 @@ public enum ErrorType {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 사용자 입니다."),
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 관리자 입니다."),
     ROOM_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 채팅방 입니다."),
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않은 메시지 입니다."),
     //데이터 충돌
     ALREADY_EXISTS_TAG(HttpStatus.CONFLICT, "이미 존재하는 태그입니다."),
     ALREADY_EXISTS_DESTINATION(HttpStatus.CONFLICT, "이미 존재하는 여행지입니다."),


### PR DESCRIPTION
## 작업 동기 및 이슈
- #55 

## 추가 및 변경사항
- 사용자가 참여중인 ChatRoomList 반환 로직 작성 (미완성)
- 채팅 읽음 처리 및 상태 변화에 필요한 Query 작성

## 테스트 결과

### 사용자 참여 채팅 리스트 반환 
<img width="886" alt="스크린샷 2025-03-25 오후 4 03 35" src="https://github.com/user-attachments/assets/54e4a108-7c6e-4455-8836-973b628777ad" />

- lastMessageContent가 잘 반영된 걸 확인 할 수 있습니다.

### ChatMessage 테이블에 반영 잘 된걸 확인할 수 있습니다.
<img width="908" alt="스크린샷 2025-03-25 오후 4 06 32" src="https://github.com/user-attachments/assets/4d230aa7-3e46-40db-9d3a-b87b6691ae57" />


## 📌 기타
- 아직 사용자 세션 관리와 , 읽음 처리 상태 업데이트에 대한 처리가 제대로 되어있지 않아서 반영 안된 필드도 있습니다. 추후 처리하도록 하겠습니다.
