### PR TITLE
Feature: 적용안된 API Swagger 문서화 적용

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/TlogApplication.java
+++ b/tlog-was/src/main/java/com/se/Tlog/TlogApplication.java
@@ -1,6 +1,6 @@
 package com.se.Tlog;
 
-import com.se.Tlog.config.RabbitMqChatProperties;
+import com.se.Tlog.config.rabbitmq.RabbitMqChatProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;

--- a/tlog-was/src/main/java/com/se/Tlog/config/async/AsyncConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/async/AsyncConfig.java
@@ -1,4 +1,4 @@
-package com.se.Tlog.config;
+package com.se.Tlog.config.async;
 
 import java.util.concurrent.Executor;
 

--- a/tlog-was/src/main/java/com/se/Tlog/config/cors/CorsConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/cors/CorsConfig.java
@@ -1,4 +1,4 @@
-package com.se.Tlog.config;
+package com.se.Tlog.config.cors;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/tlog-was/src/main/java/com/se/Tlog/config/datasource/DataSourceConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/datasource/DataSourceConfig.java
@@ -1,4 +1,4 @@
-package com.se.Tlog.config;
+package com.se.Tlog.config.datasource;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;

--- a/tlog-was/src/main/java/com/se/Tlog/config/openapi/OpenApiConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/openapi/OpenApiConfig.java
@@ -1,4 +1,4 @@
-package com.se.Tlog.config;
+package com.se.Tlog.config.openapi;
 
 import org.springframework.context.annotation.Configuration;
 

--- a/tlog-was/src/main/java/com/se/Tlog/config/rabbitmq/RabbitConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/rabbitmq/RabbitConfig.java
@@ -1,4 +1,4 @@
-package com.se.Tlog.config;
+package com.se.Tlog.config.rabbitmq;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;

--- a/tlog-was/src/main/java/com/se/Tlog/config/rabbitmq/RabbitMqChatProperties.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/rabbitmq/RabbitMqChatProperties.java
@@ -1,4 +1,4 @@
-package com.se.Tlog.config;
+package com.se.Tlog.config.rabbitmq;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/tlog-was/src/main/java/com/se/Tlog/config/rabbitmq/RabbitQueueConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/rabbitmq/RabbitQueueConfig.java
@@ -1,4 +1,4 @@
-package com.se.Tlog.config;
+package com.se.Tlog.config.rabbitmq;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.core.Binding;

--- a/tlog-was/src/main/java/com/se/Tlog/config/redis/RedisConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/redis/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.se.Tlog.config;
+package com.se.Tlog.config.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;

--- a/tlog-was/src/main/java/com/se/Tlog/config/security/SsoServiceConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/security/SsoServiceConfig.java
@@ -1,4 +1,4 @@
-package com.se.Tlog.config;
+package com.se.Tlog.config.security;
 
 import com.se.Tlog.domain.User.domain.SsoType;
 import com.se.Tlog.domain.User.repository.api.SsoOauthManager;

--- a/tlog-was/src/main/java/com/se/Tlog/config/security/WebSecurityConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/security/WebSecurityConfig.java
@@ -1,4 +1,4 @@
-package com.se.Tlog.config;
+package com.se.Tlog.config.security;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/tlog-was/src/main/java/com/se/Tlog/config/security/WebSocketConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/security/WebSocketConfig.java
@@ -1,4 +1,4 @@
-package com.se.Tlog.config;
+package com.se.Tlog.config.security;
 
 
 import com.se.Tlog.global.security.handler.HttpHandShakeInterceptor;

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/ChatController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/ChatController.java
@@ -3,8 +3,13 @@ package com.se.Tlog.domain.Social.Chat.controller;
 import com.se.Tlog.domain.Social.Chat.controller.dto.ChatMessageReadDto;
 import com.se.Tlog.domain.Social.Chat.controller.dto.ChatMessageRequestDto;
 import com.se.Tlog.domain.Social.Chat.service.ChatService;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
@@ -28,7 +33,18 @@ public class ChatController {
     }
 
     @PatchMapping("/chat/message/read")
