### PR TITLE
Refact: 삭제된 태그가 포함된 여행지 태그 리스트 필터링 로직 리팩토링

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -2,6 +2,7 @@ package com.se.Tlog.domain.Travel.application;
 
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationDto;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
 import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.domain.TagInfo;
 import com.se.Tlog.domain.Travel.domain.repository.DestinationRepositoryService;
@@ -9,6 +10,9 @@ import com.se.Tlog.domain.Travel.domain.repository.TagRepositoryService;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -22,7 +26,7 @@ public class DestinationService {
     public void createDestination(DestinationDto destinationDto) {
     	Destination.assertValidity(destinationDto.getName(), destinationRepoService);
         List<TagInfo> tagInfoList = destinationDto.getTags().stream()
-                .map(tagIdDto -> TagInfo.create(tagIdDto.tagId(), tagIdDto.weight(), tagRepoService))
+                .map(tagIdDto -> TagInfo.create(tagIdDto.tagId(), tagIdDto.weight(),tagRepoService))
                 .toList();
         Destination destination = Destination.create(
         		destinationDto.getName(),
@@ -37,11 +41,18 @@ public class DestinationService {
         destinationRepository.save(destination);
     }
 
-    public List<Destination> getAllDestinations() {
-        return destinationRepository.findAll();
+    public Page<DestinationRes> getAllDestinations(Pageable pageable) {
+        Page<Destination> destinationPage = destinationRepository.findAllWithActiveTags(pageable);
+        List<DestinationRes> destinationResList = destinationPage
+                .stream()
+                .map(DestinationRes::from).toList();
+
+        return new PageImpl<>(destinationResList, pageable, destinationPage.getTotalElements());
     }
 
-    public Destination getDestinationById(String id) {
-        return destinationRepository.findById(id).orElseThrow(() -> new RuntimeException("Destination not found"));
+    public DestinationRes getDestinationById(String id) {
+        Destination destination = destinationRepository.findById(id).orElseThrow(() -> new RuntimeException("Destination not found"));
+
+        return DestinationRes.from(destination);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/TagService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/TagService.java
@@ -1,5 +1,9 @@
 package com.se.Tlog.domain.Travel.application;
 
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.Updates;
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Travel.controller.dto.TagDto;
 import com.se.Tlog.domain.Travel.controller.dto.TagRes;
@@ -11,6 +15,11 @@ import com.se.Tlog.domain.Travel.repository.mongo.TagRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -21,12 +30,13 @@ import java.util.List;
 public class TagService {
     private final TagRepository tagRepository;
     private final TagRepositoryService tagRepo;
+    private final MongoTemplate mongoTemplate;
 
     @Transactional(readOnly = true)
-    public List<TagRes> getAllTags() {
+    public List<TagRes> getAllActiveTags(Pageable pageable) {
 
-        return tagRepository.findAll().stream()
-                .map(tag -> TagRes.from(tag.getId(), tag.getName(),tag.isDeleted()))
+        return tagRepository.findAllByActiveTags(pageable).stream()
+                .map(tag -> TagRes.from(tag.getId(), tag.getName()))
                 .toList();
     }
 
@@ -42,5 +52,18 @@ public class TagService {
                 .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
         tag.markAsDeleted();
         tagRepository.save(tag);
+
+        MongoCollection<Document> collection = mongoTemplate.getCollection("destinations");
+
+        Bson filter = Filters.eq("tags._id", new ObjectId(tagId));
+        Bson update = Updates.set("tags.$[elem].isDeleted", true);
+
+        UpdateOptions options = new UpdateOptions()
+                .arrayFilters(List.of(
+                        Filters.eq("elem._id", new ObjectId(tagId))
+                ));
+
+        collection.updateMany(filter, update, options);
+
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/TagService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/TagService.java
@@ -46,17 +46,17 @@ public class TagService {
     }
 
 
-    public void deleteTag(String tagId) {
+    public void updateTagDeletedStatus(String tagId, boolean isDeleted) {
 
         Tag tag = tagRepository.findById(tagId)
                 .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
-        tag.markAsDeleted();
+        tag.updateTagDeleted(isDeleted);
         tagRepository.save(tag);
 
         MongoCollection<Document> collection = mongoTemplate.getCollection("destinations");
 
         Bson filter = Filters.eq("tags._id", new ObjectId(tagId));
-        Bson update = Updates.set("tags.$[elem].isDeleted", true);
+        Bson update = Updates.set("tags.$[elem].isDeleted", isDeleted);
 
         UpdateOptions options = new UpdateOptions()
                 .arrayFilters(List.of(

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
@@ -2,14 +2,16 @@ package com.se.Tlog.domain.Travel.controller;
 
 import com.se.Tlog.domain.Travel.application.DestinationService;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationDto;
-import com.se.Tlog.domain.Travel.domain.Destination;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/destinations")
@@ -26,12 +28,12 @@ public class DestinationController {
     }
 
     @GetMapping
-    public ResponseEntity<List<Destination>> getAllDestinations() {
-        return ResponseEntity.ok(destinationService.getAllDestinations());
+    public ResponseEntity<Page<DestinationRes>> getAllDestinations(@PageableDefault(size = 10) Pageable pageable) {
+        return ResponseEntity.ok(destinationService.getAllDestinations(pageable));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Destination> getDestinationById(@PathVariable String id) {
+    public ResponseEntity<DestinationRes> getDestinationById(@PathVariable String id) {
         return ResponseEntity.ok(destinationService.getDestinationById(id));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/TagController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/TagController.java
@@ -5,6 +5,8 @@ import com.se.Tlog.domain.Travel.controller.dto.TagDto;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,10 +26,10 @@ public class TagController {
     }
 
     @GetMapping
-    public ResponseEntity<?> getAllTags() {
+    public ResponseEntity<?> getActiveAllTags(@PageableDefault(size = 10)Pageable pageable) {
         return ResponseEntity
                 .ok()
-                .body(SuccessRes.from(tagService.getAllTags()));
+                .body(SuccessRes.from(tagService.getAllActiveTags(pageable)));
     }
 
     @DeleteMapping("{tagId}")

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/TagController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/TagController.java
@@ -32,12 +32,13 @@ public class TagController {
                 .body(SuccessRes.from(tagService.getAllActiveTags(pageable)));
     }
 
-    @DeleteMapping("{tagId}")
-    public ResponseEntity<?> deleteTag(@PathVariable("tagId") String tagId) {
+    @PutMapping("{tagId}")
+    public ResponseEntity<?> deleteTag(@PathVariable("tagId") String tagId,
+                                       @RequestParam boolean isDeleted) {
 
-        tagService.deleteTag(tagId);
+        tagService.updateTagDeletedStatus(tagId,isDeleted);
         return ResponseEntity
-                .status(SuccessType.TAG_DELETE.getStatus())
-                .body(SuccessRes.from(SuccessType.TAG_DELETE));
+                .status(SuccessType.TAG_UPDATE.getStatus())
+                .body(SuccessRes.from(SuccessType.TAG_UPDATE));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationRes.java
@@ -1,0 +1,33 @@
+package com.se.Tlog.domain.Travel.controller.dto;
+
+import com.se.Tlog.domain.Travel.domain.Destination;
+import com.se.Tlog.domain.Travel.domain.Location;
+
+import java.util.List;
+
+public record DestinationRes(
+         String name,
+         String address,
+         Location location,
+         int rating,
+         String city,
+         boolean hasParking,
+         boolean petFriendly,
+         List<TagIdDto>tags
+) {
+    public static DestinationRes from(Destination destination) {
+        List<TagIdDto> tagIdDtoList = destination.getTags().stream().filter(tagInfo -> !tagInfo.isDeleted())
+                .map(tagInfo -> TagIdDto.from(tagInfo.getId(), tagInfo.getWeight()))
+                .toList();
+        return new DestinationRes(
+                destination.getName(),
+                destination.getAddress(),
+                destination.getLocation(),
+                destination.getRating(),
+                destination.getCity(),
+                destination.isHasParking(),
+                destination.isPetFriendly(),
+                tagIdDtoList
+        );
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/TagRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/TagRes.java
@@ -2,10 +2,9 @@ package com.se.Tlog.domain.Travel.controller.dto;
 
 public record TagRes(
         String tagId,
-        String tagName,
-        boolean deleted
+        String tagName
 ) {
-    public static TagRes from(String tagId, String tagName, boolean deleted) {
-        return new TagRes(tagId, tagName, deleted);
+    public static TagRes from(String tagId, String tagName) {
+        return new TagRes(tagId, tagName);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Tag.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Tag.java
@@ -19,7 +19,7 @@ public class Tag {
 	private String id;
 	private String name;
 
-	private boolean deleted = false;
+	private boolean isDeleted = false;
 
 	private Tag(String name, int weight) {
 		this.name = name;
@@ -32,6 +32,6 @@ public class Tag {
 	}
 
 	public void markAsDeleted() {
-		this.deleted = true;
+		this.isDeleted = true;
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Tag.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Tag.java
@@ -31,7 +31,7 @@ public class Tag {
         return new Tag(name, weight);
 	}
 
-	public void markAsDeleted() {
-		this.isDeleted = true;
+	public void updateTagDeleted(boolean isDeleted) {
+		this.isDeleted = isDeleted;
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/TagInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/TagInfo.java
@@ -15,10 +15,11 @@ import lombok.NoArgsConstructor;
 public class TagInfo { // 여행지가 갖고 있는 태그 정보
     private String id;
     private int weight;
+    private boolean isDeleted;
     
     public static TagInfo create(String tagId, int tagWeight, TagRepositoryService validator) {
     	if (!validator.existById(tagId))
     		throw new CustomException(ErrorType.NOT_FOUND_TAG);
-    	return new TagInfo(tagId, tagWeight);
+        return new TagInfo(tagId, tagWeight, false);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/DestinationRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/DestinationRepository.java
@@ -1,15 +1,20 @@
 package com.se.Tlog.domain.Travel.repository.mongo;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.se.Tlog.domain.Travel.domain.Destination;
 
-import java.util.List;
 
 @Repository
 public interface DestinationRepository extends MongoRepository<Destination, String> {
-    List<Destination> findByTagsIdContains(String tagId);
 
     boolean existsByName(String name);
+
+    @Query("{'tags.isDeleted' :  false}")
+    Page<Destination> findAllWithActiveTags(Pageable pageable);
+
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/TagRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/TagRepository.java
@@ -1,15 +1,19 @@
 package com.se.Tlog.domain.Travel.repository.mongo;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.se.Tlog.domain.Travel.domain.Tag;
 
-import java.util.Optional;
 
 @Repository
 public interface TagRepository extends MongoRepository<Tag, String> {
-    Optional<Tag> findByName(String name);
 
     boolean existsByName(String name);
+
+    @Query("{'tags.isDeleted': false}")
+    Page<Tag> findAllByActiveTags(Pageable pageable);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/success/SuccessType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/success/SuccessType.java
@@ -15,7 +15,7 @@ public enum SuccessType {
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공하였습니다."),
     REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급에 성공하였습니다."),
     AVAILABLE_ID(HttpStatus.OK, "사용가능한 아이디입니다."),
-    TAG_DELETE(HttpStatus.OK, "태그 삭제에 성공하였습니다." ),
+    TAG_UPDATE(HttpStatus.OK, "태그 상태 업데이트에 성공하였습니다." ),
 
     // 201
     CREATED(HttpStatus.CREATED, "등록을 성공하였습니다."),


### PR DESCRIPTION
## 작업 동기 및 이슈
- #69 

## 추가 및 변경사항
- 여행지 필드 내 tagList가 갖고 있는 필드로 isDeleted 추가 
- 태그 삭제 기능을 태그 상태 업데이트 기능으로 수정
- 컨트롤러 반환 타입을 Page 타입으로 수정

## 테스트 결과

### 태스트 대상 data (수성못 유원지)
<img width="927" alt="스크린샷 2025-04-07 오후 9 20 02" src="https://github.com/user-attachments/assets/0ea41ee9-00db-4d70-92bf-33ce84c87deb" />

### 특정 태그를 삭제(isDeleted = true)시 테스트 
<img width="1285" alt="스크린샷 2025-04-07 오후 9 21 13" src="https://github.com/user-attachments/assets/60c8b075-af54-4f9d-bc83-3643832de29e" />

<img width="1249" alt="스크린샷 2025-04-07 오후 9 21 28" src="https://github.com/user-attachments/assets/db2fd236-1126-4d59-b879-4250877ca829" />

<img width="1255" alt="스크린샷 2025-04-07 오후 9 21 44" src="https://github.com/user-attachments/assets/f33f479a-f671-4bf9-98ab-0f50508ba9b6" />

- 두 api 에서 삭제된 태그는 안 보이는 것을 확인할 수 있다.

### 삭제된 태그를 다시 되돌리는 경우 (isDeleted = false )

<img width="1228" alt="스크린샷 2025-04-07 오후 9 19 41" src="https://github.com/user-attachments/assets/c2a3a696-8f3a-4a8b-9183-c35282203df5" />

<img width="1252" alt="스크린샷 2025-04-07 오후 9 20 23" src="https://github.com/user-attachments/assets/ec685268-e2d7-4e78-9962-845b87dd2d8f" />

- 다시 여행지 조회시 삭제되었던 태그들이 보이는 것을 확인할 수 있다.

