### PR TITLE
Feature: 태그 삭제 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -22,7 +22,7 @@ public class DestinationService {
     public void createDestination(DestinationDto destinationDto) {
     	Destination.assertValidity(destinationDto.getName(), destinationRepoService);
         List<TagInfo> tagInfoList = destinationDto.getTags().stream()
-                .map(tagIdDto -> TagInfo.create(tagIdDto.getTagId(), tagIdDto.getWeight(), tagRepoService))
+                .map(tagIdDto -> TagInfo.create(tagIdDto.tagId(), tagIdDto.weight(), tagRepoService))
                 .toList();
         Destination destination = Destination.create(
         		destinationDto.getName(),

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/TagService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/TagService.java
@@ -2,26 +2,45 @@ package com.se.Tlog.domain.Travel.application;
 
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Travel.controller.dto.TagDto;
+import com.se.Tlog.domain.Travel.controller.dto.TagRes;
 import com.se.Tlog.domain.Travel.domain.Tag;
 import com.se.Tlog.domain.Travel.domain.repository.TagRepositoryService;
 import com.se.Tlog.domain.Travel.repository.mongo.TagRepository;
 
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @ApplicationService
 @RequiredArgsConstructor
+@Transactional
 public class TagService {
     private final TagRepository tagRepository;
     private final TagRepositoryService tagRepo;
 
-    public List<Tag> getAllTags() {
-        return tagRepository.findAll();
+    @Transactional(readOnly = true)
+    public List<TagRes> getAllTags() {
+
+        return tagRepository.findAll().stream()
+                .map(tag -> TagRes.from(tag.getId(), tag.getName()))
+                .toList();
     }
 
     public void createTag(TagDto tagDto) {
     	Tag newTag = Tag.createTag(tagDto.getName(), 0, tagRepo);
         tagRepository.save(newTag);
+    }
+
+
+    public void deleteTag(String tagId) {
+
+        Tag tag = tagRepository.findById(tagId)
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+        tag.markAsDeleted();
+        tagRepository.save(tag);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/TagService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/TagService.java
@@ -26,7 +26,7 @@ public class TagService {
     public List<TagRes> getAllTags() {
 
         return tagRepository.findAll().stream()
-                .map(tag -> TagRes.from(tag.getId(), tag.getName()))
+                .map(tag -> TagRes.from(tag.getId(), tag.getName(),tag.isDeleted()))
                 .toList();
     }
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/TagController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/TagController.java
@@ -29,4 +29,13 @@ public class TagController {
                 .ok()
                 .body(SuccessRes.from(tagService.getAllTags()));
     }
+
+    @DeleteMapping("{tagId}")
+    public ResponseEntity<?> deleteTag(@PathVariable("tagId") String tagId) {
+
+        tagService.deleteTag(tagId);
+        return ResponseEntity
+                .status(SuccessType.TAG_DELETE.getStatus())
+                .body(SuccessRes.from(SuccessType.TAG_DELETE));
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/TagIdDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/TagIdDto.java
@@ -1,14 +1,12 @@
 package com.se.Tlog.domain.Travel.controller.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class TagIdDto {
-    private String tagId;
-    private int weight;
+public record TagIdDto(
+        String tagId,
+        int weight
+) {
+    public static TagIdDto from(String tagId, int weight) {
+        return new TagIdDto(tagId, weight);
+    }
 }
+
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/TagRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/TagRes.java
@@ -1,0 +1,10 @@
+package com.se.Tlog.domain.Travel.controller.dto;
+
+public record TagRes(
+        String tagId,
+        String tagName
+) {
+    public static TagRes from(String tagId, String tagName) {
+        return new TagRes(tagId, tagName);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/TagRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/TagRes.java
@@ -2,9 +2,10 @@ package com.se.Tlog.domain.Travel.controller.dto;
 
 public record TagRes(
         String tagId,
-        String tagName
+        String tagName,
+        boolean deleted
 ) {
-    public static TagRes from(String tagId, String tagName) {
-        return new TagRes(tagId, tagName);
+    public static TagRes from(String tagId, String tagName, boolean deleted) {
+        return new TagRes(tagId, tagName, deleted);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Tag.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Tag.java
@@ -19,6 +19,8 @@ public class Tag {
 	private String id;
 	private String name;
 
+	private boolean deleted = false;
+
 	private Tag(String name, int weight) {
 		this.name = name;
 	}
@@ -27,5 +29,9 @@ public class Tag {
         if(validator.existByName(name))
             throw new CustomException(ErrorType.ALREADY_EXISTS_TAG);
         return new Tag(name, weight);
+	}
+
+	public void markAsDeleted() {
+		this.deleted = true;
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/TagInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/TagInfo.java
@@ -12,13 +12,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class TagInfo {
+public class TagInfo { // 여행지가 갖고 있는 태그 정보
     private String id;
     private int weight;
     
     public static TagInfo create(String tagId, int tagWeight, TagRepositoryService validator) {
     	if (!validator.existById(tagId))
-    		new CustomException(ErrorType.NOT_FOUND_TAG);
+    		throw new CustomException(ErrorType.NOT_FOUND_TAG);
     	return new TagInfo(tagId, tagWeight);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/success/SuccessType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/success/SuccessType.java
@@ -15,14 +15,14 @@ public enum SuccessType {
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공하였습니다."),
     REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급에 성공하였습니다."),
     AVAILABLE_ID(HttpStatus.OK, "사용가능한 아이디입니다."),
+    TAG_DELETE(HttpStatus.OK, "태그 삭제에 성공하였습니다." ),
 
     // 201
     CREATED(HttpStatus.CREATED, "등록을 성공하였습니다."),
     TAG_CREATED(HttpStatus.CREATED, "새로운 태그 등록을 성공하였습니다."),
     DESTINATION_CREATED(HttpStatus.CREATED,"새로운 여행지 등록을 성공하였습니다."),
     USER_CREATED(HttpStatus.CREATED, "사용자 회원가입을 성공하였습니다."),
-    FOLLOW_SUCCESS(HttpStatus.CREATED, "팔로우를 성공하였습니다.")
-    ;
+    FOLLOW_SUCCESS(HttpStatus.CREATED, "팔로우를 성공하였습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 작업 동기 및 이슈
- #65 

## 추가 및 변경사항
- 고유 태그 삭제 기능 컨트롤러 및 메서드 작성
- 태그 참조 무결성 보장을 위해 태그에 isdeleted 필드 추가 
- 프론트엔드에 반환시 dto로 반환되게 수정 및 dto타입 record로 수정
## 테스트 결과

### delete Tag api테스트
<img width="786" alt="스크린샷 2025-04-03 오후 9 33 13" src="https://github.com/user-attachments/assets/b35a1a12-355f-4bbf-a261-3db81310357b" />

### mongodb 적용 여부 확인
<img width="640" alt="스크린샷 2025-04-03 오후 9 33 21" src="https://github.com/user-attachments/assets/d94f769b-93fb-425b-8307-2dea87659e0c" />


## 📌 기타
- 스웨거 처리는 한번에 하겠습니다!