### PR TITLE
Feature 스크랩/장바구니 기초 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ScrapService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ScrapService.java
@@ -3,20 +3,21 @@ package com.se.Tlog.domain.Wishlist.application;
 import java.util.List;
 import java.util.UUID;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
 import com.se.Tlog.domain.Wishlist.domain.OwnerType;
 import com.se.Tlog.domain.Wishlist.domain.WishlistService;
 import com.se.Tlog.domain.Wishlist.domain.WishlistType;
 import com.se.Tlog.domain.Wishlist.domain.dto.WishlistOwnerDto;
+
+import lombok.RequiredArgsConstructor;
+
 import com.se.Tlog.domain.Wishlist.domain.UpdateType;
 
 @ApplicationService
+@RequiredArgsConstructor
 public class ScrapService {
-	@Autowired
-	WishlistService wishlistService;
+	private final WishlistService wishlistService;
 	
 	public List<DestinationRes> getScrapData(UUID userId) {
 		return wishlistService.getWishlistData(

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ScrapService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ScrapService.java
@@ -1,0 +1,47 @@
+package com.se.Tlog.domain.Wishlist.application;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
+import com.se.Tlog.domain.Wishlist.domain.OwnerType;
+import com.se.Tlog.domain.Wishlist.domain.WishlistService;
+import com.se.Tlog.domain.Wishlist.domain.WishlistType;
+import com.se.Tlog.domain.Wishlist.domain.dto.WishlistOwnerDto;
+import com.se.Tlog.domain.Wishlist.domain.UpdateType;
+
+@ApplicationService
+public class ScrapService {
+	@Autowired
+	WishlistService wishlistService;
+	
+	public List<DestinationRes> getScrapData(UUID userId) {
+		return wishlistService.getWishlistData(
+				new WishlistOwnerDto(
+						OwnerType.USER,
+						userId),
+				WishlistType.SCRAP)
+				.stream().map(DestinationRes::from).toList();
+	}
+	
+	private void updateScrap(UpdateType updateType, UUID userId, String destinationId) {
+		wishlistService.updateWishlist(
+				updateType,
+				new WishlistOwnerDto(
+						OwnerType.USER,
+						userId),
+				WishlistType.SCRAP, 
+				destinationId);
+	}
+	
+	public void scrapDestination(UUID userId, String destinationId) {
+		updateScrap(UpdateType.ADD, userId, destinationId);
+	}
+	
+	public void unscrapDescription(UUID userId, String destinationId) {
+		updateScrap(UpdateType.DELETE, userId, destinationId);
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ShoppingCartService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ShoppingCartService.java
@@ -3,20 +3,21 @@ package com.se.Tlog.domain.Wishlist.application;
 import java.util.List;
 import java.util.UUID;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
 import com.se.Tlog.domain.Wishlist.domain.OwnerType;
 import com.se.Tlog.domain.Wishlist.domain.WishlistService;
 import com.se.Tlog.domain.Wishlist.domain.WishlistType;
 import com.se.Tlog.domain.Wishlist.domain.dto.WishlistOwnerDto;
+
+import lombok.RequiredArgsConstructor;
+
 import com.se.Tlog.domain.Wishlist.domain.UpdateType;
 
 @ApplicationService
+@RequiredArgsConstructor
 public class ShoppingCartService {
-	@Autowired
-	WishlistService wishlistService;
+	private final WishlistService wishlistService;
 
 	public List<DestinationRes> getCartData(UUID ownerId, OwnerType ownerType) {
 		return wishlistService.getWishlistData(

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ShoppingCartService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ShoppingCartService.java
@@ -1,0 +1,47 @@
+package com.se.Tlog.domain.Wishlist.application;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
+import com.se.Tlog.domain.Wishlist.domain.OwnerType;
+import com.se.Tlog.domain.Wishlist.domain.WishlistService;
+import com.se.Tlog.domain.Wishlist.domain.WishlistType;
+import com.se.Tlog.domain.Wishlist.domain.dto.WishlistOwnerDto;
+import com.se.Tlog.domain.Wishlist.domain.UpdateType;
+
+@ApplicationService
+public class ShoppingCartService {
+	@Autowired
+	WishlistService wishlistService;
+
+	public List<DestinationRes> getCartData(UUID ownerId, OwnerType ownerType) {
+		return wishlistService.getWishlistData(
+				new WishlistOwnerDto(
+						ownerType,
+						ownerId),
+				WishlistType.SHOPPING_CART)
+				.stream().map(DestinationRes::from).toList();
+	}
+	
+	private void updateCart(UpdateType updateType, UUID ownerId, OwnerType ownerType, String destinationId) {
+		wishlistService.updateWishlist(
+				updateType,
+				new WishlistOwnerDto(
+						ownerType,
+						ownerId),
+				WishlistType.SHOPPING_CART, 
+				destinationId);
+	}
+	
+	public void addToCart(UUID ownerId, OwnerType ownerType, String destinationId) {
+		updateCart(UpdateType.ADD, ownerId, ownerType, destinationId);
+	}
+	
+	public void deleteFromCart(UUID ownerId, OwnerType ownerType, String destinationId) {
+		updateCart(UpdateType.DELETE, ownerId, ownerType, destinationId);
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ScrapController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ScrapController.java
@@ -1,0 +1,91 @@
+package com.se.Tlog.domain.Wishlist.contoller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
+import com.se.Tlog.domain.Wishlist.application.ScrapService;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/api/scrap")
+@RequiredArgsConstructor
+@Tag(name = "여행지 스크랩(찜목록)")
+@SecurityRequirement(
+		name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+		scopes = {"scope1", "scope2"})
+public class ScrapController {
+	@Autowired
+	private ScrapService scrapService;
+	
+	@GetMapping("/user/{userId}")
+	@Operation (
+			summary = "스크랩 된 여행지 조회",
+    		description = "특정 사용자의 스크랩 목록을 조회합니다.",
+			parameters = { @Parameter(name = "userId", description = "조회할 유저의 Id") },
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공. 유저의 스크랩한 여행지 데이터가 반환됩니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<List<DestinationRes>>> getScrapList(@PathVariable(name = "userId") UUID userId) {
+		return ResponseEntity.ok(SuccessRes.from(
+				scrapService.getScrapData(userId)));
+	}
+
+	@PutMapping("/user/{userId}")
+	@Operation (
+			summary = "여행지 스크랩 추가",
+    		description = "특정 사용자의 스크랩 목록에 여행지를 추가합니다.",
+			parameters = { @Parameter(name = "userId", description = "스크랩을 추가할 유저의 Id") },
+			requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "스크랩 할 여행지의 id<br/>쌍따옴표 불필요!",
+				content = { @Content(examples = @ExampleObject(value = "여행지 ID, 쌍따옴표 필요 없어요")) }),
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공. 해당 여행지가 스크랩 목록에 추가되었습니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<?>> addScrap(@PathVariable(name = "userId") UUID userId, @RequestBody String destinationId) {
+		scrapService.scrapDestination(userId, destinationId);
+		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+	}
+
+	@DeleteMapping("/user/{userId}/destination/{destId}")
+	@Operation (
+			summary = "여행지 스크랩 삭제",
+    		description = "특정 사용자의 스크랩 목록에서 여행지를 삭제합니다.",
+			parameters = { 
+					@Parameter(name = "userId", description = "스크랩을 삭제할 유저의 Id"),
+					@Parameter(name = "destId", description = "스크랩 취소할 여행지의 Id")},
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공. 해당 여행지가 스크랩 목록에서 제거되었습니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<?>> deleteScrap(@PathVariable(name = "userId") UUID userId, @PathVariable(name = "destId") String destinationId) {
+		scrapService.unscrapDescription(userId, destinationId);
+		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ScrapController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ScrapController.java
@@ -3,7 +3,6 @@ package com.se.Tlog.domain.Wishlist.contoller;
 import java.util.List;
 import java.util.UUID;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -37,8 +36,7 @@ import lombok.RequiredArgsConstructor;
 		name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
 		scopes = {"scope1", "scope2"})
 public class ScrapController {
-	@Autowired
-	private ScrapService scrapService;
+	private final ScrapService scrapService;
 	
 	@GetMapping("/user/{userId}")
 	@Operation (

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ShoppingCartController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ShoppingCartController.java
@@ -3,7 +3,6 @@ package com.se.Tlog.domain.Wishlist.contoller;
 import java.util.List;
 import java.util.UUID;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -38,8 +37,7 @@ import lombok.RequiredArgsConstructor;
 		name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
 		scopes = {"scope1", "scope2"} )
 public class ShoppingCartController {
-	@Autowired
-	private ShoppingCartService shoppingCartService;
+	private final ShoppingCartService shoppingCartService;
 	
 	@GetMapping("/user/{userId}")
 	@Operation (

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ShoppingCartController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ShoppingCartController.java
@@ -1,0 +1,143 @@
+package com.se.Tlog.domain.Wishlist.contoller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
+import com.se.Tlog.domain.Wishlist.application.ShoppingCartService;
+import com.se.Tlog.domain.Wishlist.domain.OwnerType;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/api/shopcart")
+@RequiredArgsConstructor
+@Tag(name = "여행지 장바구니(필수 포함 여행지)")
+@SecurityRequirement(
+		name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+		scopes = {"scope1", "scope2"} )
+public class ShoppingCartController {
+	@Autowired
+	private ShoppingCartService shoppingCartService;
+	
+	@GetMapping("/user/{userId}")
+	@Operation (
+			summary = "유저 장바구니 조회",
+    		description = "특정 유저의 장바구니를 조회합니다.",
+			parameters = { @Parameter(name = "userId", description = "조회할 유저의 Id") },
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공. 유저의 장바구니 데이터가 반환됩니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<List<DestinationRes>>> getCartOfUser(@PathVariable(name = "userId") UUID userId) {
+		return ResponseEntity.ok(SuccessRes.from(
+				shoppingCartService.getCartData(userId, OwnerType.USER)));
+	}
+	
+	@PutMapping("/user/{userId}")
+	@Operation (
+			summary = "유저 장바구니에 여행지 추가",
+    		description = "특정 사용자의 장바구니에 여행지를 추가합니다.",
+			parameters = { @Parameter(name = "userId", description = "여행지를 장바구니에 추가할 유저의 Id") },
+			requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "추가할 여행지의 id<br/>쌍따옴표 불필요!",
+				content = { @Content(examples = @ExampleObject(value = "여행지 ID, 쌍따옴표 필요 없어요")) }),
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공. 해당 여행지가 장바구니에 추가되었습니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<?>> addToCartOfUser(@PathVariable(name = "userId") UUID userId, @RequestBody String destinationId) {
+		shoppingCartService.addToCart(userId, OwnerType.USER, destinationId);
+		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+	}
+	
+	@DeleteMapping("/user/{userId}/destination/{destId}")
+	@Operation (
+			summary = "유저 장바구니에서 여행지 삭제",
+    		description = "특정 사용자의 장바구니에서 여행지를 삭제합니다.",
+			parameters = { 
+					@Parameter(name = "userId", description = "장바구니에서 여행지를 삭제할 유저의 Id"),
+					@Parameter(name = "destId", description = "장바구니에서 삭제할 여행지의 Id")},
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공. 해당 여행지가 장바구니에서 제거되었습니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<?>> deleteFromCartOfUser(@PathVariable(name = "userId") UUID userId, @PathVariable(name = "destId") String destinationId) {
+		shoppingCartService.deleteFromCart(userId, OwnerType.USER, destinationId);
+		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+	}
+	
+	
+
+	@GetMapping("/team/{teamId}")
+	@Operation (
+			summary = "팀 장바구니 조회",
+    		description = "특정 팀의 장바구니를 조회합니다.",
+			parameters = { @Parameter(name = "teamId", description = "조회할 팀의 Id") },
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공. 팀의 장바구니 데이터가 반환됩니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<List<DestinationRes>>> getCartOfTeam(@PathVariable(name = "teamId") UUID teamId) {
+		return ResponseEntity.ok(SuccessRes.from(
+				shoppingCartService.getCartData(teamId, OwnerType.TEAM)));
+	}
+	
+	@PutMapping("/team/{teamId}")
+	@Operation (
+			summary = "팀 장바구니에 여행지 추가",
+    		description = "특정 팀의 장바구니에 여행지를 추가합니다.",
+			parameters = { @Parameter(name = "teamId", description = "여행지를 장바구니에 추가할 팀의 Id") },
+			requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "추가할 여행지의 id<br/>쌍따옴표 불필요!",
+				content = { @Content(examples = @ExampleObject(value = "여행지 ID, 쌍따옴표 필요 없어요")) }),
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공. 해당 여행지가 장바구니에 추가되었습니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<?>> addCartOfTeam(@PathVariable(name = "teamId") UUID teamId, @RequestBody String destinationId) {
+		shoppingCartService.addToCart(teamId, OwnerType.TEAM, destinationId);
+		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+	}
+	
+	@DeleteMapping("/team/{teamId}/destination/{destId}")
+	@Operation (
+			summary = "팀 장바구니에서 여행지 삭제",
+    		description = "특정 팀의 장바구니에서 여행지를 삭제합니다.",
+			parameters = { 
+					@Parameter(name = "teamId", description = "장바구니에서 여행지를 삭제할 팀의 Id"),
+					@Parameter(name = "destId", description = "장바구니에서 삭제할 여행지의 Id")},
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공. 해당 여행지가 장바구니에서 제거되었습니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<?>> deleteFromCartOfTeam(@PathVariable(name = "teamId") UUID teamId, @PathVariable(name = "destId") String destinationId) {
+		shoppingCartService.deleteFromCart(teamId, OwnerType.TEAM, destinationId);
+		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/OwnerType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/OwnerType.java
@@ -1,0 +1,6 @@
+package com.se.Tlog.domain.Wishlist.domain;
+
+public enum OwnerType {
+	USER,
+	TEAM
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/UpdateType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/UpdateType.java
@@ -1,0 +1,6 @@
+package com.se.Tlog.domain.Wishlist.domain;
+
+public enum UpdateType {
+	ADD,
+	DELETE
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/Wishlist.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/Wishlist.java
@@ -1,0 +1,83 @@
+package com.se.Tlog.domain.Wishlist.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
+@Document(collection = "wishlists")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Wishlist {
+	@Id
+	private String id;
+	
+	private UUID ownerId;
+	private OwnerType ownerType;
+	
+	private List<String> scrapList = new ArrayList<String>();
+	private List<String> shoppingCart = new ArrayList<String>();
+
+	private Wishlist(OwnerType ownerType, UUID ownerId) {
+		this.ownerType = ownerType;
+		this.ownerId = ownerId;
+	}
+	
+	public static Wishlist create(OwnerType ownerType, UUID ownerId) {
+		return new Wishlist(ownerType, ownerId);
+	}
+	
+	public List<String> getWishlistItems(WishlistType listType) {
+		switch (listType) {
+		case SCRAP:
+			return new ArrayList<String>(scrapList);
+		case SHOPPING_CART:
+			return new ArrayList<String>(shoppingCart);
+		default:
+			log.error("장바구니 타입" + listType.toString() +"에 대한 처리가 구현되지 않았습니다!");
+			return new ArrayList<String>();
+		}
+	}
+
+	public void addDestination(String destinationId, WishlistType listType) {
+		switch (listType) {
+		case SCRAP:
+			if (!scrapList.contains(destinationId))
+				scrapList.add(destinationId);
+			return;
+		case SHOPPING_CART:
+			if (!shoppingCart.contains(destinationId))
+				shoppingCart.add(destinationId);
+			return;
+		default:
+			log.error("장바구니 타입" + listType.toString() +"에 대한 처리가 구현되지 않았습니다!");
+		}
+	}
+	
+	public void deleteDestination(String destinationId, WishlistType listType) {
+		switch (listType) {
+		case SCRAP:
+			if (!scrapList.contains(destinationId))
+				throw new CustomException(ErrorType.SCRAP_NOT_FOUND);
+			scrapList.remove(destinationId);
+			return;
+		case SHOPPING_CART:
+			if (!shoppingCart.contains(destinationId))
+				throw new CustomException(ErrorType.SHOPCART_NOT_FOUND);
+			shoppingCart.remove(destinationId);
+			return;
+		default:
+			log.error("장바구니 타입" + listType.toString() +"에 대한 처리가 구현되지 않았습니다!");
+		}
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistService.java
@@ -2,6 +2,7 @@ package com.se.Tlog.domain.Wishlist.domain;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
@@ -53,11 +54,11 @@ public class WishlistService {
 	public List<Destination> getWishlistData(WishlistOwnerDto ownerDto, WishlistType wishlistType) {
 		validateOwner(ownerDto, wishlistType);
 		
-		Wishlist wishlist = wishlistRepository.
+		Optional<Wishlist> wishlist = wishlistRepository.
 				findByOwnerIdAndOwnerType(ownerDto.ownerId(), ownerDto.ownerType());
 		
-		if (wishlist != null)
-			return destinationRepository.findAllById(wishlist.getWishlistItems(wishlistType));
+		if (wishlist.isPresent())
+			return destinationRepository.findAllById(wishlist.get().getWishlistItems(wishlistType));
 		else
 			return new ArrayList<Destination>();
 	}
@@ -80,9 +81,8 @@ public class WishlistService {
 			throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);
 
 		Wishlist wishlist = wishlistRepository.
-				findByOwnerIdAndOwnerType(ownerDto.ownerId(), ownerDto.ownerType());
-		if (wishlist == null)
-			wishlist = Wishlist.create(ownerDto.ownerType(), ownerDto.ownerId());
+				findByOwnerIdAndOwnerType(ownerDto.ownerId(), ownerDto.ownerType())
+				.orElseGet(() -> Wishlist.create(ownerDto.ownerType(), ownerDto.ownerId()));
 		
 		if (UpdateType.ADD == updateType)
 			wishlist.addDestination(destinationId, wishlistType);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistService.java
@@ -3,7 +3,6 @@ package com.se.Tlog.domain.Wishlist.domain;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.se.Tlog.domain.Team.repository.jpa.TeamRepository;
@@ -15,20 +14,18 @@ import com.se.Tlog.domain.Wishlist.repository.mongo.WishlistRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 
 @Component
+@RequiredArgsConstructor
 public class WishlistService {
-	@Autowired
-	private WishlistRepository wishlistRepository;
-	@Autowired
-	private UserRepository userRepository;
-	@Autowired
-	private TeamRepository teamRepository;
-	@Autowired
-	private DestinationRepository destinationRepository;
+	private final WishlistRepository wishlistRepository;
+	private final UserRepository userRepository;
+	private final TeamRepository teamRepository;
+	private final DestinationRepository destinationRepository;
 	
 	private void validateOwner(WishlistOwnerDto ownerDto, WishlistType listType) {
 		if (OwnerType.USER == ownerDto.ownerType()) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistService.java
@@ -1,0 +1,96 @@
+package com.se.Tlog.domain.Wishlist.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.se.Tlog.domain.Team.repository.jpa.TeamRepository;
+import com.se.Tlog.domain.Travel.domain.Destination;
+import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
+import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.domain.Wishlist.domain.dto.WishlistOwnerDto;
+import com.se.Tlog.domain.Wishlist.repository.mongo.WishlistRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
+@Component
+public class WishlistService {
+	@Autowired
+	private WishlistRepository wishlistRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private TeamRepository teamRepository;
+	@Autowired
+	private DestinationRepository destinationRepository;
+	
+	private void validateOwner(WishlistOwnerDto ownerDto, WishlistType listType) {
+		if (OwnerType.USER == ownerDto.ownerType()) {
+			if (!userRepository.existsById(ownerDto.ownerId()))
+				throw new CustomException(ErrorType.USER_NOT_FOUND);
+		}
+		else if (OwnerType.TEAM == ownerDto.ownerType()) {
+			if (!teamRepository.existsById(ownerDto.ownerId()))
+				throw new CustomException(ErrorType.TEAM_NOT_FOUND);
+			if (WishlistType.SCRAP == listType)
+				throw new CustomException(ErrorType.SCRAP_UNSUPPORTED_TO_TEAM);
+		}
+		else {
+			log.error("장바구니 주인 타입" + ownerDto.ownerType().toString() +"에 대한 처리가 구현되지 않았습니다!");
+			throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
+		}
+	}
+	
+	/**
+	 * 위시리스트(스크랩/장바구니 등) 항목을 반환합니다.
+	 * @param ownerDto
+	 * @param wishlistType
+	 * @return
+	 */
+	public List<Destination> getWishlistData(WishlistOwnerDto ownerDto, WishlistType wishlistType) {
+		validateOwner(ownerDto, wishlistType);
+		
+		Wishlist wishlist = wishlistRepository.
+				findByOwnerIdAndOwnerType(ownerDto.ownerId(), ownerDto.ownerType());
+		
+		if (wishlist != null)
+			return destinationRepository.findAllById(wishlist.getWishlistItems(wishlistType));
+		else
+			return new ArrayList<Destination>();
+	}
+	
+	/**
+	 * 각종 위시리스트(스크랩/장바구니 등)의 여행지를 추가/제거합니다.
+	 * @param updateType
+	 * @param ownerDto
+	 * @param wishlistType
+	 * @param destinationId
+	 */
+	public void updateWishlist(
+			UpdateType updateType,
+			WishlistOwnerDto ownerDto, 
+			WishlistType wishlistType, 
+			String destinationId) {
+		validateOwner(ownerDto, wishlistType);
+		if (UpdateType.ADD == updateType &&
+				!destinationRepository.existsById(destinationId))
+			throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);
+
+		Wishlist wishlist = wishlistRepository.
+				findByOwnerIdAndOwnerType(ownerDto.ownerId(), ownerDto.ownerType());
+		if (wishlist == null)
+			wishlist = Wishlist.create(ownerDto.ownerType(), ownerDto.ownerId());
+		
+		if (UpdateType.ADD == updateType)
+			wishlist.addDestination(destinationId, wishlistType);
+		if (UpdateType.DELETE == updateType)
+			wishlist.deleteDestination(destinationId, wishlistType);
+		wishlistRepository.save(wishlist);
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistService.java
@@ -33,11 +33,13 @@ public class WishlistService {
 		case USER:
 			if (!userRepository.existsById(ownerDto.ownerId()))
 				throw new CustomException(ErrorType.USER_NOT_FOUND);
+			return;
 		case TEAM:
 			if (!teamRepository.existsById(ownerDto.ownerId()))
 				throw new CustomException(ErrorType.TEAM_NOT_FOUND);
 			if (WishlistType.SCRAP == listType)
 				throw new CustomException(ErrorType.SCRAP_UNSUPPORTED_TO_TEAM);
+			return;
 		default:
 			log.error("장바구니 주인 타입" + ownerDto.ownerType().toString() +"에 대한 처리가 구현되지 않았습니다!");
 			throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistService.java
@@ -29,17 +29,16 @@ public class WishlistService {
 	private final DestinationRepository destinationRepository;
 	
 	private void validateOwner(WishlistOwnerDto ownerDto, WishlistType listType) {
-		if (OwnerType.USER == ownerDto.ownerType()) {
+		switch (ownerDto.ownerType()) {
+		case USER:
 			if (!userRepository.existsById(ownerDto.ownerId()))
 				throw new CustomException(ErrorType.USER_NOT_FOUND);
-		}
-		else if (OwnerType.TEAM == ownerDto.ownerType()) {
+		case TEAM:
 			if (!teamRepository.existsById(ownerDto.ownerId()))
 				throw new CustomException(ErrorType.TEAM_NOT_FOUND);
 			if (WishlistType.SCRAP == listType)
 				throw new CustomException(ErrorType.SCRAP_UNSUPPORTED_TO_TEAM);
-		}
-		else {
+		default:
 			log.error("장바구니 주인 타입" + ownerDto.ownerType().toString() +"에 대한 처리가 구현되지 않았습니다!");
 			throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
 		}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistType.java
@@ -1,0 +1,6 @@
+package com.se.Tlog.domain.Wishlist.domain;
+
+public enum WishlistType {
+	SCRAP,
+	SHOPPING_CART
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/dto/WishlistOwnerDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/dto/WishlistOwnerDto.java
@@ -1,0 +1,11 @@
+package com.se.Tlog.domain.Wishlist.domain.dto;
+
+import java.util.UUID;
+
+import com.se.Tlog.domain.Wishlist.domain.OwnerType;
+
+public record WishlistOwnerDto(
+		OwnerType ownerType,
+		UUID ownerId) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/repository/mongo/WishlistRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/repository/mongo/WishlistRepository.java
@@ -1,0 +1,12 @@
+package com.se.Tlog.domain.Wishlist.repository.mongo;
+
+import java.util.UUID;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import com.se.Tlog.domain.Wishlist.domain.Wishlist;
+import com.se.Tlog.domain.Wishlist.domain.OwnerType;
+
+public interface WishlistRepository extends MongoRepository<Wishlist, String> {
+	Wishlist findByOwnerIdAndOwnerType(UUID ownerId, OwnerType ownerType);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/repository/mongo/WishlistRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/repository/mongo/WishlistRepository.java
@@ -1,5 +1,6 @@
 package com.se.Tlog.domain.Wishlist.repository.mongo;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -8,5 +9,5 @@ import com.se.Tlog.domain.Wishlist.domain.Wishlist;
 import com.se.Tlog.domain.Wishlist.domain.OwnerType;
 
 public interface WishlistRepository extends MongoRepository<Wishlist, String> {
-	Wishlist findByOwnerIdAndOwnerType(UUID ownerId, OwnerType ownerType);
+	Optional<Wishlist> findByOwnerIdAndOwnerType(UUID ownerId, OwnerType ownerType);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -14,6 +14,7 @@ public enum ErrorType {
     TEAM_CANNOT_BE_ORPHAN(HttpStatus.BAD_REQUEST, "팀에 최소 1명 이상의 팀원이 필요합니다."),
     ROLE_MISMATCH(HttpStatus.BAD_REQUEST,"Role 값을 잘못 입력하였습니다."),
     INVALID_FIREBASE_TOKEN(HttpStatus.BAD_REQUEST,"클라이언트 FCM Token이 유효하지 않습니다!"),
+    SCRAP_UNSUPPORTED_TO_TEAM(HttpStatus.BAD_REQUEST, "팀에는 스크랩 기능을 지원하지 않습니다!"),
     
     // 사용자로부터 소셜 로그인 인증 실패
     SSO_LOGIN_FAIL(HttpStatus.BAD_REQUEST,"외부 소셜 로그인이 취소되거나 실패했습니다."),
@@ -45,6 +46,9 @@ public enum ErrorType {
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 팀입니다."),
     TEAM_USER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 팀원입니다."),
     INVALID_DESTINATION(HttpStatus.NOT_FOUND, "존재하지 않는 구독경로입니다."),
+    DESTINATION_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 여행지입니다."),
+    SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 여행지가 스크랩 목록에 없습니다."),
+    SHOPCART_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 여행지가 장바구니에 없습니다."),
     //데이터 충돌
     ALREADY_EXISTS_TAG(HttpStatus.CONFLICT, "이미 존재하는 태그입니다."),
     ALREADY_EXISTS_DESTINATION(HttpStatus.CONFLICT, "이미 존재하는 여행지입니다."),


### PR DESCRIPTION
## 작업 동기 및 이슈
- #71 

## 추가 및 변경사항
### 데이터 저장소
- **스크랩/장바구니 데이터를 저장하는 DBMS로 MongoDB를 사용했습니다.**
  - 여행지 데이터 변동 관점에서 볼 때, JPA 사용에 대한 뚜렷한 장점이 없습니다.
     -> 여행지 데이터가 이미 MongoDB에 저장되므로, 영속성 전이 기술 사용이 어려움
  - 한 Wishlist 엔티티로 스크랩, 장바구니를 함께 관리하기 용이합니다.
     -> 소유자가 동일한데 스크랩/장바구니 테이블을 나누어 관리하는 것보다 코드 응집력이 훨씬 좋다고 판단

- **추후 고려사항**
  - 현재 방식으로는 유저 탈퇴, 팀 삭제 등의 상황에 영속성 전이 사용 불가.
    -> 추후 여행지 데이터 변동과 유저/팀 추가/삭제 사이의 빈도 등등 다양한 관점에서 문제 확인 후 판단 필요.

### 기능
#### **[기능][GET] :** 특정 유저나 팀의 스크랩/장바구니 목록을 확인합니다.
  - 목록 소유자 ID의 유효성을 함께 검사합니다.
   
#### **[기능][PUT] :** 특정 유저나 팀의 스크랩/장바구니 목록에 여행지를 추가합니다.
  - 목록 소유자 ID의 유효성을 함께 검사합니다.
  - 여행지ID의 유효성을 함께 검사합니다.
  - 이미 존재하는 여행지는 중복해서 추가하지 않습니다.
   
#### **[기능][DELETE] :** 특정 유저나 팀의 스크랩/장바구니 목록에서 여행지를 제거합니다.
  - 목록 소유자 ID의 유효성을 함께 검증합니다.
  - 주어진 여행지ID가 존재하면 제거하며, 그렇지 않다면 404[NotFound] 에러를 반환합니다.

#### 제공 API 정리 :

  <img src="https://github.com/user-attachments/assets/16ff25b3-903e-4167-a4e9-6e52e2f73183" width="600"/>

## 테스트 결과
- 이상 무.
  - API 동작 확인
  - MongoDB 데이터 추가/삭제 과정 확인

## 📌 기타
- 유저/팀 삭제, 여행지 삭제 상황에 따른 목록 업데이트 과정도 추후 작업 예정입니다!