-    public void checkMessage(@RequestBody ChatMessageReadDto chatMessageCheckDto) {
+    @Operation(
+            summary = "채팅 메시지 읽음 처리",
+            description = "특정 사용자가 특정 메시지를 읽었다고 서버에 알립니다.",
+            tags = {"Chat 관리"},
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "메시지 읽음 처리 성공"),
+                    @ApiResponse(responseCode = "404", description = "사용자 또는 메시지를 찾을 수 없습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    public ResponseEntity<?> checkMessage(@RequestBody ChatMessageReadDto chatMessageCheckDto) {
         chatService.checkMessage(chatMessageCheckDto);
+        return ResponseEntity.ok().body(SuccessRes.from(SuccessType.MESSAGE_READ_SUCCESS));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/ChatRoomController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/ChatRoomController.java
@@ -4,7 +4,13 @@ import com.se.Tlog.domain.Social.Chat.controller.dto.ChatRoomResponseDto;
 import com.se.Tlog.domain.Social.Chat.controller.dto.RequestInviteList;
 import com.se.Tlog.domain.Social.Chat.service.ChatRoomService;
 import com.se.Tlog.domain.User.domain.Role;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
 import com.se.Tlog.global.util.jwt.AccessTokenProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,16 +26,43 @@ public class ChatRoomController {
     private final AccessTokenProvider accessTokenProvider;
 
     @PostMapping("/room/{hostId}")
+    @Operation(
+            summary = "채팅방을 생성합니다.",
+            description = "특정 유저가 참여하고 있는 채팅방 리스트 조회합니다.",
+            tags = {"ChatRoom 관리"},
+            security = @SecurityRequirement(
+                    name = "JwtAuthScheme",
+                    scopes = {"scope1", "scope2"}),
+            parameters = {@Parameter(name = "hostId", description = "채팅방 리스트 조회하는 유저의 UUID 입니다.")},
+            responses = {
+                    @ApiResponse( responseCode = "200", description = "성공"),
+                    @ApiResponse( responseCode = "400", description = "초대하려는 유저 중 존재하지 않는 유저가 있습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
     public ResponseEntity<?> createRoom(@PathVariable(name = "hostId") UUID hostId,
                                         @RequestBody RequestInviteList requestInviteList) {
         ChatRoomResponseDto chatRoomResponseDto = chatRoomService.create(hostId, requestInviteList);
-
-        return ResponseEntity.ok().body(chatRoomResponseDto);
+        return ResponseEntity.ok().body(SuccessRes.of(SuccessType.CHATROOM_CREATE,chatRoomResponseDto));
     }
 
     @GetMapping("/room/{hostId}")
+    @Operation(
+            summary = "유저 채팅방 리스트 조회",
+            description = "특정 유저가 참여하고 있는 채팅방 리스트 조회합니다.",
+            tags = {"ChatRoom 관리"},
+            security = @SecurityRequirement(
+                    name = "JwtAuthScheme",
+                    scopes = {"scope1", "scope2"}),
+            parameters = {@Parameter(name = "hostId", description = "채팅방 리스트 조회하는 유저의 UUID 입니다.")},
+            responses = {
+                    @ApiResponse( responseCode = "200", description = "성공"),
+                    @ApiResponse( responseCode = "404", description = "존재하지 않는 사용자 입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
     public ResponseEntity<?> getRoomList(@PathVariable(name = "hostId") UUID hostId) {
-        return ResponseEntity.ok().body(chatRoomService.getRoomList(hostId));
+        return ResponseEntity.ok().body(SuccessRes.from(chatRoomService.getRoomList(hostId)));
     }
     // test 편의성 때문에 토큰 생성 api 작성
     @PostMapping("/{userId}")

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatMessageReadDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/ChatMessageReadDto.java
@@ -1,9 +1,14 @@
 package com.se.Tlog.domain.Social.Chat.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.UUID;
 
+@Schema(description = "특정 채팅 메시지 읽음 처리 요청 DTO")
 public record ChatMessageReadDto(
+        @Schema(description = "메시지를 읽은 사용자의 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
         UUID readerId,
-        Long lastReadMessageId
+        @Schema(description = "읽은 채팅 메시지의 ID", example = "12345")
+        Long messageId
 ) {
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/RequestInviteList.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/controller/dto/RequestInviteList.java
@@ -1,9 +1,13 @@
 package com.se.Tlog.domain.Social.Chat.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "초대할 유저들의 UUID 리스트 요청 DTO")
 public record RequestInviteList(
+        @Schema(description = "초대할 유저들의 UUID 리스트")
         List<UUID> inviteList
 ) {
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatRoomService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatRoomService.java
@@ -40,7 +40,7 @@ public class ChatRoomService {
 
         List<User> users = userRepository.findAllById(allUserIds);
         if(users.size() != allUserIds.size()){
-            throw new CustomException(ErrorType.NOT_FOUND);
+            throw new CustomException(ErrorType.INVITE_USER_NOT_FOUND);
         }
 
         List<ChatRoomUser> chatRoomUsers = users.stream()

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/ChatService.java
@@ -45,7 +45,7 @@ public class ChatService {
     public void checkMessage(ChatMessageReadDto chatMessageCheckDto) {
         User user = userRepository.findById(chatMessageCheckDto.readerId())
                 .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
-        ChatMessage chatMessage = chatMessageRepository.findById(chatMessageCheckDto.lastReadMessageId())
+        ChatMessage chatMessage = chatMessageRepository.findById(chatMessageCheckDto.messageId())
                 .orElseThrow(() -> new CustomException(ErrorType.MESSAGE_NOT_FOUND));
 
         Boolean alreadyRead = chatReadUsersRepository.existsByUserAndMessage(user, chatMessage);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/RabbitPublisher.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/service/RabbitPublisher.java
@@ -1,6 +1,6 @@
 package com.se.Tlog.domain.Social.Chat.service;
 
-import com.se.Tlog.config.RabbitMqChatProperties;
+import com.se.Tlog.config.rabbitmq.RabbitMqChatProperties;
 import com.se.Tlog.domain.Social.Chat.domain.ChatMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -9,6 +9,8 @@ import com.se.Tlog.domain.Travel.domain.repository.DestinationRepositoryService;
 import com.se.Tlog.domain.Travel.domain.repository.TagRepositoryService;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
 
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -51,7 +53,8 @@ public class DestinationService {
     }
 
     public DestinationRes getDestinationById(String id) {
-        Destination destination = destinationRepository.findById(id).orElseThrow(() -> new RuntimeException("Destination not found"));
+        Destination destination = destinationRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorType.DESTINATION_NOT_FOUND));
 
         return DestinationRes.from(destination);
     }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/TagService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/TagService.java
@@ -41,7 +41,7 @@ public class TagService {
     }
 
     public void createTag(TagDto tagDto) {
-    	Tag newTag = Tag.createTag(tagDto.getName(), 0, tagRepo);
+    	Tag newTag = Tag.createTag(tagDto.name(), 0, tagRepo);
         tagRepository.save(newTag);
     }
 
@@ -49,7 +49,7 @@ public class TagService {
     public void updateTagDeletedStatus(String tagId, boolean isDeleted) {
 
         Tag tag = tagRepository.findById(tagId)
-                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_TAG));
         tag.updateTagDeleted(isDeleted);
         tagRepository.save(tag);
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
@@ -5,6 +5,10 @@ import com.se.Tlog.domain.Travel.controller.dto.DestinationDto;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +24,19 @@ public class DestinationController {
     private final DestinationService destinationService;
 
     @PostMapping
+    @Operation(
+            summary = "새로운 여행지 생성하기",
+            description = "새로운 여행지를 생성합니다.",
+            tags = {"Travel 도메인"},
+            security = @SecurityRequirement(
+                    name = "JwtAuthScheme",
+                    scopes = {"scope1", "scope2"}),
+            responses = {
+                    @ApiResponse( responseCode = "201", description = "새로운 여행지 등록을 성공하였습니다."),
+                    @ApiResponse( responseCode = "409", description = "이미 존재하는 여행지입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
     public ResponseEntity<?> createDestination(@RequestBody DestinationDto destinationDto) {
         destinationService.createDestination(destinationDto);
         return ResponseEntity
@@ -28,12 +45,37 @@ public class DestinationController {
     }
 
     @GetMapping
+    @Operation(
+            summary = "전체 여행지 리스트 조회",
+            description = "전체 여행지 정보를 페이지네이션하여 반환합니다.",
+            tags = {"Travel 도메인"},
+            security = @SecurityRequirement(name = "JwtAuthScheme"),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
     public ResponseEntity<Page<DestinationRes>> getAllDestinations(@PageableDefault(size = 10) Pageable pageable) {
         return ResponseEntity.ok(destinationService.getAllDestinations(pageable));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<DestinationRes> getDestinationById(@PathVariable String id) {
+    @Operation (
+            summary = "특정 여행지 GET",
+            description = "특정 id 여행지를 얻습니다.",
+            tags = {"Travel 도메인"},
+            security = @SecurityRequirement(
+                    name = "JwtAuthScheme",
+                    scopes = {"scope1", "scope2"}),
+            parameters = {@Parameter(name = "id", description = "특정 destinaion의 UUID 입니다.")},
+            responses = {
+                    @ApiResponse( responseCode = "200", description = "성공"),
+                    @ApiResponse( responseCode = "400", description = "존재하지 않는 여행지입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    public ResponseEntity<DestinationRes> getDestinationById(
+            @Parameter(description = "특정 destination의 UUID 입니다.") @PathVariable String id) {
         return ResponseEntity.ok(destinationService.getDestinationById(id));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/TagController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/TagController.java
@@ -4,6 +4,10 @@ import com.se.Tlog.domain.Travel.application.TagService;
 import com.se.Tlog.domain.Travel.controller.dto.TagDto;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -18,27 +22,63 @@ public class TagController {
     private final TagService tagService;
 
     @PostMapping
+    @Operation(
+            summary = "새로운 여행지 고유 태그 생성",
+            description = "새로운 여행지 고유 태그를 생성합니다.",
+            tags = {"고유 Tag 관리"},
+            security = @SecurityRequirement(
+                    name = "JwtAuthScheme",
+                    scopes = {"scope1", "scope2"}),
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "새로운 태그 등록을 성공하였습니다."),
+                    @ApiResponse(responseCode = "409", description = "이미 존재하는 태그입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
     public ResponseEntity<?> createTag(@RequestBody TagDto tagDto) {
         tagService.createTag(tagDto);
-        return ResponseEntity
-                .status(SuccessType.TAG_CREATED.getStatus())
-                .body(SuccessRes.from(SuccessType.TAG_CREATED));
+        return ResponseEntity.ok().body(SuccessRes.from(SuccessType.TAG_CREATED));
     }
 
     @GetMapping
+    @Operation(
+            summary = "활성화된 태그 리스트 반환",
+            description = "활성화된 태그들을 리스트 형태로 반환합니다.",
+            tags = {"고유 Tag 관리"},
+            security = @SecurityRequirement(
+                    name = "JwtAuthScheme",
+                    scopes = {"scope1", "scope2"}),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "요청이 성공했습니다."),
+                    @ApiResponse(responseCode = "409", description = "이미 존재하는 태그입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
     public ResponseEntity<?> getActiveAllTags(@PageableDefault(size = 10)Pageable pageable) {
-        return ResponseEntity
-                .ok()
-                .body(SuccessRes.from(tagService.getAllActiveTags(pageable)));
+        return ResponseEntity.ok().body(SuccessRes.from(tagService.getAllActiveTags(pageable)));
     }
 
     @PutMapping("{tagId}")
-    public ResponseEntity<?> deleteTag(@PathVariable("tagId") String tagId,
-                                       @RequestParam boolean isDeleted) {
-
+    @Operation(
+            summary = "태그 삭제 상태 수정",
+            description = "특정 태그의 삭제 여부를 수정합니다. (isDeleted 값을 true 또는 false로 설정)",
+            tags = {"고유 Tag 관리"},
+            security = @SecurityRequirement(
+                    name = "JwtAuthScheme",
+                    scopes = {"scope1", "scope2"}),
+            parameters = {
+                    @Parameter(name = "tagId", description = "삭제할 태그의 UUID 입니다."),
+                    @Parameter(name = "isDeleted", description = "true: 삭제 상태로 변경, false: 복구 상태로 변경")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "요청이 성공했습니다."),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 태그 입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    public ResponseEntity<?> updateTagDeletedStatus(@PathVariable("tagId") String tagId,
+                                                    @RequestParam boolean isDeleted){
         tagService.updateTagDeletedStatus(tagId,isDeleted);
-        return ResponseEntity
-                .status(SuccessType.TAG_UPDATE.getStatus())
-                .body(SuccessRes.from(SuccessType.TAG_UPDATE));
+        return ResponseEntity.ok().body(SuccessRes.from(SuccessType.TAG_UPDATE));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/TagDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/TagDto.java
@@ -1,12 +1,9 @@
 package com.se.Tlog.domain.Travel.controller.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class TagDto {
-    private String name;
-}
+@Schema(description = "생성할 태그 name 요청 Dto")
+public record TagDto(
+        @Schema(description = "생성할 태그 name")
+        String name
+) {}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/TagRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/TagRepository.java
@@ -14,6 +14,6 @@ public interface TagRepository extends MongoRepository<Tag, String> {
 
     boolean existsByName(String name);
 
-    @Query("{'tags.isDeleted': false}")
+    @Query("{'isDeleted': false}")
     Page<Tag> findAllByActiveTags(Pageable pageable);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.se.Tlog.domain.User.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -61,6 +63,20 @@ public class AuthController {
 	}
 
 	@PostMapping("login/user")
+	@Operation(
+			summary = "SSO 로그인 요청",
+			description = "카카오 또는 구글 액세스 토큰을 이용하여 사용자 로그인을 처리합니다.",
+			tags = {"SSO Authentication"},
+			requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+					description = "SSO 로그인 요청 데이터",
+					required = true
+			),
+			responses = {
+					@ApiResponse(responseCode = "200", description = "로그인 성공 (액세스 토큰 및 리프레시 토큰 발급)"),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류"),
+					@ApiResponse(responseCode = "501", description = "현재 해당 소셜 로그인 방식은 아직 지원되지 않습니다.")
+			}
+	)
 	public ResponseEntity<?> login(@RequestBody LoginRequest request){
 
 		TokenDto tokenDto = ssoService.login(request);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/LoginRequest.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/LoginRequest.java
@@ -1,10 +1,14 @@
 package com.se.Tlog.domain.User.controller.dto;
 
 import com.se.Tlog.domain.User.domain.SsoType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-
+@Schema(description = "SSO 로그인 요청 DTO")
 public record LoginRequest(
+        @Schema(description = "로그인할 소셜 타입 (KAKAO, GOOGLE)", example = "KAKAO")
         SsoType type,
+
+        @Schema(description = "소셜 액세스 토큰")
         String accessToken
 ) {
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -15,7 +15,7 @@ public enum ErrorType {
     ROLE_MISMATCH(HttpStatus.BAD_REQUEST,"Role 값을 잘못 입력하였습니다."),
     INVALID_FIREBASE_TOKEN(HttpStatus.BAD_REQUEST,"클라이언트 FCM Token이 유효하지 않습니다!"),
     SCRAP_UNSUPPORTED_TO_TEAM(HttpStatus.BAD_REQUEST, "팀에는 스크랩 기능을 지원하지 않습니다!"),
-    
+    INVITE_USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "초대하려는 유저 중 존재하지 않는 유저가 있습니다."),
     // 사용자로부터 소셜 로그인 인증 실패
     SSO_LOGIN_FAIL(HttpStatus.BAD_REQUEST,"외부 소셜 로그인이 취소되거나 실패했습니다."),
     

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/success/SuccessRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/success/SuccessRes.java
@@ -1,9 +1,9 @@
 package com.se.Tlog.global.response.success;
 
 public record SuccessRes<T> (
-int status,
-String message,
-T data // 필수 X
+    int status,
+    String message,
+    T data // 필수 X
 ){
 public static SuccessRes<?> from(SuccessType success) {
     return new SuccessRes<>(success.getStatusCode(), success.getMessage(), null);
@@ -15,5 +15,5 @@ public static <T> SuccessRes<T> from(T data) {
 
 public static <T> SuccessRes<T> of(SuccessType success, T data) {
     return new SuccessRes<T>(success.getStatusCode(), success.getMessage(), data);
-}
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/success/SuccessType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/success/SuccessType.java
@@ -16,9 +16,10 @@ public enum SuccessType {
     REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급에 성공하였습니다."),
     AVAILABLE_ID(HttpStatus.OK, "사용가능한 아이디입니다."),
     TAG_UPDATE(HttpStatus.OK, "태그 상태 업데이트에 성공하였습니다." ),
-
+    MESSAGE_READ_SUCCESS(HttpStatus.OK, "메시지 읽음 처리에 성공하였습니다."),
     // 201
     CREATED(HttpStatus.CREATED, "등록을 성공하였습니다."),
+    CHATROOM_CREATE(HttpStatus.CREATED, "채팅방 생성을 성공하였습니다."),
     TAG_CREATED(HttpStatus.CREATED, "새로운 태그 등록을 성공하였습니다."),
     DESTINATION_CREATED(HttpStatus.CREATED,"새로운 여행지 등록을 성공하였습니다."),
     USER_CREATED(HttpStatus.CREATED, "사용자 회원가입을 성공하였습니다."),


### PR DESCRIPTION
## 작업 동기 및 이슈
- #83 

## 추가 및 변경사항
- 적용 안된 API Swagger 문서화 적용 및 테스트
- TagRepository Query 오류 수정
- Config 디렉터리 세분화

## 테스트 결과

### Swagger UI 화면 
<img width="1565" alt="스크린샷 2025-04-11 오후 2 55 17" src="https://github.com/user-attachments/assets/8eb11aca-fb43-44a9-8392-e53e65b0f67b" />

<img width="1474" alt="스크린샷 2025-04-11 오후 2 55 27" src="https://github.com/user-attachments/assets/20224944-37c3-4e8a-b710-d68b9dd3b68a" />


## 📌 기타
- SwaggerUI 보시면 reviewController 와 AuthController 라고 되어있는 부분이 있는데 Auth 에서 login 제외하고 추후 삭제할 부분이라 login만 따로 SSO Authenticaiton 으로 두었고 review는 api 수정후 적용하도록 하겠습니다.
- chat-room-controller 는 accessToken 바로 발급받는 테스트 api라 따로 적용안했습니다!
