### PR TITLE
Feature: 구글로그인 IdToken 검증 로직 변경

### DIFF
--- a/tlog-was/build.gradle
+++ b/tlog-was/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 	
+	implementation 'com.google.api-client:google-api-client:2.2.0'
 	implementation 'com.google.firebase:firebase-admin:9.4.3'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/repository/api/GoogleSsoService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/repository/api/GoogleSsoService.java
@@ -2,35 +2,56 @@ package com.se.Tlog.domain.User.repository.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+
 import com.se.Tlog.domain.User.controller.dto.SsoUserInfo;
 import com.se.Tlog.domain.User.domain.SsoType;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestClient;
-import org.springframework.web.client.RestClientResponseException;
+
+@Slf4j
 
 @Service
 public class GoogleSsoService implements SsoService{
-    private final String GOOGLE_USER_INFO_API = "https://www.googleapis.com/oauth2/v3/userinfo";
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public SsoUserInfo getUserInfo(String accessToken) {
-        try {
-            ResponseEntity<String> response = RestClient.create().get()
-                    .uri(GOOGLE_USER_INFO_API)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                    .retrieve()
-                    .toEntity(String.class);
+    	// Id Token을 사용하는 인증 방식입니다.
+    	
+    	GoogleIdToken idToken = Optional.ofNullable(getIdToken(accessToken))
+    			.orElseThrow(() -> new CustomException(ErrorType.GOOGLE_AUTH_FAIL));
 
-            JsonNode jsonNode = objectMapper.readTree(response.getBody());
-            return SsoUserInfo.from(jsonNode, "google");
-        } catch (RestClientResponseException e) {
-            throw new CustomException(ErrorType.GOOGLE_AUTH_FAIL);
-        } catch (Exception e) {
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("id", idToken.getPayload().getSubject());
+		map.put("email", idToken.getPayload().getEmail());
+		map.put("nickname", idToken.getPayload().get("name"));
+		
+        JsonNode jsonNode = objectMapper.valueToTree(map);
+        return SsoUserInfo.from(jsonNode, "google");
+    }
+    
+    private GoogleIdToken getIdToken(String IdTokenString) {
+    	try {
+			return new GoogleIdTokenVerifier
+					.Builder(new NetHttpTransport(), GsonFactory.getDefaultInstance())
+	                .build()
+	                .verify(IdTokenString);
+        } catch (IllegalArgumentException e) {
+			throw new CustomException(ErrorType.GOOGLE_AUTH_FAIL);
+		} catch (Exception e) {
+        	log.error("Google SSO verifying Error : ", e);
             throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
         }
     }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #88 

## 추가 및 변경사항
- 구글 소셜로그인 인증시 access token이 아닌 id token을 사용하도록 변경
- 인증을 위해 google-api-client 라이브러리 도입

## 테스트 결과
- 구글 로그인 인증의 경우, id token으로 인증하면 잘 동작합니다!

## 📌 기타
