### PR TITLE
Feature: Wishlist의 소유자 삭제시 함께 삭제되는 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/TeamDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/TeamDomainService.java
@@ -4,6 +4,9 @@ import org.springframework.stereotype.Service;
 
 import com.se.Tlog.domain.Team.domain.repository.TeamRepositoryService;
 import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.domain.Wishlist.domain.OwnerType;
+import com.se.Tlog.domain.Wishlist.domain.WishlistService;
+import com.se.Tlog.domain.Wishlist.domain.dto.WishlistOwnerDto;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 
@@ -16,9 +19,11 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class TeamDomainService {
 	private final TeamRepositoryService repoService;
+	private final WishlistService wishlistService;
 	
 	public void deleteTeamData(Team team) {
 		// 팀 삭제시 각종 처리...
+		wishlistService.deleteWishlist(new WishlistOwnerDto(OwnerType.TEAM, team.getId()));
 		
 		repoService.deleteTeamUsers(team.getId());
 	}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/service/UserDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/service/UserDomainService.java
@@ -3,6 +3,9 @@ package com.se.Tlog.domain.User.domain.service;
 
 import com.se.Tlog.domain.User.controller.dto.UserSummaryDto;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.domain.Wishlist.domain.OwnerType;
+import com.se.Tlog.domain.Wishlist.domain.WishlistService;
+import com.se.Tlog.domain.Wishlist.domain.dto.WishlistOwnerDto;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -15,11 +18,21 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class UserDomainService {
     private final UserRepository userRepository;
+    private final WishlistService wishlistService;
 
     public List<UserSummaryDto> getUserByIds(List<UUID> uuidList) {
         return userRepository.findAllById(uuidList).stream()
                 .map(UserSummaryDto::from)
                 .toList();
+    }
+    
+    public void deleteUserAccount(UUID userId) {
+    	validateExists(userId);
+    	
+    	// 각종 유저 계정 삭제 처리
+    	wishlistService.deleteWishlist(new WishlistOwnerDto(OwnerType.USER, userId));
+    	
+    	userRepository.deleteById(userId);
     }
 
     public void validateExists(UUID userId) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistService.java
@@ -6,14 +6,10 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
-import com.se.Tlog.domain.Team.repository.jpa.TeamRepository;
 import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
-import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.domain.Wishlist.domain.dto.WishlistOwnerDto;
 import com.se.Tlog.domain.Wishlist.repository.mongo.WishlistRepository;
-import com.se.Tlog.global.exception.CustomException;
-import com.se.Tlog.global.response.error.ErrorType;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,27 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class WishlistService {
 	private final WishlistRepository wishlistRepository;
-	private final UserRepository userRepository;
-	private final TeamRepository teamRepository;
 	private final DestinationRepository destinationRepository;
-	
-	private void validateOwner(WishlistOwnerDto ownerDto, WishlistType listType) {
-		switch (ownerDto.ownerType()) {
-		case USER:
-			if (!userRepository.existsById(ownerDto.ownerId()))
-				throw new CustomException(ErrorType.USER_NOT_FOUND);
-			return;
-		case TEAM:
-			if (!teamRepository.existsById(ownerDto.ownerId()))
-				throw new CustomException(ErrorType.TEAM_NOT_FOUND);
-			if (WishlistType.SCRAP == listType)
-				throw new CustomException(ErrorType.SCRAP_UNSUPPORTED_TO_TEAM);
-			return;
-		default:
-			log.error("장바구니 주인 타입" + ownerDto.ownerType().toString() +"에 대한 처리가 구현되지 않았습니다!");
-			throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
-		}
-	}
+	private final WishlistServiceValidator serviceValidator;
 	
 	/**
 	 * 위시리스트(스크랩/장바구니 등) 항목을 반환합니다.
@@ -53,11 +30,11 @@ public class WishlistService {
 	 * @return
 	 */
 	public List<Destination> getWishlistData(WishlistOwnerDto ownerDto, WishlistType wishlistType) {
-		validateOwner(ownerDto, wishlistType);
+		serviceValidator.validateOwner(ownerDto);
+		serviceValidator.validateWishlistType(ownerDto.ownerType(), wishlistType);
 		
 		Optional<Wishlist> wishlist = wishlistRepository.
 				findByOwnerIdAndOwnerType(ownerDto.ownerId(), ownerDto.ownerType());
-		
 		if (wishlist.isPresent())
 			return destinationRepository.findAllById(wishlist.get().getWishlistItems(wishlistType));
 		else
@@ -76,10 +53,10 @@ public class WishlistService {
 			WishlistOwnerDto ownerDto, 
 			WishlistType wishlistType, 
 			String destinationId) {
-		validateOwner(ownerDto, wishlistType);
-		if (UpdateType.ADD == updateType &&
-				!destinationRepository.existsById(destinationId))
-			throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);
+		serviceValidator.validateOwner(ownerDto);
+		serviceValidator.validateWishlistType(ownerDto.ownerType(), wishlistType);
+		if (UpdateType.ADD == updateType)
+			serviceValidator.validateDestination(destinationId);
 
 		Wishlist wishlist = wishlistRepository.
 				findByOwnerIdAndOwnerType(ownerDto.ownerId(), ownerDto.ownerType())

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistService.java
@@ -68,4 +68,12 @@ public class WishlistService {
 			wishlist.deleteDestination(destinationId, wishlistType);
 		wishlistRepository.save(wishlist);
 	}
+	
+	/**
+	 * 위시리스트를 제거합니다.
+	 * @param ownerDto
+	 */
+	public void deleteWishlist(WishlistOwnerDto ownerDto) {
+		wishlistRepository.deleteByOwnerIdAndOwnerType(ownerDto.ownerId(), ownerDto.ownerType());
+	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistServiceValidator.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/WishlistServiceValidator.java
@@ -1,0 +1,50 @@
+package com.se.Tlog.domain.Wishlist.domain;
+
+import org.springframework.stereotype.Component;
+
+import com.se.Tlog.domain.Team.repository.jpa.TeamRepository;
+import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
+import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.domain.Wishlist.domain.dto.WishlistOwnerDto;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
+@Component
+@RequiredArgsConstructor
+public class WishlistServiceValidator {
+	private final UserRepository userRepository;
+	private final TeamRepository teamRepository;
+	private final DestinationRepository destinationRepository;
+
+	public void validateOwner(WishlistOwnerDto ownerDto) {
+		switch (ownerDto.ownerType()) {
+		case USER:
+			if (!userRepository.existsById(ownerDto.ownerId()))
+				throw new CustomException(ErrorType.USER_NOT_FOUND);
+			return;
+		case TEAM:
+			if (!teamRepository.existsById(ownerDto.ownerId()))
+				throw new CustomException(ErrorType.TEAM_NOT_FOUND);
+			return;
+		default:
+			log.error("장바구니 주인 타입" + ownerDto.ownerType().toString() +"에 대한 처리가 구현되지 않았습니다!");
+			throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
+		}
+	}
+	
+	public void validateWishlistType(OwnerType ownerType, WishlistType listType) {
+		if (OwnerType.TEAM == ownerType
+			&& WishlistType.SCRAP == listType)
+			throw new CustomException(ErrorType.SCRAP_UNSUPPORTED_TO_TEAM);
+	}
+	
+	public void validateDestination(String destinationId) {
+		if (!destinationRepository.existsById(destinationId))
+			throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/repository/mongo/WishlistRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/repository/mongo/WishlistRepository.java
@@ -10,4 +10,5 @@ import com.se.Tlog.domain.Wishlist.domain.OwnerType;
 
 public interface WishlistRepository extends MongoRepository<Wishlist, String> {
 	Optional<Wishlist> findByOwnerIdAndOwnerType(UUID ownerId, OwnerType ownerType);
+	int deleteByOwnerIdAndOwnerType(UUID ownerId, OwnerType ownerType);
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #79 
- 현재는 소유자가 삭제되어도 Wishlist가 함께 삭제되는 등의 관리가 이루어지지 않고 있습니다.

## 추가 및 변경사항
### 1. Wishlist 도메인 내에서 삭제 기능 추가
  - **[리팩토링]**
  이 과정에서 WishlistService 내 Validator 기능이 복잡하게 얽혀있어,
  별도의 클래스로 역할이 분리되었습니다.
### 2. Team 삭제 로직 내에 Wishlist 삭제 흐름 포함
### 3. User 계정 삭제 로직 내에 Wishlist 삭제 흐름 포함
  - **[참고사항]**
  현재는 별도의 User 계정 삭제 기능이 없으므로,
  UserDomainService 내에 임시로 deleteUserAccount() 기능을 추가했습니다!!

## 테스트 결과
- 이상 무.
- 팀 소유자 삭제 예시
  - 팀 생성 후 장바구니 등록
     <img src="https://github.com/user-attachments/assets/b01f7941-3f63-4ccc-a485-3f45b6e1185c" width="400">
  - 팀 삭제 API 요청
     <img src="https://github.com/user-attachments/assets/599a24ed-4af9-4cba-a34c-cfcc93c2b503" height="300">
  - Wishlist 삭제 쿼리가 함께 호출됨
     <img src="https://github.com/user-attachments/assets/bbdd920a-6705-4753-96a7-e8121dee17e6" width="600">

## 📌 기타
