### PR TITLE
Test: JwtTest - 테스트 환경에서 커스텀 Bean 사용 방법 개선 #77

### DIFF
--- a/tlog-was/src/test/java/com/se/Tlog/jwt/JwtTest.java
+++ b/tlog-was/src/test/java/com/se/Tlog/jwt/JwtTest.java
@@ -6,12 +6,16 @@ import com.se.Tlog.global.util.jwt.JwtUtil;
 import com.se.Tlog.global.util.jwt.RefreshTokenProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
 
+@SpringBootTest
 public class JwtTest {
 
-    private JwtUtil jwtUtil;
+    @Autowired
     private AccessTokenProvider accessTokenProvider;
+    @Autowired
     private RefreshTokenProvider refreshTokenProvider;
 
 

--- a/tlog-was/src/test/java/com/se/Tlog/jwt/JwtTest.java
+++ b/tlog-was/src/test/java/com/se/Tlog/jwt/JwtTest.java
@@ -4,10 +4,11 @@ import com.se.Tlog.domain.User.domain.Role;
 import com.se.Tlog.global.util.jwt.AccessTokenProvider;
 import com.se.Tlog.global.util.jwt.JwtUtil;
 import com.se.Tlog.global.util.jwt.RefreshTokenProvider;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 
 
 @SpringBootTest
@@ -18,16 +19,18 @@ public class JwtTest {
     @Autowired
     private RefreshTokenProvider refreshTokenProvider;
 
-
-    @BeforeEach
-    void setup() {
-        String secretKey = "GjCU1g8/AbJhSzj4McaCKa7Amu+Fz1N4w8jJfZanEIk="; // 테스트용 키
-
-        jwtUtil = new JwtUtil(
-                secretKey,
-                "issuer"
-        );
-    }
+	@TestConfiguration
+	static class JwtTestConfig {
+		private static String secretKey = "GjCU1g8/AbJhSzj4McaCKa7Amu+Fz1N4w8jJfZanEIk="; // 테스트용 키
+		
+		@Bean
+		public static JwtUtil jwtUtil() {
+			return new JwtUtil(
+	                secretKey,
+	                "issuer"
+	        );
+		}
+	}
 
     @Test
     void generateTokenTest(){


### PR DESCRIPTION
## 작업 동기 및 이슈
- #77 

## 추가 및 변경사항
### JwtTest에서 별도의 Bean을 사용하는 방법 개선
  - 특정 테스트 환경에서, 기존 등록된 Spring Bean을 덮어쓰기 가능
    - 테스트 클래스 내부에 `@TestConfiguration` 어노테이션이 등록된 Nested Class를 포함하여,
      해당 테스트 클래스에서만 적용되는 Bean을 등록 가능

### JwtTest에 등록된 Spring Bean이 주입되지 않는 문제 수정
 - `@SpringBootTest` 및 `@Autowired` 도입하여 수정
  (Test 환경에서는 Autowired 방식의 의존성 주입만 지원하는 문제)

## 테스트 결과
- 덮어쓴 Bean이 해당 테스트 내에서만 적용되는 것 확인.
  - Bean 설정 환경 : 
    - 기존 JwtUtil의 Issuer : 'tlog'
    - 커스텀 JwtUtil의 Issuer : 'issuer'
  - 기존 Bean을 사용하는 타 테스트 클래스
  ![image](https://github.com/user-attachments/assets/c68a68b3-48a5-4468-ac8a-bd28caa5036d)
  ![image](https://github.com/user-attachments/assets/74a0e58d-d96a-4445-86df-9b9d68f7cda6)
  - 커스텀 Bean을 사용하는 JwtTest 클래스
  ![image](https://github.com/user-attachments/assets/04c48765-f6b4-4f0f-924c-a523c936617b)

- 전체 테스트 통과.

## 📌 기타
