### PR TITLE
Feature: 사용자별 읽지 않은 메시지수 카운트 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/ChatRoomController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/ChatRoomController.java
@@ -1,7 +1,10 @@
 package com.se.Tlog.domain.Social.Chat.controller;
 
 import com.se.Tlog.domain.Social.Chat.controller.dto.ChatRoomResponseDto;
+import com.se.Tlog.domain.Social.Chat.controller.dto.RequestInviteList;
 import com.se.Tlog.domain.Social.Chat.service.ChatRoomService;
+import com.se.Tlog.domain.User.domain.Role;
+import com.se.Tlog.global.util.jwt.AccessTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,14 +17,23 @@ import java.util.UUID;
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
+    private final AccessTokenProvider accessTokenProvider;
+
     @PostMapping("/room/{hostId}")
-    public ResponseEntity<?> createRoom(@PathVariable(name = "hostId") UUID hostId) {
-        ChatRoomResponseDto chatRoomResponseDto = chatRoomService.create(hostId);
+    public ResponseEntity<?> createRoom(@PathVariable(name = "hostId") UUID hostId,
+                                        @RequestBody RequestInviteList requestInviteList) {
+        ChatRoomResponseDto chatRoomResponseDto = chatRoomService.create(hostId, requestInviteList);
+
         return ResponseEntity.ok().body(chatRoomResponseDto);
     }
 
     @GetMapping("/room/{hostId}")
-    public ResponseEntity<?> getRoomList(@PathVariable(name = "hostId") UUID hostId){
+    public ResponseEntity<?> getRoomList(@PathVariable(name = "hostId") UUID hostId) {
         return ResponseEntity.ok().body(chatRoomService.getRoomList(hostId));
+    }
+    // test 편의성 때문에 토큰 생성 api 작성
+    @PostMapping("/{userId}")
+    public ResponseEntity<?> createToken(@PathVariable(name = "userId") UUID userId) {
+        return ResponseEntity.ok().body(accessTokenProvider.generateToken(userId.toString(), Role.USER.getValue()));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatRoomResponseDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatRoomResponseDto.java
@@ -1,12 +1,20 @@
 package com.se.Tlog.domain.Social.Chat.controller.dto;
 
+import com.se.Tlog.domain.User.domain.User;
+
+import java.util.List;
 import java.util.UUID;
 
 public record ChatRoomResponseDto(
         Long roomId,
-        UUID hostId
+        UUID hostId,
+        List<ChatUserSummaryDto> chatUserSummaryDtoList
 ) {
-    public static ChatRoomResponseDto from(Long roomId, UUID hostId) {
-        return new ChatRoomResponseDto(roomId, hostId);
+    public static ChatRoomResponseDto from(Long roomId, UUID hostId, List<User> users) {
+        return new ChatRoomResponseDto(
+                roomId,
+                hostId,
+                users.stream().map(ChatUserSummaryDto::from).toList()
+        );
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatUserSummaryDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatUserSummaryDto.java
@@ -1,0 +1,18 @@
+package com.se.Tlog.domain.Social.Chat.controller.dto;
+
+import com.se.Tlog.domain.User.domain.User;
+
+import java.util.UUID;
+
+public record ChatUserSummaryDto(
+        UUID userId,
+        String nickname
+        // image?
+) {
+    public static ChatUserSummaryDto from(User user) {
+        return new ChatUserSummaryDto(
+                user.getId(),
+                user.getName()
+        );
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/RequestInviteList.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/RequestInviteList.java
@@ -1,0 +1,10 @@
+package com.se.Tlog.domain.Social.Chat.controller.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record RequestInviteList(
+        List<UUID> inviteList
+) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatReadStatusService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatReadStatusService.java
@@ -1,8 +1,14 @@
 package com.se.Tlog.domain.Social.Chat.service;
 
 import com.se.Tlog.domain.Social.Chat.domain.ChatReadStatus;
+import com.se.Tlog.domain.Social.Chat.domain.ChatRoom;
 import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatMessageRepository;
 import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatReadStatusRepository;
+import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatRoomRepository;
+import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,11 +24,25 @@ public class ChatReadStatusService {
 
     private final ChatReadStatusRepository chatReadStatusRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
     @Transactional
     public void updateReadStatus(UUID userId, Long roomId, Long lastReadMessageId) {
         ChatReadStatus status = chatReadStatusRepository.findByUserIdAndChatRoomId(userId, roomId);
-        status.updateRead(lastReadMessageId);
+
+        if (status == null) {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+
+            ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                    .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+
+            status = ChatReadStatus.create(user, chatRoom, lastReadMessageId);
+        } else {
+            status.updateRead(lastReadMessageId);
+        }
+
         chatReadStatusRepository.save(status);
     }
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatRoomService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatRoomService.java
@@ -2,8 +2,8 @@ package com.se.Tlog.domain.Social.Chat.service;
 
 import com.se.Tlog.domain.Social.Chat.controller.dto.ChatRoomListResponseDto;
 import com.se.Tlog.domain.Social.Chat.controller.dto.ChatRoomResponseDto;
+import com.se.Tlog.domain.Social.Chat.controller.dto.RequestInviteList;
 import com.se.Tlog.domain.Social.Chat.domain.ChatMessage;
-import com.se.Tlog.domain.Social.Chat.domain.ChatReadUsers;
 import com.se.Tlog.domain.Social.Chat.domain.ChatRoom;
 import com.se.Tlog.domain.Social.Chat.domain.ChatRoomUser;
 import com.se.Tlog.domain.Social.Chat.repository.jpa.ChatMessageRepository;
@@ -18,9 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -33,16 +31,24 @@ public class ChatRoomService {
     private final ChatReadStatusService chatReadStatusService;
 
 
-    public ChatRoomResponseDto create(UUID hostId) {
+    public ChatRoomResponseDto create(UUID hostId, RequestInviteList requestInviteList) {
         ChatRoom chatRoom = ChatRoom.create(hostId);
         chatRoomRepository.save(chatRoom);
-        User host = userRepository.findById(hostId)
-                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
 
-        ChatRoomUser chatRoomUser = ChatRoomUser.join(chatRoom,host);
-        chatRoomUserRepository.save(chatRoomUser);
+        Set<UUID> allUserIds = new HashSet<>(requestInviteList.inviteList());
+        allUserIds.add(hostId);
 
-        return ChatRoomResponseDto.from(chatRoom.getId(),chatRoom.getHostId());
+        List<User> users = userRepository.findAllById(allUserIds);
+        if(users.size() != allUserIds.size()){
+            throw new CustomException(ErrorType.NOT_FOUND);
+        }
+
+        List<ChatRoomUser> chatRoomUsers = users.stream()
+                .map(user -> ChatRoomUser.join(chatRoom, user))
+                .toList();
+        chatRoomUserRepository.saveAll(chatRoomUsers);
+
+        return ChatRoomResponseDto.from(chatRoom.getId(),chatRoom.getHostId(),users);
     }
 
     public List<ChatRoomListResponseDto> getRoomList(UUID userId) {


### PR DESCRIPTION
## 작업 동기 및 이슈
- #63 

## 추가 및 변경사항
- 채팅방 생성할 때 다수의 유저를 List 로 받아 처리하게끔 수정
- STOMP 명령어 disconnect 일때 ChatReadStatus가 null인경우 처리 로직 작성
## 테스트 결과

### 채팅방 생성 테스트
<img width="1313" alt="스크린샷 2025-04-01 오후 9 50 03" src="https://github.com/user-attachments/assets/fd5c2527-ceb4-4703-95af-a71c69a56cf3" />

- inviteList로 초대 리스트를 받아 초대된 유저 반환
- ChatRoomUser db에 잘 반환된 걸 확인할 수 있습니다.

### 읽지않은 메시지 카운트 테스트

<img width="786" alt="스크린샷 2025-04-01 오후 10 08 32" src="https://github.com/user-attachments/assets/3bd901c2-f2eb-44d7-81dd-b3f2d095e3a4" />

<img width="1283" alt="스크린샷 2025-04-01 오후 10 08 22" src="https://github.com/user-attachments/assets/883dde5f-1ed9-474a-b11e-b5d9ed0851e3" />

- 위 첫번째 사진은 "박봄"의 화면이고 "중수"가 "그래 난 박봄21345"까지 읽고 disconnect된 상황입니다. 로직이 정상적으로 작동했다면 unReadCount는 7개가 되어야 합니다.
- 두번째 사진을 보면 count가 정상적으로 된 걸 확인할 수 있습니다.



## 📌 기타

