### PR TITLE
Feature:  STOMP 명령어별 분기 처리 및 유저 세션 추적 로직 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/config/WebSocketConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/WebSocketConfig.java
@@ -1,26 +1,33 @@
 package com.se.Tlog.config;
 
 
+import com.se.Tlog.global.security.handler.HttpHandShakeInterceptor;
+import com.se.Tlog.global.security.handler.StompHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
 
 @RequiredArgsConstructor
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private final StompHandler stompHandler;
+    private final HttpHandShakeInterceptor httpHandShakeInterceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         System.out.println("웹 소켓 endpoint registered"); // /ws-stomp를 웹 소켓 엔드포인트로 등록하여 통신 연결한다.
         registry.addEndpoint("/ws-stomp")
+                .addInterceptors(httpHandShakeInterceptor)
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
-        //.addInterceptors(new HttpSessionHandshakeInterceptor())
+
     }
 
     @Override
@@ -29,5 +36,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.setApplicationDestinationPrefixes("/pub");
     }
 
-    //추후 InboundChannel 작성
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompHandler);
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/domain/ConnectedUserSession.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/domain/ConnectedUserSession.java
@@ -1,0 +1,39 @@
+package com.se.Tlog.domain.Social.Chat.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class ConnectedUserSession {
+    @Id
+    private String sessionId;
+
+    private UUID userId;
+
+    private Long roomId;
+
+    private LocalDateTime connectedAt;
+    private LocalDateTime disconnectedAt;
+
+    private ConnectedUserSession(String sessionId,UUID userId, Long roomId) {
+        this.sessionId = sessionId;
+        this.userId = userId;
+        this.roomId = roomId;
+        this.connectedAt = LocalDateTime.now();
+    }
+
+    public static ConnectedUserSession create(String sessionId,UUID userId,Long roomId){
+        return new ConnectedUserSession(sessionId, userId, roomId);
+    }
+
+    public void disconnected() {
+        this.disconnectedAt = LocalDateTime.now();
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatMessageRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatMessageRepository.java
@@ -7,7 +7,9 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ChatMessageRepository extends JpaRepository<ChatMessage,Long> {
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
     @Query("SELECT count(cm) from ChatMessage cm where cm.chatRoom.id = :roomId and cm.id > :lastReadMessageId")
     int countUnreadMessages(@Param("roomId") Long roomId, @Param("lastReadMessageId") Long lastReadMessageId);
+
+    ChatMessage findFirstByChatRoomIdOrderByIdDesc(Long roomId);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatReadStatusRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ChatReadStatusRepository.java
@@ -17,4 +17,8 @@ public interface ChatReadStatusRepository extends JpaRepository<ChatReadStatus,L
             "where crs.user.id = :userId and crs.chatRoom.id IN :chatRoomIds")
     List<ChatReadStatus> findByUserIdAndChatRoomIds(@Param("userId") UUID userId,
                                                     @Param("chatRoomIds") List<Long> chatRoomIds);
+
+    @Query("select crs from ChatReadStatus crs where crs.user.id = :userId and crs.chatRoom.id = :chatRoomId")
+    ChatReadStatus findByUserIdAndChatRoomId(@Param("userId") UUID userId,
+                                             @Param("chatRoomId") Long chatRoomId);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ConnectedUserSessionRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/repository/jpa/ConnectedUserSessionRepository.java
@@ -1,0 +1,9 @@
+package com.se.Tlog.domain.Social.Chat.repository.jpa;
+
+import com.se.Tlog.domain.Social.Chat.domain.ConnectedUserSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConnectedUserSessionRepository extends JpaRepository<ConnectedUserSession, String> {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatReadStatusService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatReadStatusService.java
@@ -3,6 +3,7 @@ package com.se.Tlog.domain.Social.Chat.service;
 import com.se.Tlog.domain.Social.Chat.domain.ChatReadStatus;
 import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatMessageRepository;
 import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatReadStatusRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,9 +19,11 @@ public class ChatReadStatusService {
     private final ChatReadStatusRepository chatReadStatusRepository;
     private final ChatMessageRepository chatMessageRepository;
 
-    // 추후 작성
+    @Transactional
     public void updateReadStatus(UUID userId, Long roomId, Long lastReadMessageId) {
-
+        ChatReadStatus status = chatReadStatusRepository.findByUserIdAndChatRoomId(userId, roomId);
+        status.updateRead(lastReadMessageId);
+        chatReadStatusRepository.save(status);
     }
 
     public Map<Long, Integer> unreadMessagesCount(UUID userId, List<Long> roomIds) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatSessionEventService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatSessionEventService.java
@@ -1,0 +1,59 @@
+package com.se.Tlog.domain.Social.Chat.service;
+
+import com.se.Tlog.domain.Social.Chat.domain.ChatMessage;
+import com.se.Tlog.domain.Social.Chat.domain.ConnectedUserSession;
+import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatMessageRepository;
+import com.se.Tlog.domain.Social.Chat.repository.jpa.ConnectedUserSessionRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatSessionEventService {  // 명령어별 처리 로직
+    private final ChatReadStatusService chatReadStatusService;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ConnectedUserSessionRepository connectedUserSessionRepository;
+    private final ConnectedUserSessionService connectedUserSessionService;
+
+    public void handleConnect(StompHeaderAccessor accessor) {
+        Principal principal = (Principal) accessor.getSessionAttributes().get("userPrincipal");
+        accessor.setUser(principal);
+        log.info("사용자 연결: {}", principal.getName());
+    }
+
+    public void handleSubscribe(StompHeaderAccessor accessor) {
+        //구독 경로 "/sub/chat/room/${roomId}"
+        System.out.println("accessor.getUser() = " + accessor.getUser());
+        Principal user = accessor.getUser();
+        String sessionId = accessor.getSessionId();
+
+        String destination = accessor.getDestination();
+        if (destination == null) {
+            throw new CustomException(ErrorType.INVALID_DESTINATION);
+        }
+        Long roomId = Long.parseLong(destination.substring(destination.lastIndexOf("/") + 1));
+
+        connectedUserSessionService.connect(sessionId,UUID.fromString(user.getName()),roomId);
+    }
+
+    public void handleDisconnect(StompHeaderAccessor accessor) {
+        String sessionId = accessor.getSessionId();
+        Principal principal = accessor.getUser();
+        UUID userId = UUID.fromString(principal.getName());
+        ConnectedUserSession connectedUserSession = connectedUserSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+        ChatMessage roomLastMessage = chatMessageRepository.findFirstByChatRoomIdOrderByIdDesc(connectedUserSession.getRoomId());
+
+        //유저별 마지막으로 읽은 메시지 업데이트 ( 유저별 읽지 않은 메시지 수 카운팅 추적 하기 위함)
+        chatReadStatusService.updateReadStatus(userId, connectedUserSession.getRoomId(), roomLastMessage.getId());
+        connectedUserSessionService.disconnect(sessionId);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ConnectedUserSessionService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ConnectedUserSessionService.java
@@ -1,0 +1,31 @@
+package com.se.Tlog.domain.Social.Chat.service;
+
+import com.se.Tlog.domain.Social.Chat.domain.ConnectedUserSession;
+import com.se.Tlog.domain.Social.Chat.repository.jpa.ConnectedUserSessionRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ConnectedUserSessionService {
+    private final ConnectedUserSessionRepository connectedUserSessionRepository;
+
+    public void connect(String sessionId, UUID userId, Long roomId) {
+        ConnectedUserSession connectedUserSession = ConnectedUserSession.create(sessionId, userId, roomId);
+        connectedUserSessionRepository.save(connectedUserSession);
+    }
+
+
+    public void disconnect(String sessionId) {
+        ConnectedUserSession connectedUserSession = connectedUserSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+
+        connectedUserSession.disconnected();
+
+        connectedUserSessionRepository.deleteById(sessionId);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -10,7 +10,8 @@ import com.se.Tlog.domain.User.domain.SsoType;
 import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
-import com.se.Tlog.global.util.jwt.JwtUtil;
+import com.se.Tlog.global.util.jwt.AccessTokenProvider;
+import com.se.Tlog.global.util.jwt.RefreshTokenProvider;
 import com.se.Tlog.global.util.redis.RedisProperties;
 import com.se.Tlog.global.util.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +24,8 @@ import java.util.Optional;
 public class SsoAuthService {
     private final Map<SsoType, SsoService> ssoServiceMap;
     private final UserRepository userRepository;
-    private final JwtUtil jwtUtil;
+    private final AccessTokenProvider accessTokenProvider;
+    private final RefreshTokenProvider refreshTokenProvider;
     private final RedisUtil redisUtil;
 
     public TokenDto login(LoginRequest loginRequest){
@@ -37,10 +39,10 @@ public class SsoAuthService {
         User user = userRepository.findByProviderUserInfo(providerUserInfo)
                 .orElseGet(() -> userRepository.save(User.create(ssoUserInfo)));
 
-        String accessToken = jwtUtil.generateAccessToken(user.getId().toString(), user.getRole().getValue());
-        String refreshToken = jwtUtil.generateRefreshToken(user.getId().toString(), user.getRole().getValue());
+        String accessToken = accessTokenProvider.generateToken(user.getId().toString(), user.getRole().getValue());
+        String refreshToken = refreshTokenProvider.generateToken(user.getId().toString(), user.getRole().getValue());
 
-        redisUtil.save(RedisProperties.REFRESH_TOKEN_PREFIX + user.getId(), refreshToken, jwtUtil.getRefreshTokenDuration());
+        redisUtil.save(RedisProperties.REFRESH_TOKEN_PREFIX + user.getId(), refreshToken, refreshTokenProvider.getRefreshTokenDuration());
 
         return TokenDto.builder()
                 .accessToken(accessToken)

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -43,6 +43,7 @@ public enum ErrorType {
     MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않은 메시지 입니다."),
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 팀입니다."),
     TEAM_USER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 팀원입니다."),
+    INVALID_DESTINATION(HttpStatus.NOT_FOUND, "존재하지 않는 구독경로입니다."),
     //데이터 충돌
     ALREADY_EXISTS_TAG(HttpStatus.CONFLICT, "이미 존재하는 태그입니다."),
     ALREADY_EXISTS_DESTINATION(HttpStatus.CONFLICT, "이미 존재하는 여행지입니다."),

--- a/tlog-was/src/main/java/com/se/Tlog/global/security/handler/CustomPrincipal.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/security/handler/CustomPrincipal.java
@@ -1,0 +1,25 @@
+package com.se.Tlog.global.security.handler;
+
+import io.jsonwebtoken.Claims;
+import java.security.Principal;
+import java.util.UUID;
+
+
+public record CustomPrincipal(
+        UUID userId,
+        String nickname,
+        String role
+) implements Principal {
+
+    @Override
+    public String getName() {
+        return userId.toString();
+    }
+
+    public static CustomPrincipal from(Claims claims) {
+        return new CustomPrincipal(
+                UUID.fromString(claims.getSubject()),
+                (String) claims.get("nickname"),
+                (String) claims.get("role"));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/global/security/handler/HttpHandShakeInterceptor.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/security/handler/HttpHandShakeInterceptor.java
@@ -1,0 +1,59 @@
+package com.se.Tlog.global.security.handler;
+
+import com.se.Tlog.global.util.jwt.AccessTokenProvider;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class HttpHandShakeInterceptor implements HandshakeInterceptor {
+
+    private final AccessTokenProvider accessTokenProvider;
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        //String authorization = request.getHeaders().get("Authorization").get(0);  현재 브라우저로 테스트를 하고있어서 헤더를 체울수가 없음 그래서 주석처리! 앱과 통신할땐 해당 코드 사용할 것!
+
+        /*if (authorization == null || !authorization.startsWith("Bearer ")) {
+            log.warn("TOKEN NOT FOUND or TOKEN HEADER IS WRONG : " + authorization);
+            return false;
+        }*/
+        String token = ((ServletServerHttpRequest) request)
+                .getServletRequest()
+                .getParameter("token");
+        try {
+            //String token = authorization.split(" ")[1];
+
+            token = token.split(" ")[1];
+            System.out.println("token = " + token);
+            Claims claims = accessTokenProvider.parseAndValidate(token);
+            System.out.println("claims = " + claims);
+            CustomPrincipal userPrincipal = CustomPrincipal.from(claims);
+            attributes.put("userPrincipal", userPrincipal);
+
+        } catch (Exception e) {
+            log.warn("JWT 인증 실패: {}", e.getMessage());
+            return false;
+        }
+
+        ServletServerHttpRequest servletRequest = (ServletServerHttpRequest) request;
+        String clientId = servletRequest.getServletRequest().getRemoteAddr();
+        attributes.put("clientId", clientId);   //세션 속성에 저장
+
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/global/security/handler/StompHandler.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/security/handler/StompHandler.java
@@ -1,0 +1,36 @@
+package com.se.Tlog.global.security.handler;
+
+import com.se.Tlog.domain.Social.Chat.service.ChatSessionEventService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class StompHandler implements ChannelInterceptor {
+    private final ChatSessionEventService chatSessionEventService;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        System.out.println("message = " + message);
+        System.out.println("accessor = " + accessor);
+        Principal principal = (Principal) accessor.getSessionAttributes().get("userPrincipal");
+        accessor.setUser(principal);
+        switch (accessor.getCommand()) {
+            case CONNECT -> chatSessionEventService.handleConnect(accessor); //STOMP 세션 연결 성공
+            case SUBSCRIBE -> chatSessionEventService.handleSubscribe(accessor); //채팅 구독 요청
+            case DISCONNECT -> chatSessionEventService.handleDisconnect(accessor);
+        }
+
+        return ChannelInterceptor.super.preSend(message, channel);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/AccessTokenProvider.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/AccessTokenProvider.java
@@ -1,0 +1,65 @@
+package com.se.Tlog.global.util.jwt;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Primary
+public class AccessTokenProvider implements JwtTokenProvider {
+
+    private final JwtUtil jwtUtil;
+
+    @Value("${JWT_ACCESS_EXPIRATION}")
+    private Duration accessTokenDuration;
+
+    @Override
+    public String generateToken(String userId, String role) {
+        Map<String, Object> claims = Map.of(
+                "role", role,
+                "tokenType", "access"
+        );
+        return jwtUtil.generateToken(userId,accessTokenDuration,role,claims);
+    }
+
+    @Override
+    public boolean isTokenExpired(String token) {
+        try {
+            Claims claims = jwtUtil.parseToken(token);
+            return claims.getExpiration().before(new Date());
+        } catch (Exception e) {
+            log.warn("JWT 검증 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public Claims parseToken(String token) {
+        return jwtUtil.parseToken(token);
+    }
+
+    @Override
+    public Claims parseAndValidate(String token) {
+        Claims claims = parseToken(token);
+        if (claims.getExpiration().before(new Date())) {
+            throw new CustomException(ErrorType.TOKEN_EXPIRED);
+        }
+        return claims;
+    }
+
+    @Override
+    public Date getExpiration(String token) {
+        return parseToken(token).getExpiration();
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/JwtTokenProvider.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/JwtTokenProvider.java
@@ -1,0 +1,19 @@
+package com.se.Tlog.global.util.jwt;
+
+import io.jsonwebtoken.Claims;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public interface JwtTokenProvider {
+    String generateToken(String userId, String role);
+
+    boolean isTokenExpired(String token);
+
+    Claims parseToken(String token);
+
+    Claims parseAndValidate(String token);
+
+    Date getExpiration(String token);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/JwtUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/JwtUtil.java
@@ -9,46 +9,28 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.time.Duration;
 import java.util.Date;
+import java.util.Map;
 
 @Component
 public class JwtUtil {
     private final SecretKey secretKey;
-    private final Duration accessTokenDuration;
-    private final Duration refreshTokenDuration;
     private final String issuer;
 
     public JwtUtil(
             @Value("${JWT_SECRET_KEY}") String secretKey,
-            @Value("${JWT_ACCESS_EXPIRATION}")Duration accessTokenDuration,
-            @Value("${JWT_REFRESH_EXPIRATION}")Duration refreshTokenDuration,
             @Value("${JWT_ISSUER}") String issuer
     ){
         this.secretKey = new SecretKeySpec(secretKey.getBytes(), Jwts.SIG.HS256.key().build().getAlgorithm());
-        this.accessTokenDuration = accessTokenDuration;
-        this.refreshTokenDuration = refreshTokenDuration;
         this.issuer = issuer;
     }
 
-    public String generateAccessToken(String userId, String role){
+    public String generateToken(String subject,Duration duration, String role, Map<String, Object> claims){
         return Jwts.builder()
-                .subject(userId)
+                .subject(subject)
                 .issuedAt(new Date())
                 .issuer(issuer)
-                .expiration(createExpire(accessTokenDuration.toMillis()))
-                .claim("role",role)
-                .claim("tokenType","access")
-                .signWith(secretKey)
-                .compact();
-    }
-
-    public String generateRefreshToken(String userId, String role){
-        return Jwts.builder()
-                .subject(userId)
-                .issuedAt(new Date())
-                .issuer(issuer)
-                .expiration(createExpire(refreshTokenDuration.toMillis()))
-                .claim("role",role)
-                .claim("tokenType","refresh")
+                .expiration(createExpire(duration.toMillis()))
+                .claims(claims)
                 .signWith(secretKey)
                 .compact();
     }
@@ -59,9 +41,6 @@ public class JwtUtil {
                 .build()
                 .parseSignedClaims(token)   //jwt 토큰 전체
                 .getPayload();
-    }
-    public long getRefreshTokenDuration(){
-        return refreshTokenDuration.toMillis();
     }
     private Date createExpire(Long expiration){
         return new Date(System.currentTimeMillis() + expiration);

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/RefreshTokenProvider.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/RefreshTokenProvider.java
@@ -1,0 +1,64 @@
+package com.se.Tlog.global.util.jwt;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenProvider implements JwtTokenProvider{
+    private final JwtUtil jwtUtil;
+
+    @Value("${JWT_REFRESH_EXPIRATION}")
+    private Duration refreshTokenDuration;
+
+    @Override
+    public String generateToken(String userId, String role) {
+        Map<String, Object> claims = Map.of(
+                "role", role,
+                "tokenType", "refresh"
+        );
+        return jwtUtil.generateToken(userId, refreshTokenDuration, role, claims);
+    }
+
+    @Override
+    public boolean isTokenExpired(String token) {
+        try {
+            return parseToken(token).getExpiration().before(new Date());
+        } catch (Exception e) {
+            return true; // 파싱 에러 -> 만료 취급
+        }
+    }
+
+    @Override
+    public Claims parseToken(String token) {
+        return jwtUtil.parseToken(token);
+    }
+
+    @Override
+    public Claims parseAndValidate(String token) {
+        Claims claims = parseToken(token);
+        if (claims.getExpiration().before(new Date())) {
+            throw new CustomException(ErrorType.TOKEN_EXPIRED);
+        }
+        return claims;
+    }
+
+    @Override
+    public Date getExpiration(String token) {
+
+        return parseToken(token).getExpiration();
+    }
+
+    public long getRefreshTokenDuration() {
+        return refreshTokenDuration.toMillis();
+    }
+}

--- a/tlog-was/src/test/java/com/se/Tlog/jwt/JwtTest.java
+++ b/tlog-was/src/test/java/com/se/Tlog/jwt/JwtTest.java
@@ -1,15 +1,18 @@
 package com.se.Tlog.jwt;
 
 import com.se.Tlog.domain.User.domain.Role;
+import com.se.Tlog.global.util.jwt.AccessTokenProvider;
 import com.se.Tlog.global.util.jwt.JwtUtil;
+import com.se.Tlog.global.util.jwt.RefreshTokenProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
 
 public class JwtTest {
 
     private JwtUtil jwtUtil;
+    private AccessTokenProvider accessTokenProvider;
+    private RefreshTokenProvider refreshTokenProvider;
 
 
     @BeforeEach
@@ -18,8 +21,6 @@ public class JwtTest {
 
         jwtUtil = new JwtUtil(
                 secretKey,
-                Duration.ofDays(10000),
-                Duration.ofDays(7),
                 "issuer"
         );
     }
@@ -27,8 +28,8 @@ public class JwtTest {
     @Test
     void generateTokenTest(){
 
-        String accessToken = jwtUtil.generateAccessToken("hello", Role.USER.toString());
-        String refreshToken = jwtUtil.generateRefreshToken("hello", Role.USER.toString());
+        String accessToken = accessTokenProvider.generateToken("hello", Role.USER.toString());
+        String refreshToken = refreshTokenProvider.generateToken("hello", Role.USER.toString());
         System.out.println("token = " + accessToken);
         System.out.println("refreshToken = " + refreshToken);
     }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #61 

## 추가 및 변경사항
- JwtUtil에 토큰관련 역할이 너무 많아서 타입별로 분리 했습니다.
- StompHandler , HttpHandshakeInterceptor 작성 했습니다.
- 사용자 세션 추적에 필요한 엔티티와 서비스로직 작성했습니다.

## 테스트 결과
### STOMP 명령어별 분기 처리 로그
![스크린샷 2025-03-31 오전 2 48 42](https://github.com/user-attachments/assets/ed3d2a2f-8e8b-4c8f-adf2-e37248c83c06)

### 유저 sessionId db 저장 테스트
![스크린샷 2025-03-31 오전 2 58 21](https://github.com/user-attachments/assets/498ee218-0055-4ea0-9339-fd9145f7d258)
<img width="790" alt="스크린샷 2025-03-31 오전 2 58 46" src="https://github.com/user-attachments/assets/9bcc615d-aea9-4267-9aa7-ecd82aae8e75" />

## 📌 기타
- 현재 코드에서는 사용자 CONNECT,SUBSCRIBE,SEND,DISCONNECT 명령어에 대한 로그 추적은 잘 됩니다. 하지만 세션 유지와 끊김에 따른 채팅 요소들에 실시간 반영은 추후에 적용하도록 하겠습니다!
- 그리고 아직 클래스들이 정리가 되지 않아서 난잡한데 세션부분 개발이 마무리되면 역할에 따라 분리하겠습니다!
- HttpHandshakeInterceptor 쪽에 주석 처리 해놓은 부분이 있는데 현재 채팅 테스트 환경때문에 url쿼리 파라미터 방식으로 테스트 중이어서 기존 코드 주석처리 해놨습니다!
