### PR TITLE
Feature: 로그아웃 기능 작성 및 jwt 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/config/security/WebSecurityConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/security/WebSecurityConfig.java
@@ -6,7 +6,8 @@ import com.se.Tlog.domain.Admin.repository.jpa.AdminRepository;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.global.security.filter.JwtAuthenticationFilter;
 import com.se.Tlog.global.security.filter.JwtExceptionFilter;
-import com.se.Tlog.global.util.jwt.JwtUtil;
+import com.se.Tlog.global.util.jwt.AccessTokenProvider;
+import com.se.Tlog.global.util.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,10 +28,9 @@ import org.springframework.web.cors.CorsConfigurationSource;
 @RequiredArgsConstructor
 public class WebSecurityConfig {
     private final CorsConfigurationSource corsConfigurationSource;
-    private final AuthenticationConfiguration authenticationConfiguration;
-    private final JwtUtil jwtUtil;
+    private final AccessTokenProvider accessTokenProvider;
     private final ObjectMapper objectMapper;
-
+    private final RedisUtil redisUtil;
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
@@ -63,7 +63,7 @@ public class WebSecurityConfig {
 
 
                 })
-                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil,userRepository,adminRepository), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(accessTokenProvider,userRepository,adminRepository,redisUtil), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtExceptionFilter(objectMapper), JwtAuthenticationFilter.class);
 
         return http.build();

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationRes.java
@@ -6,20 +6,23 @@ import com.se.Tlog.domain.Travel.domain.Location;
 import java.util.List;
 
 public record DestinationRes(
-         String name,
-         String address,
-         Location location,
-         int rating,
-         String city,
-         boolean hasParking,
-         boolean petFriendly,
-         List<TagIdDto>tags
+        String id,
+        String name,
+        String address,
+        Location location,
+        int rating,
+        String city,
+        boolean hasParking,
+        boolean petFriendly,
+        List<TagIdDto> tags
 ) {
     public static DestinationRes from(Destination destination) {
         List<TagIdDto> tagIdDtoList = destination.getTags().stream().filter(tagInfo -> !tagInfo.isDeleted())
                 .map(tagInfo -> TagIdDto.from(tagInfo.getId(), tagInfo.getWeight()))
                 .toList();
+        System.out.println("destinationId = " + destination.getId());
         return new DestinationRes(
+                destination.getId(),
                 destination.getName(),
                 destination.getAddress(),
                 destination.getLocation(),

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Destination.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Destination.java
@@ -9,23 +9,25 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import com.se.Tlog.domain.Travel.domain.repository.DestinationRepositoryService;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "destinations")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Destination {
 	@Id
+	@Field("_id")
 	private String id;
 	private String name;
 	private String address;
 	private String city;
 
-	@Embedded
 	private Location location;
 
 	private List<TagInfo> tags = new ArrayList<>();

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -14,13 +14,16 @@ import com.se.Tlog.global.util.jwt.AccessTokenProvider;
 import com.se.Tlog.global.util.jwt.RefreshTokenProvider;
 import com.se.Tlog.global.util.redis.RedisProperties;
 import com.se.Tlog.global.util.redis.RedisUtil;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
 import java.util.Optional;
 
 @ApplicationService
 @RequiredArgsConstructor
+@Slf4j
 public class SsoAuthService {
     private final Map<SsoType, SsoService> ssoServiceMap;
     private final UserRepository userRepository;
@@ -42,11 +45,37 @@ public class SsoAuthService {
         String accessToken = accessTokenProvider.generateToken(user.getId().toString(), user.getRole().getValue());
         String refreshToken = refreshTokenProvider.generateToken(user.getId().toString(), user.getRole().getValue());
 
-        redisUtil.save(RedisProperties.REFRESH_TOKEN_PREFIX + user.getId(), refreshToken, refreshTokenProvider.getRefreshTokenDuration());
+        String jti = refreshTokenProvider.parseToken(refreshToken).get("jti").toString();
+        String refreshKey = RedisProperties.REFRESH_TOKEN_PREFIX + user.getId() + ":" + jti;
+
+        redisUtil.save(refreshKey, refreshToken, refreshTokenProvider.getRefreshTokenDuration());
 
         return TokenDto.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
     }
+    public void logout(String accessToken,String refreshToken) {
+        Claims accessClaims = accessTokenProvider.parseToken(accessToken);
+        String accessJti = accessClaims.get("jti").toString();
+
+        long remainingTime = accessTokenProvider.getExpiration(accessToken).getTime() - System.currentTimeMillis();
+
+        Claims refreshClaims = refreshTokenProvider.parseToken(refreshToken);
+        String refreshJti = refreshClaims.get("jti").toString();
+        String refreshKey = RedisProperties.REFRESH_TOKEN_PREFIX + refreshClaims.getSubject() + ":" + refreshJti;
+
+        try {
+            redisUtil.setBlacklistToken(RedisProperties.ACCESS_TOKEN_PREFIX + accessJti, remainingTime);
+        } catch (Exception e) {
+            log.error("블랙리스트 등록 실패: {}", accessJti, e);
+            throw new CustomException(ErrorType.LOGOUT_FAILED);
+        }
+
+        boolean isDeleted = redisUtil.delete(refreshKey);
+        if (!isDeleted) {
+            log.warn("Refresh token 삭제 실패: {}", refreshKey);
+        }
+    }
+
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -69,7 +69,7 @@ public class SsoAuthService {
             redisUtil.setBlacklistToken(RedisProperties.ACCESS_TOKEN_PREFIX + accessJti, remainingTime);
         } catch (Exception e) {
             log.error("블랙리스트 등록 실패: {}", accessJti, e);
-            throw new CustomException(ErrorType.LOGOUT_FAILED);
+            throw new CustomException(ErrorType.BLACKLIST_SAVE_FAILED);
         }
 
         boolean isDeleted = redisUtil.delete(refreshKey);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.se.Tlog.domain.User.controller;
 
+import com.se.Tlog.global.util.jwt.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
@@ -23,19 +24,20 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthController {
 
-	private final AuthenticationService authService;
-	private final SsoAuthService ssoService;
+	private final AuthenticationService authenticationService;
+	private final SsoAuthService ssoAuthService;
+	private final JwtUtil jwtUtil;
 
 	@GetMapping("/sso/login/kakao")
 	public ResponseEntity<SuccessRes<SsoLoginRequest>> getSsoLoginByKakao() {
 		return ResponseEntity.ok(
-				SuccessRes.from(authService.getSsoLoginRequest(SsoType.KAKAO)));
+				SuccessRes.from(authenticationService.getSsoLoginRequest(SsoType.KAKAO)));
 	}
 
 	@GetMapping("/sso/login/google")
 	public ResponseEntity<SuccessRes<SsoLoginRequest>> getSsoLoginByGoogle() {
 		return ResponseEntity.ok(
-				SuccessRes.from(authService.getSsoLoginRequest(SsoType.GOOGLE)));
+				SuccessRes.from(authenticationService.getSsoLoginRequest(SsoType.GOOGLE)));
 	}
 
 	@GetMapping("/sso/callback/kakao")
@@ -55,8 +57,8 @@ public class AuthController {
 	private ResponseEntity<SuccessRes<?>> ssoCallBack(SsoType type, String code, String error) {
 		if (error != null)
 			throw new CustomException(ErrorType.SSO_LOGIN_FAIL);
-		
-		authService.checkSsoAuthCode(type, code);
+
+		authenticationService.checkSsoAuthCode(type, code);
 		return ResponseEntity
                 .status(SuccessType.LOGIN_SSO_SUCCESS.getStatus())
                 .body(SuccessRes.from(SuccessType.LOGIN_SSO_SUCCESS));
@@ -79,11 +81,22 @@ public class AuthController {
 	)
 	public ResponseEntity<?> login(@RequestBody LoginRequest request){
 
-		TokenDto tokenDto = ssoService.login(request);
+		TokenDto tokenDto = ssoAuthService.login(request);
 
 		return ResponseEntity.ok()
 				.header("Authorization",tokenDto.accessToken())
 				.header("Set-Cookie",tokenDto.refreshToken())
 				.body(SuccessRes.from(SuccessType.LOGIN_SSO_SUCCESS));
+	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<?> logout(@RequestHeader("Authorization") String authorizationHeader,
+									@CookieValue(value = "refreshToken", required = false)String refreshToken) {
+		String token = jwtUtil.resolveToken(authorizationHeader);
+		System.out.println("refreshToken = " + refreshToken);
+
+		ssoAuthService.logout(token,refreshToken);
+		return ResponseEntity.ok()
+					.body(SuccessRes.from(SuccessType.LOGOUT_SUCCESS));
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
@@ -90,6 +90,15 @@ public class AuthController {
 	}
 
 	@PostMapping("/logout")
+	@Operation(
+			summary = "SSO 로그아웃 요청",
+			description = "사용자 accessToken 과 refreshToken을 쿠키로 받아 처리합니다.",
+			tags = {"SSO Authentication"},
+			responses = {
+					@ApiResponse(responseCode = "200", description = "로그아웃 성공 (토큰 블랙리스트 처리 완료)"),
+					@ApiResponse(responseCode = "500", description = "블랙리스트 등록 실패")
+			}
+	)
 	public ResponseEntity<?> logout(@RequestHeader("Authorization") String authorizationHeader,
 									@CookieValue(value = "refreshToken", required = false)String refreshToken) {
 		String token = jwtUtil.resolveToken(authorizationHeader);

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -16,6 +16,7 @@ public enum ErrorType {
     INVALID_FIREBASE_TOKEN(HttpStatus.BAD_REQUEST,"클라이언트 FCM Token이 유효하지 않습니다!"),
     SCRAP_UNSUPPORTED_TO_TEAM(HttpStatus.BAD_REQUEST, "팀에는 스크랩 기능을 지원하지 않습니다!"),
     INVITE_USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "초대하려는 유저 중 존재하지 않는 유저가 있습니다."),
+    LOGOUT_FAILED(HttpStatus.BAD_REQUEST,"로그아웃에 실패하였습니다." ),
     // 사용자로부터 소셜 로그인 인증 실패
     SSO_LOGIN_FAIL(HttpStatus.BAD_REQUEST,"외부 소셜 로그인이 취소되거나 실패했습니다."),
     

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -62,7 +62,7 @@ public enum ErrorType {
     INTERNAL_ERROR_BY_INVITE_CODE(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. 팀 초대 코드 에러."),
     FIREBASE_INITIALIZE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. Firebase 라이브러리 초기화 에러."),
     FIREBASE_INITIALIZE_FAIL_KEY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. Firebase Key 파일을 찾지 못했습니다."),
-    
+    BLACKLIST_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"블랙리스트 등록에 실패했습니다."),
     // 외부 소셜 로그인 처리 중 에러
     SSO_ACCESSTOKEN_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "외부 인증 서버로부터 인증을 받는데 실패했습니다."),
 

--- a/tlog-was/src/main/java/com/se/Tlog/global/security/filter/JwtAuthenticationFilter.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/security/filter/JwtAuthenticationFilter.java
@@ -6,7 +6,9 @@ import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.global.response.error.ErrorType;
 import com.se.Tlog.global.security.dto.AdminDetails;
 import com.se.Tlog.global.security.dto.AppUserDetails;
-import com.se.Tlog.global.util.jwt.JwtUtil;
+import com.se.Tlog.global.util.jwt.AccessTokenProvider;
+import com.se.Tlog.global.util.redis.RedisProperties;
+import com.se.Tlog.global.util.redis.RedisUtil;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -30,9 +32,10 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final JwtUtil jwtUtil;
+    private final AccessTokenProvider accessTokenProvider;
     private final UserRepository userRepository;
     private final AdminRepository adminRepository;
+    private final RedisUtil redisUtil;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -42,14 +45,28 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.warn("TOKEN NOT FOUND or TOKEN HEADER IS WRONG : " + authorization);
         } else {
             String accessToken = authorization.split(" ")[1];
-            Authentication authToken = getAuthentication(accessToken, response);
+
+            Claims claims = accessTokenProvider.parseToken(accessToken);
+            String jti = claims.get("jti").toString();
+            String accessKey = RedisProperties.ACCESS_TOKEN_PREFIX + jti;
+
+            boolean isBlacklisted = redisUtil.isTokenBlacklisted(accessKey);
+
+            if (isBlacklisted) {
+                log.warn("BLOCKED TOKEN (jti = {})", jti);
+                response.setStatus(ErrorType.UN_AUTHORIZATION.getStatusCode());
+                response.setContentType("application/json");
+                response.getWriter().write("Token is blacklisted.");
+                return;
+            }
+            Authentication authToken = getAuthentication(claims, response);
             SecurityContextHolder.getContext().setAuthentication(authToken);
         }
         filterChain.doFilter(request,response);
     }
 
-    private Authentication getAuthentication(String token, HttpServletResponse response) throws IOException {
-        Claims claims = jwtUtil.parseToken(token);
+    private Authentication getAuthentication(Claims claims, HttpServletResponse response) throws IOException {
+
         UUID id = UUID.fromString(claims.getSubject());
         String role = claims.get("role").toString();
 

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/AccessTokenProvider.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/AccessTokenProvider.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import java.time.Duration;
 import java.util.Date;
 import java.util.Map;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -28,7 +29,8 @@ public class AccessTokenProvider implements JwtTokenProvider {
     public String generateToken(String userId, String role) {
         Map<String, Object> claims = Map.of(
                 "role", role,
-                "tokenType", "access"
+                "tokenType", "access",
+                "jti", UUID.randomUUID().toString()
         );
         return jwtUtil.generateToken(userId,accessTokenDuration,role,claims);
     }

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/JwtUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/JwtUtil.java
@@ -45,4 +45,8 @@ public class JwtUtil {
     private Date createExpire(Long expiration){
         return new Date(System.currentTimeMillis() + expiration);
     }
+
+    public String resolveToken(String headerToken) {
+        return headerToken.substring(7);
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/RefreshTokenProvider.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/RefreshTokenProvider.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import java.time.Duration;
 import java.util.Date;
 import java.util.Map;
+import java.util.UUID;
 
 
 @Component
@@ -24,7 +25,8 @@ public class RefreshTokenProvider implements JwtTokenProvider{
     public String generateToken(String userId, String role) {
         Map<String, Object> claims = Map.of(
                 "role", role,
-                "tokenType", "refresh"
+                "tokenType", "refresh",
+                "jti", UUID.randomUUID().toString()
         );
         return jwtUtil.generateToken(userId, refreshTokenDuration, role, claims);
     }

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisUtil.java
@@ -15,4 +15,24 @@ public class RedisUtil {
     public void save(String key,Object value,long expiration){
         redisTemplate.opsForValue().set(key, value, expiration, TimeUnit.MILLISECONDS);
     }
+
+    public boolean delete(String key) {
+        return Boolean.TRUE.equals(redisTemplate.delete(key));
+    }
+
+    public void setBlacklistToken(String key, long remainingTime) {
+        redisTemplate.opsForValue().set(key, "blacklisted", remainingTime, TimeUnit.MILLISECONDS);
+    }
+
+    public Object get(String key){
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public boolean isTokenBlacklisted(String key) {
+        if ("blacklisted".equals(get(key))) {
+            return true;
+        }else{
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #87

## 추가 및 변경사항
- 로그아웃 기능 작성
- jwt 토큰 claim에 jti(토큰 식별 id) 추가 -> 사용자가 여러 기기로 동시 로그인시 토큰 구분해주기 위해 jti 추가 (현재 그대로 진행된다면 
사용자가 다른 기기로 로그인시 기존 refreshToken이 덮어씌워진다. 기존 refreshToken의 redis 저장시 Key값이 refresh_token: user.id()
였어서 덮어씌워지는 문제가 발생! 그럼 기존 기기에서는 토큰 재발급 할 때 refreshToken을 찾을 수 없게된다. 따라서 토큰별 구분이 필요함!)
따라서 refresh_Token:user.id:jti 로 수정했습니다!
- 블랙리스트 처리때는 access_token:jti 로 수정했습니다! 가운데에 user.id 넣어도 될 것 같기는 한데 일단은 jti로 넣어서 관리하는 것으로 수정했습니다.
- jwtAuthentication 필터에서 블랙리스트된 토큰일시 처리하는 로직 작성했습니다.
- 여행지 응답시 destination id 포함되게끔 수정하였습니다!

## 테스트 결과

### postman cookie 설정 및 postman api 
<img width="846" alt="스크린샷 2025-04-16 오전 2 26 40" src="https://github.com/user-attachments/assets/3a3acc4e-753b-4a30-ab57-2635ae72b4a4" />

<img width="919" alt="스크린샷 2025-04-16 오전 2 26 33" src="https://github.com/user-attachments/assets/7c2b0e48-d773-4468-8261-08f5be4815be" />

### refreshToken redis 저장되는 값 확인 (로그인 했을 때)
![스크린샷 2025-04-16 오전 2 25 57](https://github.com/user-attachments/assets/cdc519ae-0dd3-44fd-827b-b78261a98257)

### 로그아웃 api 정상 요청시 블랙리스트 등록과 refreshToken 삭제되는 값 확인 테스트
![스크린샷 2025-04-16 오전 2 26 04](https://github.com/user-attachments/assets/698a9110-1b03-4b0d-9f69-0f46cb9d8942)





## 📌 기타
