### PR TITLE
Feature: 알림 기능 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ build/
 .env.*
 *.env
 
+## firebase key ##
+**/firebaseKey.json
+
 ### STS ###
 .apt_generated
 .classpath

--- a/tlog-docker/docker-compose.yml
+++ b/tlog-docker/docker-compose.yml
@@ -1,5 +1,9 @@
 version: '3.8'
 
+secrets:
+  firebase_key:
+    file: ${FIREBASE_SERVICE_ACCOUNT_KEY_PATH}
+
 services:
   spring:
     container_name: tlog-spring
@@ -28,6 +32,9 @@ services:
       SSO_GOOGLE_CLIENT_ID: ${SSO_GOOGLE_CLIENT_ID}
       SSO_GOOGLE_SECRET: ${SSO_GOOGLE_SECRET}
       SSO_CALLBACK_URL: ${SSO_CALLBACK_URL}
+      FIREBASE_SERVICE_ACCOUNT_KEY_PATH: /run/secrets/firebase_key # Docker Secret으로 적용
+    secrets:
+      - firebase_key
     networks:
       - tlog-network
   mysql:

--- a/tlog-was/build.gradle
+++ b/tlog-was/build.gradle
@@ -39,7 +39,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
-
+	
+	implementation 'com.google.firebase:firebase-admin:9.4.3'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/tlog-was/src/main/java/com/se/Tlog/config/AsyncConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/AsyncConfig.java
@@ -1,0 +1,48 @@
+package com.se.Tlog.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import com.se.Tlog.global.exception.GlobalAsyncUncaughtExceptionHandler;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+	@Autowired
+	private GlobalAsyncUncaughtExceptionHandler globalAsyncUncaughtExceptionHandler;
+	
+	private static int CORE_POOL_SIZE = 15;
+    private static int MAX_POOL_SIZE = 200;
+    private static int QUEUE_CAPACITY = 2000;
+    private static String THREAD_NAME_PREFIX = "async-task-pool";
+    
+    @Override
+    public Executor getAsyncExecutor() {
+    	// 작업 거부 예외(Reject Exception)는 
+    	// GlobalExceptionHandler에서 처리됩니다. 
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(CORE_POOL_SIZE);
+        executor.setMaxPoolSize(MAX_POOL_SIZE);
+        executor.setQueueCapacity(QUEUE_CAPACITY);
+        executor.setThreadNamePrefix(THREAD_NAME_PREFIX);
+        executor.initialize();
+        return executor;
+    }
+    
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+    	// 비동기 작업 중 예외(AsyncUncaughtException)는
+    	// globalAsyncUncaughtExceptionHandler에서 처리됩니다.
+    	return globalAsyncUncaughtExceptionHandler;
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/application/NotificationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/application/NotificationService.java
@@ -1,0 +1,40 @@
+package com.se.Tlog.domain.Notification.application;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Notification.controller.dto.AssignTokenRequestDto;
+import com.se.Tlog.domain.Notification.repository.NotificationUtil;
+import com.se.Tlog.domain.Notification.repository.jpa.FcmTokenRepository;
+import com.se.Tlog.domain.Notification.repository.jpa.entity.UserFcmTokenJpaEntity;
+import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+@ApplicationService
+public class NotificationService {
+	@Autowired
+	private NotificationUtil notificationUtil;
+	@Autowired
+	private FcmTokenRepository fcmTokenRepository;
+	@Autowired
+	private UserRepository userRepository;
+	
+	public void assignFirebaseToken(AssignTokenRequestDto request) {
+		Optional<User> user = userRepository.findById(request.userId());
+		if (user.isEmpty())
+			throw new CustomException(ErrorType.USER_NOT_FOUND);
+		if (!notificationUtil.isValidToken(request.firebaseToken()))
+			throw new CustomException(ErrorType.INVALID_FIREBASE_TOKEN);
+		
+		UserFcmTokenJpaEntity userFcmEntity = fcmTokenRepository.findByUserId(request.userId());
+		if (userFcmEntity == null)
+			userFcmEntity = new UserFcmTokenJpaEntity(user.get(), request.firebaseToken());
+		else
+			userFcmEntity.updateFirebaseToken(request.firebaseToken());
+		fcmTokenRepository.save(userFcmEntity);
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/NotificationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/NotificationController.java
@@ -1,0 +1,47 @@
+package com.se.Tlog.domain.Notification.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.se.Tlog.domain.Notification.application.NotificationService;
+import com.se.Tlog.domain.Notification.controller.dto.AssignTokenRequestDto;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/api/notify")
+@RequiredArgsConstructor
+public class NotificationController {
+	@Autowired
+	private NotificationService notificationService;
+	
+	@PostMapping
+	@Operation (
+			summary = "FCM Token 등록",
+    		description = "사용자 단말기 앱의 고유 FCM Token을 서버에 등록합니다.",
+			tags = {"알림"},
+			security = @SecurityRequirement(
+					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+					scopes = {"scope1", "scope2"}),
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<?>> assignUserFcmToken(@RequestBody AssignTokenRequestDto request) {
+		notificationService.assignFirebaseToken(request);
+		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/dto/AssignTokenRequestDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/dto/AssignTokenRequestDto.java
@@ -1,0 +1,9 @@
+package com.se.Tlog.domain.Notification.controller.dto;
+
+import java.util.UUID;
+
+public record AssignTokenRequestDto(
+		UUID userId,
+		String firebaseToken) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestFcmMessageByTokenDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestFcmMessageByTokenDto.java
@@ -1,0 +1,16 @@
+package com.se.Tlog.domain.Notification.controller.test;
+
+import java.util.List;
+
+import com.se.Tlog.domain.Notification.repository.dto.FcmKeyValuePairDto;
+
+record TestFcmMessageDto(
+		List<FcmKeyValuePairDto> payloads) {
+	
+}
+
+public record TestFcmMessageByTokenDto(
+		List<String> tokens,
+		List<TestFcmMessageDto> messages) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestFcmMessageByUserIdDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestFcmMessageByUserIdDto.java
@@ -1,0 +1,10 @@
+package com.se.Tlog.domain.Notification.controller.test;
+
+import java.util.List;
+import java.util.UUID;
+
+public record TestFcmMessageByUserIdDto(
+		List<UUID> users,
+		List<TestFcmMessageDto> messages) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestNotificationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestNotificationController.java
@@ -1,0 +1,171 @@
+package com.se.Tlog.domain.Notification.controller.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.se.Tlog.domain.Notification.repository.FcmWrapper;
+import com.se.Tlog.domain.Notification.repository.NotificationUtil;
+import com.se.Tlog.domain.Notification.repository.dto.FcmMessageDto;
+import com.se.Tlog.domain.Notification.repository.dto.FcmRequestDto;
+import com.se.Tlog.domain.Notification.repository.jpa.FcmTokenRepository;
+import com.se.Tlog.domain.Notification.repository.jpa.entity.UserFcmTokenJpaEntity;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.error.ErrorType;
+import com.se.Tlog.global.response.success.SuccessRes;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
+@Controller
+@RequestMapping("/test/notify")
+public class TestNotificationController {
+	@Autowired
+	private NotificationUtil notificationUtil;
+	@Autowired
+	private FcmWrapper fcmWrapper;
+	@Autowired
+	private FcmTokenRepository repository;
+	
+	@Value("${springdoc.swagger-ui.enabled}")
+	private boolean swaggerTestEnabled;
+	
+	@PostMapping("/byUserId")
+	@Operation (
+			summary = "FCM 테스트 - UserId (dev 환경에서만 지원됨)",
+    		description = "FCM 기능을 테스트하는 API입니다. (Swagger UI를 사용하는 dev환경에서만 지원됩니다.)"
+    				+ "<br/>"
+    				+ "<br/> User 및 FcmToken은 DB에 별도 등록 필요."
+    				+ "<br/> 요청 처리 결과를 반환합니다. (실패 사유 : 유저 또는 FCM 토큰이 DB에 등록되지 않음)"
+    				+ "<br/>"
+    				+ "<br/> 다음의 3가지 기능을 제공합니다 : "
+    				+ "<br/> - 한 유저에게 단일 메세지 전송 : 1 userId, 1 message일 때"
+    				+ "<br/> - 여러 유저에게 단일 메세지 전송 : N userId, 1 message일 때"
+    				+ "<br/> - 여러 유저에게 여러 메세지 전송(메세지 수 만큼 전송합니다.) : N userId, M message일 때",
+			tags = {"알림"},
+			security = @SecurityRequirement(
+					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+					scopes = {"scope1", "scope2"}),
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<String>> testFcmNotificationByUserId(@RequestBody TestFcmMessageByUserIdDto request) {
+		if (!swaggerTestEnabled)
+			throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
+		if (request.users().size() == 0)
+			return ResponseEntity.ok(SuccessRes.from("전송할 유저가 등록되지 않았습니다."));
+
+		// TestDto to FcmDto
+		List<FcmRequestDto> messages = new ArrayList<FcmRequestDto>();
+		for (int i = 0; i < request.messages().size(); i++) {
+			TestFcmMessageDto message = request.messages().get(i);
+		    UUID userId = request.users().get(Math.min(i, request.users().size() - 1));
+			messages.add(
+					new FcmRequestDto(
+							userId,
+							message.payloads()));
+		}
+		
+		if (request.users().size() == 1 && messages.size() == 1) {
+			boolean requested = notificationUtil.sendNotification(messages.get(0));
+			UserFcmTokenJpaEntity entity = repository.findByUserId(messages.get(0).userId());
+			log.info("Send single message : " + (entity != null ? entity.getFcmToken() : "user not found"));
+			
+			return ResponseEntity.ok(SuccessRes.from("처리 결과 : " + (requested?"1":"0") + "/1"));
+		} else if (messages.size() == 1) {
+			int requestedCount = notificationUtil.sendNotifications(request.users(), messages.get(0));
+			log.info("Send same multiple messages");
+			
+			return ResponseEntity.ok(SuccessRes.from("처리 결과 : " + requestedCount + "/" + request.users().size()));
+		} else {
+			int requestedCount = notificationUtil.sendNotifications(messages);
+			log.info("Send another multiple messages");
+			
+			return ResponseEntity.ok(SuccessRes.from("처리 결과 : " + requestedCount + "/" + messages.size()));
+		}
+	}
+	
+	@PostMapping("/byToken")
+	@Operation (
+			summary = "FCM 테스트 - FcmToken (dev 환경에서만 지원됨)",
+    		description = "FCM 기능을 테스트하는 API입니다. (Swagger UI를 사용하는 dev환경에서만 지원됩니다.)"
+    				+ "<br/>"
+    				+ "<br/> 요청 처리 결과를 반환합니다. (실패 사유 : 토큰이 유효하지 않음)"
+    				+ "<br/>"
+    				+ "<br/> 다음의 3가지 기능을 제공합니다 : "
+    				+ "<br/> - 한 클라이언트에게 단일 메세지 전송 : 1 token, 1 message일 때"
+    				+ "<br/> - 여러 클라이언트에게 단일 메세지 전송 : N token, 1 message일 때"
+    				+ "<br/> - 여러 클라이언트에게 여러 메세지 전송(메세지 수 만큼 전송합니다.) : N token, M message일 때",
+			tags = {"알림"},
+			security = @SecurityRequirement(
+					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+					scopes = {"scope1", "scope2"}),
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<String>> testFcmNotificationByToken(@RequestBody TestFcmMessageByTokenDto request) {
+		if (!swaggerTestEnabled)
+			throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
+		if (request.tokens().size() == 0)
+			return ResponseEntity.ok(SuccessRes.from("전송할 토큰이 등록되지 않았습니다."));
+		
+		// TestDto to FcmDto
+		List<FcmMessageDto> messages = new ArrayList<FcmMessageDto>();
+		for (int i = 0; i < request.messages().size(); i++) {
+			TestFcmMessageDto message = request.messages().get(i);
+			String token = request.tokens().get(Math.min(i, request.tokens().size() - 1));
+			messages.add(
+					new FcmMessageDto(
+							token,
+							message.payloads()));
+		}
+		
+		if (request.tokens().size() == 1 && messages.size() == 1) {
+			try {
+				boolean successed = fcmWrapper.sendFcmMessage(messages.get(0)).get();	
+				log.info("Send single message : " + messages.get(0).fcmToken());
+				return ResponseEntity.ok(SuccessRes.from("처리 결과 : " + (successed?1:0) + "/1"));
+			} catch (Exception e) {
+				log.info("Send single message : fail");
+				return ResponseEntity.ok(SuccessRes.from("처리 결과 : 0/1"));
+			}
+		} else if (messages.size() == 1) {
+			try {
+				int successedCount = fcmWrapper.sendFcmMessages(request.tokens(), messages.get(0)).get();
+				log.info("Send same multiple messages");
+				return ResponseEntity.ok(SuccessRes.from("처리 결과 : " + successedCount + "/" + request.tokens().size()));
+			} catch (Exception e) {
+				log.info("Send same multiple messages : Fail");
+				return ResponseEntity.ok(SuccessRes.from("처리 결과 : 0/" + request.tokens().size()));
+			}
+		} else {
+			try {
+				int successedCount = fcmWrapper.sendFcmMessages(messages).get();
+				log.info("Send another multiple messages");
+				return ResponseEntity.ok(SuccessRes.from("처리 결과 : " + successedCount + "/" + messages.size()));
+			} catch (Exception e) {
+				log.info("Send another multiple messages : Fail");
+				return ResponseEntity.ok(SuccessRes.from("처리 결과 : 0/" + messages.size()));
+			}
+		}
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/FcmWrapper.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/FcmWrapper.java
@@ -1,0 +1,214 @@
+package com.se.Tlog.domain.Notification.repository;
+
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.MulticastMessage;
+import com.se.Tlog.domain.Notification.repository.dto.FcmKeyValuePairDto;
+import com.se.Tlog.domain.Notification.repository.dto.FcmMessageDto;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
+@Component
+public class FcmWrapper implements InitializingBean {
+	@Autowired
+	private InvalidTokenHandler invalidTokenHandler;
+	
+	@Value("${SERVICE_ACCOUNT_KEY_PATH}")
+	private String SERVICE_ACCOUNT_KEY_PATH;
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		initializeFirebaseApp();
+		log.info("FCM Initialize Done");
+	}
+
+	private static final int MAX_MESSAGE_COUNT = 500;
+	
+	private void initializeFirebaseApp() {
+		try {
+			FileInputStream serviceAccount = new FileInputStream(SERVICE_ACCOUNT_KEY_PATH);
+			FirebaseOptions options = FirebaseOptions.builder()
+					.setCredentials(GoogleCredentials.fromStream(serviceAccount))
+					.build();
+
+			FirebaseApp.initializeApp(options);
+		} catch (Exception e) {
+			throw new CustomException(ErrorType.FIREBASE_INITIALIZE_FAIL);
+		}		
+	}
+	
+	public boolean isValidToken(String firebaseToken) {
+		Message message = Message.builder()
+			    .putData("dummyData", "dummy")
+			    .setToken(firebaseToken)
+			    .build();
+
+		try {
+			FirebaseMessaging.getInstance().send(message, true);
+			return true;
+		} catch (FirebaseMessagingException e) {
+			return false;
+		} catch (Exception e) {
+			throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
+		}
+	}
+	
+	private void handleExternalException(Exception e) {
+		log.error("fail to send FCM message, without firebase messaging system.", e);
+	}
+	
+	private void handleFcmException(FirebaseMessagingException e) {
+		if (e.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED
+				|| e.getMessagingErrorCode() == MessagingErrorCode.INVALID_ARGUMENT) {
+			log.error("fail to send FCM message, invalid token found, Error code : " + e.getMessagingErrorCode().toString());
+			// 유효하지 않은 토큰 삭제 처리
+			//invalidTokenHandler.handle();
+		}
+		else
+			log.error("fail to send FCM message, Error code : " + e.getMessagingErrorCode().toString(), e);
+	}
+
+	private Message toMessage(FcmMessageDto dto) {
+		Message.Builder messageBuilder = Message.builder();
+		messageBuilder.setToken(dto.fcmToken());
+		for (FcmKeyValuePairDto payload : dto.payload())
+			messageBuilder.putData(payload.key(), payload.value());
+		
+		return messageBuilder.build();
+	}
+	
+	/**
+	 * Firebase에서 허용하는 단일 최대 전송 수량에 맞추어 복수의 메세지를 분할합니다.
+	 * @return
+	 */
+	private List<List<Message>> separatedMessages(List<FcmMessageDto> messagesDto) {
+		List<List<Message>> separatedMessages = new ArrayList<List<Message>>();
+		
+		int messageCount = 0;
+		for (int partition = 0; partition <= (messagesDto.size()-1)/MAX_MESSAGE_COUNT; partition++) {
+			List<Message> messages = new ArrayList<Message>();
+			while (messageCount < messagesDto.size() && messages.size() < MAX_MESSAGE_COUNT)
+				messages.add(toMessage(messagesDto.get(messageCount++)));
+			
+			separatedMessages.add(messages);
+		}
+		
+		return separatedMessages;
+	}
+	
+	/**
+	 * Firebase에서 허용하는 단일 최대 전송 수량에 맞추어 복수의 메세지를 분할합니다.
+	 * @return
+	 */
+	private List<MulticastMessage> separatedMessages(List<String> tokens, FcmMessageDto messageDto) {
+		List<MulticastMessage> separatedMessages = new ArrayList<MulticastMessage>();
+		
+		for (int partition = 0; partition <= (tokens.size()-1)/MAX_MESSAGE_COUNT; partition++) {
+			MulticastMessage.Builder messageBuilder = MulticastMessage.builder();
+			messageBuilder.addAllTokens(
+					tokens.subList(
+							partition * MAX_MESSAGE_COUNT, 
+							Math.min((partition + 1) * MAX_MESSAGE_COUNT, tokens.size())));
+			for (FcmKeyValuePairDto payload : messageDto.payload())
+				messageBuilder.putData(payload.key(), payload.value());
+			
+			separatedMessages.add(messageBuilder.build());
+		}
+		
+		return separatedMessages;
+	}
+	
+	/**
+	 * 단일 푸시 메세지를 전송할 때 사용합니다.
+	 * <br/> 메세지 전송 성공 여부를 반환합니다.
+	 * <br/> 여러 메세지를 일괄 전송할 경우, <code>sendFcmMessages()</code>를 사용하는 것이 권장됩니다.
+	 * @param messageDto
+	 */
+	@Async
+	public CompletableFuture<Boolean> sendFcmMessage(FcmMessageDto messageDto) {
+		try {
+			FirebaseMessaging.getInstance().send(toMessage(messageDto));
+			return CompletableFuture.completedFuture(true);
+		} catch (FirebaseMessagingException e) {
+			handleFcmException(e);
+		} catch (Exception e) {
+			handleExternalException(e);
+		}
+		return CompletableFuture.completedFuture(false);
+	}
+	
+	/**
+	 * 동일 내용의 푸시 메세지를 여러 클라이언트에 전송할 때 사용합니다.
+	 * <br/> 메세지 전송 성공 수를 반환합니다.
+	 * <br/><code>messageDto.fcmToken()</code>는 사용되지 않습니다.
+	 */
+	@Async
+	public CompletableFuture<Integer> sendFcmMessages(List<String> tokens, FcmMessageDto messageDto) {
+		int successCount = 0;
+		for (MulticastMessage messages : separatedMessages(tokens, messageDto)) {
+			try {
+				BatchResponse result = FirebaseMessaging.getInstance().sendEachForMulticast(messages);
+				if (result.getFailureCount() > 0) {
+					result.getResponses().forEach((response) -> {
+						if (!response.isSuccessful()) 
+							handleFcmException(response.getException());
+					});
+				}
+				successCount += result.getSuccessCount();
+			} catch (FirebaseMessagingException e) {
+				handleFcmException(e);
+			} catch (Exception e) {
+				handleExternalException(e);
+			}
+		}
+		return CompletableFuture.completedFuture(successCount);
+	}
+	
+	/**
+	 * 서로 다른 내용의 여러 메세지를 전송할 때 사용합니다.
+	 * <br/> 메세지 전송 성공 수를 반환합니다.
+	 * @param messagesDto
+	 */
+	@Async
+	public CompletableFuture<Integer> sendFcmMessages(List<FcmMessageDto> messagesDto) {
+		int successCount = 0;
+		for (List<Message> messages : separatedMessages(messagesDto)) {
+			try {
+				BatchResponse result = FirebaseMessaging.getInstance().sendEach(messages);
+				if (result.getFailureCount() > 0) {
+					result.getResponses().forEach((response) -> {
+						if (!response.isSuccessful())
+							handleFcmException(response.getException());
+					});
+				}
+				successCount += result.getSuccessCount();
+			} catch (FirebaseMessagingException e) {
+				handleFcmException(e);
+			} catch (Exception e) {
+				handleExternalException(e);
+			}
+		}
+		return CompletableFuture.completedFuture(successCount);
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/FcmWrapper.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/FcmWrapper.java
@@ -1,6 +1,7 @@
 package com.se.Tlog.domain.Notification.repository;
 
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -34,7 +35,7 @@ public class FcmWrapper implements InitializingBean {
 	@Autowired
 	private InvalidTokenHandler invalidTokenHandler;
 	
-	@Value("${SERVICE_ACCOUNT_KEY_PATH}")
+	@Value("${firebase-env.key-path}")
 	private String SERVICE_ACCOUNT_KEY_PATH;
 
 	@Override
@@ -46,6 +47,9 @@ public class FcmWrapper implements InitializingBean {
 	private static final int MAX_MESSAGE_COUNT = 500;
 	
 	private void initializeFirebaseApp() {
+		if (!FirebaseApp.getApps().isEmpty())
+			return;
+		
 		try {
 			FileInputStream serviceAccount = new FileInputStream(SERVICE_ACCOUNT_KEY_PATH);
 			FirebaseOptions options = FirebaseOptions.builder()
@@ -54,7 +58,10 @@ public class FcmWrapper implements InitializingBean {
 
 			FirebaseApp.initializeApp(options);
 		} catch (Exception e) {
-			throw new CustomException(ErrorType.FIREBASE_INITIALIZE_FAIL);
+			if (e.getClass() == FileNotFoundException.class)
+				throw new CustomException(ErrorType.FIREBASE_INITIALIZE_FAIL_KEY_NOT_FOUND);
+			else
+				throw new CustomException(ErrorType.FIREBASE_INITIALIZE_FAIL);
 		}		
 	}
 	

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/InvalidTokenHandler.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/InvalidTokenHandler.java
@@ -1,0 +1,10 @@
+package com.se.Tlog.domain.Notification.repository;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class InvalidTokenHandler {
+	public void handle(String token) {
+		// 유효하지 않은 FCM 토큰 처리 로직 필요
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/NotificationUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/NotificationUtil.java
@@ -1,0 +1,89 @@
+package com.se.Tlog.domain.Notification.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.se.Tlog.domain.Notification.repository.dto.FcmMessageDto;
+import com.se.Tlog.domain.Notification.repository.dto.FcmRequestDto;
+import com.se.Tlog.domain.Notification.repository.jpa.FcmTokenRepository;
+import com.se.Tlog.domain.Notification.repository.jpa.entity.UserFcmTokenJpaEntity;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
+@Component
+public class NotificationUtil {
+	@Autowired
+	private FcmWrapper fcmWrapper;
+	@Autowired
+	private FcmTokenRepository fcmTokenRepository;
+	
+	public boolean isValidToken(String firebaseToken) {
+		return fcmWrapper.isValidToken(firebaseToken);
+	}
+	
+	/**
+	 * 단일 메세지를 전송합니다.
+	 * <br/> 알림을 전송할 유저의 클라이언트가 등록되지 않은 경우, <code>false</code>를 반환합니다.
+	 * <br/> 여러 메세지를 전송할 경우, <code>sendNotifications()</code>를 사용할 것을 권장합니다.
+	 * @param request
+	 */
+	public boolean sendNotification(FcmRequestDto request) {
+		UserFcmTokenJpaEntity dbEntity = fcmTokenRepository.findByUserId(request.userId());
+		if (dbEntity == null)
+			return false;
+		
+		fcmWrapper.sendFcmMessage(new FcmMessageDto(dbEntity.getFcmToken(), request.payload()));
+		return true;
+	}
+	
+	/**
+	 * 동일 메세지를 여러 클라이언트에 전송합니다.
+	 * <br/> 등록된 클라이언트가 있어 요청을 진행한 수를 반환합니다. 
+	 * @param users
+	 * @param sendPayload <code>sendPayload.userId</code>는 사용되지 않습니다.
+	 */
+	public int sendNotifications(List<UUID> users, FcmRequestDto request) {
+		// DB 접근의 최소화를 위해, user -> token 일괄 변환
+		List<String> tokens = fcmTokenRepository.findFcmTokenByUserIdIn(users);
+		int validTokens = tokens.size();
+		
+		if (validTokens > 0)
+			fcmWrapper.sendFcmMessages(tokens, new FcmMessageDto(null, request.payload()));
+		return validTokens;
+	}
+	
+	/**
+	 * 서로 다른 여러 메세지를 여러 클라이언트에 전송합니다.
+	 * <br/> 등록된 클라이언트가 있어 요청을 진행한 수를 반환합니다.
+	 * @param sendData
+	 */
+	public int sendNotifications(List<FcmRequestDto> requests) {
+		// DB 접근의 최소화를 위해, user -> token 일괄 변환
+		List<UUID> users = new ArrayList<UUID>();
+		for (FcmRequestDto m : requests)
+			users.add(m.userId());
+		if (users.size() == 0)
+			return 0;
+		
+		Map<UUID, String> tokenMap = fcmTokenRepository.findAllByUserIdIn(users)
+				.stream().collect(Collectors.toMap(e -> e.getUser().getId(), e -> e.getFcmToken()));
+		if (tokenMap.size() == 0)
+			return 0;
+
+		List<FcmMessageDto> messages = new ArrayList<FcmMessageDto>();
+		for (FcmRequestDto m : requests)
+			if (tokenMap.containsKey(m.userId()))
+				messages.add(new FcmMessageDto(tokenMap.get(m.userId()), m.payload()));
+		fcmWrapper.sendFcmMessages(messages);
+		
+		return tokenMap.size();
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmKeyValuePairDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmKeyValuePairDto.java
@@ -1,0 +1,7 @@
+package com.se.Tlog.domain.Notification.repository.dto;
+
+public record FcmKeyValuePairDto(
+		String key,
+		String value) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmMessageDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmMessageDto.java
@@ -1,0 +1,9 @@
+package com.se.Tlog.domain.Notification.repository.dto;
+
+import java.util.List;
+
+public record FcmMessageDto(
+		String fcmToken,
+		List<FcmKeyValuePairDto> payload) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmRequestDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmRequestDto.java
@@ -1,0 +1,10 @@
+package com.se.Tlog.domain.Notification.repository.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record FcmRequestDto(
+		UUID userId,
+		List<FcmKeyValuePairDto> payload) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/jpa/FcmTokenRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/jpa/FcmTokenRepository.java
@@ -1,0 +1,18 @@
+package com.se.Tlog.domain.Notification.repository.jpa;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.se.Tlog.domain.Notification.repository.jpa.entity.UserFcmTokenJpaEntity;
+
+public interface FcmTokenRepository extends JpaRepository<UserFcmTokenJpaEntity, UUID> {
+	public UserFcmTokenJpaEntity findByUserId(UUID userId);
+	public List<UserFcmTokenJpaEntity> findAllByUserIdIn(List<UUID> userIds);
+	
+	@Query("SELECT t.fcmToken FROM UserFcmTokenJpaEntity t WHERE t.user.id IN :userIds")
+	public List<String> findFcmTokenByUserIdIn(@Param("userIds") List<UUID> userIds);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/jpa/entity/UserFcmTokenJpaEntity.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/jpa/entity/UserFcmTokenJpaEntity.java
@@ -1,0 +1,41 @@
+package com.se.Tlog.domain.Notification.repository.jpa.entity;
+
+import java.util.UUID;
+
+import com.se.Tlog.domain.User.domain.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "userfcmtoken")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserFcmTokenJpaEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
+	
+	@OneToOne
+	@JoinColumn(name = "user_id")
+	private User user;
+	
+	private String fcmToken;
+	
+	public UserFcmTokenJpaEntity(User user, String fcmToken) {
+		this.user = user;
+		this.fcmToken = fcmToken;
+	}
+	
+	public void updateFirebaseToken(String fcmToken) {
+		this.fcmToken = fcmToken;
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/global/exception/GlobalAsyncUncaughtExceptionHandler.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/exception/GlobalAsyncUncaughtExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.se.Tlog.global.exception;
+
+import java.lang.reflect.Method;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
+@Component
+public class GlobalAsyncUncaughtExceptionHandler implements AsyncUncaughtExceptionHandler {
+	@Override
+	public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+        log.error("Error occurred - Async uncaught exception : [errorCode={}, message={}]", ex.getClass(), ex.getMessage(), ex);
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/global/exception/GlobalExceptionHandler.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import static com.se.Tlog.global.response.error.ErrorType.INTERNAL_SERVER_ERROR;
 
+import java.util.concurrent.RejectedExecutionException;
 
 @RestControllerAdvice
 @Slf4j
@@ -19,6 +20,15 @@ public class GlobalExceptionHandler {
         ErrorType errorType = e.getErrorType();
         ErrorRes error = ErrorRes.of(errorType.getStatusCode(), errorType.getMessage());
         log.error("Error occurred : [errorCode={}, message={}]",e.getClass(), e.getMessage(),e);;
+        return ResponseEntity.status(error.status()).body(error);
+    }
+    
+    // 비동기 요청 거부 에러
+    @ExceptionHandler(RejectedExecutionException.class)
+    protected ResponseEntity<?> handleRejectedExecutionException(RejectedExecutionException e) {
+    	ErrorRes error = ErrorRes.of(INTERNAL_SERVER_ERROR.getStatusCode(), INTERNAL_SERVER_ERROR.getMessage());
+    	log.error("Error occurred : Task rejected - Server Thread Overflow!!");
+    	log.error("\t\t : [errorCode={}, message={}]", e.getClass(), e.getMessage(), e);
         return ResponseEntity.status(error.status()).body(error);
     }
 

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -56,6 +56,7 @@ public enum ErrorType {
     NO_MORE_SPACE_FOR_INVITE_CODE(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. 팀 초대 코드를 더 이상 생성할 수 없습니다."),
     INTERNAL_ERROR_BY_INVITE_CODE(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. 팀 초대 코드 에러."),
     FIREBASE_INITIALIZE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. Firebase 라이브러리 초기화 에러."),
+    FIREBASE_INITIALIZE_FAIL_KEY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. Firebase Key 파일을 찾지 못했습니다."),
     
     // 외부 소셜 로그인 처리 중 에러
     SSO_ACCESSTOKEN_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "외부 인증 서버로부터 인증을 받는데 실패했습니다."),

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -13,6 +13,7 @@ public enum ErrorType {
     TEAM_NAME_NOT_FOUND(HttpStatus.BAD_REQUEST, "팀 이름이 비어있습니다."),
     TEAM_CANNOT_BE_ORPHAN(HttpStatus.BAD_REQUEST, "팀에 최소 1명 이상의 팀원이 필요합니다."),
     ROLE_MISMATCH(HttpStatus.BAD_REQUEST,"Role 값을 잘못 입력하였습니다."),
+    INVALID_FIREBASE_TOKEN(HttpStatus.BAD_REQUEST,"클라이언트 FCM Token이 유효하지 않습니다!"),
     
     // 사용자로부터 소셜 로그인 인증 실패
     SSO_LOGIN_FAIL(HttpStatus.BAD_REQUEST,"외부 소셜 로그인이 취소되거나 실패했습니다."),
@@ -54,6 +55,7 @@ public enum ErrorType {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. 서버 팀으로 연락주시기 바랍니다."),
     NO_MORE_SPACE_FOR_INVITE_CODE(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. 팀 초대 코드를 더 이상 생성할 수 없습니다."),
     INTERNAL_ERROR_BY_INVITE_CODE(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. 팀 초대 코드 에러."),
+    FIREBASE_INITIALIZE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. Firebase 라이브러리 초기화 에러."),
     
     // 외부 소셜 로그인 처리 중 에러
     SSO_ACCESSTOKEN_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "외부 인증 서버로부터 인증을 받는데 실패했습니다."),

--- a/tlog-was/src/main/resources/application.yml
+++ b/tlog-was/src/main/resources/application.yml
@@ -102,6 +102,9 @@ sso:
   clientSecret:
     google: ${SSO_GOOGLE_SECRET}
 
+firebase-env:
+  key-path: ${FIREBASE_SERVICE_ACCOUNT_KEY_PATH}
+
 # springdoc swagger
 springdoc:
   api-docs:


### PR DESCRIPTION
## 작업 동기 및 이슈
- #59 

## 환경설정 변동

- 노션 - "백엔드/firebase" 페이지 참고
  - **FIREBASE_SERVICE_ACCOUNT_KEY_PATH 환경변수가 추가되었습니다!**
  - **firebaseKey.json 파일이 추가되었습니다!**

## 추가 및 변경사항

- **비동기 처리 기능이 도입되었습니다.**
  - [Class] : AsyncConfig
  - [Class] : AsyncUncaughtExceptionHandler
  - [Method] : GlobalExceptionHandler.handleRejectedExecutionException()

- **푸시 알림을 위해 Firebase 라이브러리가 도입되었습니다.**
  - **환경변수 및 Key 파일 추가됨**

- **FCM Token을 관리하는 테이블이 추가되었습니다.**
  - [Table] : userfcmtoken
  - [Entity] : UserFcmTokenJpaEntity

- **알림 기능을 제공하는 클래스가 추가되었습니다.**
  - FcmWrapper : FCM 서버와의 통신을 래핑합니다. 비동기 처리 등 하위 계층의 구현을 포함합니다.
  - NotificationUtil : 도메인 내에서 사용할 수 있도록 알림 기능을 제공합니다.

- **기능 변경사항**
  - 특정 유저의 FCM 토큰을 등록하는 기능 추가.
    _현재는 유저 당 하나의 FCM 토큰만을 등록할 수 있습니다!
    추후 유저 당 여러 FCM 토큰을 등록할 수 있도록 개선이 필요합니다. (기기가 여러개일 경우 필요)
    -> 이슈 관리 목록에 추가됨_

- **별도의 테스트를 위한 컨트롤러가 추가되었습니다.**
  - Swagger UI가 사용되는 환경에서만 활성화됩니다.
  <img src="https://github.com/user-attachments/assets/3056f97b-ed4c-4b74-bede-98d2821faad3" width="400">

## 테스트 결과

- 개발 환경 및 Docker 배포 환경 실행 테스트 완료.

- **Firebase Token 등록**
  - 등록 요청
  - <img src="https://github.com/user-attachments/assets/f4f2f3c6-07c9-48f2-bdf5-762402edca9e" width="400">
  - DB 상태
  - <img src="https://github.com/user-attachments/assets/10fa7615-b513-42bb-8237-e42c3e231288" width="400">

- **FCM 메세징 테스트**
  - 메세지 전송 요청
  - <img src="https://github.com/user-attachments/assets/e6305b2e-2cc0-467c-ad51-2b0fef60006b" width="400">
  - 푸시 알림 수신
  - <img src="https://github.com/user-attachments/assets/c7284744-41ba-48da-8eb2-6f1cb66df60b" height="600">

## 📌 기타
- 테스트용 어플리케이션 등 추가 정보를 위해 노션 - "백엔드/firebase" 페이지 참고!