### PR TITLE
Fix: 배포환경에서 Swagger UI 및 OpenApi 기능 비활성화

### DIFF
--- a/tlog-was/src/main/resources/application.yml
+++ b/tlog-was/src/main/resources/application.yml
@@ -26,6 +26,15 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+      
+# springdoc swagger
+springdoc:
+  api-docs:
+    # enable /v3/api-docs endpoint
+    enabled: true
+  swagger-ui:
+    # enable the swagger-ui
+    enabled: true
     
 ---
 
@@ -39,6 +48,15 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+      
+# springdoc swagger
+springdoc:
+  api-docs:
+    # disable /v3/api-docs endpoint
+    enabled: false
+  swagger-ui:
+    # disable swagger-ui
+    enabled: false
 
 ---
 
@@ -104,12 +122,3 @@ sso:
 
 firebase-env:
   key-path: ${FIREBASE_SERVICE_ACCOUNT_KEY_PATH}
-
-# springdoc swagger
-springdoc:
-  api-docs:
-    # false : Disabling the /v3/api-docs endpoint
-    enabled: true
-  swagger-ui:
-    # false : Disabling the swagger-ui
-    enabled: true


### PR DESCRIPTION
## 작업 동기 및 이슈
- #73 

## 추가 및 변경사항
- application.yml :
  - Swagger UI 및 Open API 기능이 dev/prod 환경에 따라 활성화/비활성화 됩니다.

## 테스트 결과
- dev 및 prod 환경에서 모두 이상 무.
  - **prod 상태에서 실행 : Swagger UI 및 Open API 비활성화** 
    ![img1](https://github.com/user-attachments/assets/ce5eec2b-c647-4548-8d66-e53500c7f059)

  - **Swagger UI 접속 : 페이지 없음 [NoResourceFoundException]** 
    ![img2](https://github.com/user-attachments/assets/b4a4a9dc-490e-4b08-901a-f593c49c79ce)

## 📌 기타
