### PR TITLE
Feature: 스크랩 기초 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/Scrap/application/ScrapService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/Scrap/application/ScrapService.java
@@ -1,0 +1,62 @@
+package com.se.Tlog.domain.Wishlist.Scrap.application;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Travel.domain.Destination;
+import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
+import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.domain.Wishlist.Scrap.domain.Scrap;
+import com.se.Tlog.domain.Wishlist.Scrap.repository.mongo.ScrapRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+@ApplicationService
+public class ScrapService {
+	@Autowired
+	private ScrapRepository scrapRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private DestinationRepository destinationRepository;
+	
+	public List<Destination> getScrapList(UUID userId) {
+		if (!userRepository.existsById(userId))
+			throw new CustomException(ErrorType.USER_NOT_FOUND);
+		
+		Scrap scrap = scrapRepository.findByUserId(userId);
+		if (scrap != null)
+			return destinationRepository.findAllById(scrap.getDestinationIds());
+		return new ArrayList<Destination>();
+	}
+	
+	public void scrapDescription(UUID userId, String destinationId) {
+		if (!userRepository.existsById(userId))
+			throw new CustomException(ErrorType.USER_NOT_FOUND);
+		if (!destinationRepository.existsById(destinationId))
+			throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);
+		
+		Scrap scrap = scrapRepository.findByUserId(userId);
+		if (scrap == null)
+			scrap = Scrap.create(userId);
+		
+		scrap.addDestination(destinationId);
+		scrapRepository.save(scrap);
+	}
+	
+	public void unscrapDescription(UUID userId, String destinationId) {
+		if (!userRepository.existsById(userId))
+			throw new CustomException(ErrorType.USER_NOT_FOUND);
+		
+		Scrap scrap = scrapRepository.findByUserId(userId);
+		if (scrap == null)
+			scrap = Scrap.create(userId);
+		
+		scrap.deleteDestination(destinationId);
+		scrapRepository.save(scrap);
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/Scrap/controller/ScrapController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/Scrap/controller/ScrapController.java
@@ -1,0 +1,99 @@
+package com.se.Tlog.domain.Wishlist.Scrap.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.se.Tlog.domain.Travel.domain.Destination;
+import com.se.Tlog.domain.Wishlist.Scrap.application.ScrapService;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/api/scrap")
+@RequiredArgsConstructor
+public class ScrapController {
+	@Autowired
+	private ScrapService scrapService;
+	
+	@GetMapping("/user/{userId}")
+	@Operation (
+			summary = "스크랩 된 여행지 조회",
+    		description = "특정 사용자의 스크랩 목록을 조회합니다.",
+			tags = {"유저 여행지 스크랩(찜목록)"},
+			security = @SecurityRequirement(
+					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+					scopes = {"scope1", "scope2"}),
+			parameters = { @Parameter(name = "userId", description = "조회할 유저의 Id") },
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공. 유저의 스크랩한 여행지 데이터가 반환됩니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<List<Destination>>> getScrapList(@PathVariable(name = "userId") UUID userId) {
+		return ResponseEntity.ok(
+				SuccessRes.from(
+						scrapService.getScrapList(userId)));
+	}
+
+	@PutMapping("/user/{userId}")
+	@Operation (
+			summary = "여행지 스크랩 추가",
+    		description = "특정 사용자의 스크랩 목록에 여행지를 추가합니다.",
+			tags = {"유저 여행지 스크랩(찜목록)"},
+			security = @SecurityRequirement(
+					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+					scopes = {"scope1", "scope2"}),
+			parameters = { @Parameter(name = "userId", description = "스크랩을 추가할 유저의 Id") },
+			requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "스크랩 할 여행지의 id<br/>쌍따옴표 불필요!",
+				content = { @Content(examples = @ExampleObject(value = "여행지 ID, 쌍따옴표 필요 없어요")) }),
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공. 해당 여행지가 스크랩 목록에 추가되었습니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<?>> addScrap(@PathVariable(name = "userId") UUID userId, @RequestBody String destinationId) {
+		scrapService.scrapDescription(userId, destinationId);
+		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+	}
+
+	@DeleteMapping("/user/{userId}/destination/{destId}")
+	@Operation (
+			summary = "여행지 스크랩 삭제",
+    		description = "특정 사용자의 스크랩 목록에서 여행지를 삭제합니다.",
+			tags = {"유저 여행지 스크랩(찜목록)"},
+			security = @SecurityRequirement(
+					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+					scopes = {"scope1", "scope2"}),
+			parameters = { 
+					@Parameter(name = "userId", description = "스크랩을 삭제할 유저의 Id"),
+					@Parameter(name = "destId", description = "스크랩 취소할 여행지의 Id")},
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공. 해당 여행지가 스크랩 목록에서 제거되었습니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<?>> deleteScrap(@PathVariable(name = "userId") UUID userId, @PathVariable(name = "destId") String destinationId) {
+		scrapService.unscrapDescription(userId, destinationId);
+		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/Scrap/domain/Scrap.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/Scrap/domain/Scrap.java
@@ -1,0 +1,45 @@
+package com.se.Tlog.domain.Wishlist.Scrap.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "scraps")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Scrap {
+	@Id
+	private String id;
+	
+    private UUID userId;
+	
+	private List<String> destinationIds = new ArrayList<String>();
+	
+	public void addDestination(String destinationId) {
+		if (destinationIds.contains(destinationId))
+			throw new CustomException(ErrorType.ALREADY_SCRAPED_DESTINATION);
+		destinationIds.add(destinationId);
+	}
+	
+	public void deleteDestination(String destinationId) {
+		destinationIds.remove(destinationId);
+	}
+	
+	private Scrap(UUID ownerId) {
+		this.userId = ownerId;
+	}
+	
+	public static Scrap create(UUID ownerId) {
+		return new Scrap(ownerId);
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/Scrap/repository/mongo/ScrapRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/Scrap/repository/mongo/ScrapRepository.java
@@ -1,0 +1,11 @@
+package com.se.Tlog.domain.Wishlist.Scrap.repository.mongo;
+
+import java.util.UUID;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import com.se.Tlog.domain.Wishlist.Scrap.domain.Scrap;
+
+public interface ScrapRepository extends MongoRepository<Scrap, String> {
+	Scrap findByUserId(UUID userId);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -45,11 +45,13 @@ public enum ErrorType {
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 팀입니다."),
     TEAM_USER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 팀원입니다."),
     INVALID_DESTINATION(HttpStatus.NOT_FOUND, "존재하지 않는 구독경로입니다."),
+    DESTINATION_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 여행지입니다."),
     //데이터 충돌
     ALREADY_EXISTS_TAG(HttpStatus.CONFLICT, "이미 존재하는 태그입니다."),
     ALREADY_EXISTS_DESTINATION(HttpStatus.CONFLICT, "이미 존재하는 여행지입니다."),
     ALREADY_OWN_REWARD(HttpStatus.CONFLICT, "이미 보유하고 있는 보상입니다."),
     ALREADY_EXIST_IN_TEAM(HttpStatus.CONFLICT, "이미 팀에 속해있는 유저입니다."),
+    ALREADY_SCRAPED_DESTINATION(HttpStatus.CONFLICT, "이미 스크랩 목록에 추가된 여행지입니다."),
     // 서버 에러
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. 서버 팀으로 연락주시기 바랍니다."),


### PR DESCRIPTION
## 작업 동기 및 이슈
- #71 

## 추가 및 변경사항
### 데이터 저장소
- **스크랩 데이터를 저장하는 DBMS로 MongoDB를 사용했습니다.**
  - 여행지 데이터 변동에 대한 영속성 전이 관점에서 볼 때, JPA를 사용할 만한 메리트가 낮습니다!
     -> 여행지 데이터가 이미 MongoDB에 저장되므로, 영속성 전이 기술 사용 불가
  - 여러 클라이언트가 동시에 데이터에 접근하지 않습니다!
     -> MongoDB를 활용하더라도 데이터의 변동에 크게 취약하지 않을 것으로 예상됨.

- **추후 고려사항**
  - 유저마다 여행지 스크랩 수가 매우 상이함.
    -> 기존 관계형 DB를 사용해도 큰 무리가 없을 것.
  - 현재 방식으로는 유저 탈퇴시, 영속성 전이 사용 불가.
    -> 추후 여행지 데이터 변동보다 유저 추가/삭제가 더 빈번할지 확인 후 판단 필요.

### 기능
  <img src="https://github.com/user-attachments/assets/efb3fe5b-f792-4822-b91a-c57a14afb51c" width="600"/>

#### **[기능][GET] :** 특정 유저의 스크랩 목록을 확인합니다.
  - 유저ID의 유효성을 함께 검증합니다.
   
#### **[기능][PUT] :** 특정 유저의 스크랩 목록에 여행지를 추가합니다.
  - 유저ID의 유효성을 함께 검증합니다.
  - 여행지ID의 유효성을 함께 검증합니다.
  - 이미 존재하는 여행지를 중복해서 추가하지 않습니다.
   
#### **[기능][DELETE] :** 특정 유저의 스크랩 목록에서 여행지를 제거합니다.
  - 유저ID의 유효성을 함께 검증합니다.
  - 주어진 여행지ID가 존재하면 제거하며, 그렇지 않을 경우에도 별다른 처리는 하지 않습니다.

## 테스트 결과
- 이상 무.
  - API 동작 확인
  - MongoDB 데이터 기입/삭제 과정 확인

## 📌 기타
- 유저 삭제, 여행지 삭제 상황에 따른 스크랩 데이터 처리 과정도 추후 작업 예정입니다!