### PR TITLE
Feature: Destination 필드 추가 및 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -33,12 +33,14 @@ public class DestinationService {
         Destination destination = Destination.create(
         		destinationDto.getName(),
                 destinationDto.getLocation(),
-                destinationDto.getRating(),
                 destinationDto.getAddress(),
                 tagInfoList,
                 destinationDto.getCity(),
+                destinationDto.getDistrict(),
                 destinationDto.isHasParking(),
                 destinationDto.isPetFriendly(),
+                destinationDto.getDescription(),
+                destinationDto.getImageUrl(),
                 destinationRepoService);
         destinationRepository.save(destination);
     }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationDto.java
@@ -16,10 +16,12 @@ public class DestinationDto {
     private String name;
     private String address;
     private Location location;
-    private int rating;
     private String city;
+    private String district;
     private boolean hasParking;
     private boolean petFriendly;
+    private String imageUrl;
+    private String description;
     private List<TagIdDto> tags;
     
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationRes.java
@@ -4,6 +4,7 @@ import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.domain.Location;
 
 import java.util.List;
+import java.util.Map;
 
 public record DestinationRes(
         String id,
@@ -18,7 +19,8 @@ public record DestinationRes(
         int reviewCount,
         float averageRating,
         String imageUrl,
-        List<TagIdDto> tags
+        List<TagIdDto> tags,
+        Map<Integer,Integer> ratingDistribution
 ) {
     public static DestinationRes from(Destination destination) {
         List<TagIdDto> tagIdDtoList = destination.getTags().stream().filter(tagInfo -> !tagInfo.isDeleted())
@@ -38,7 +40,14 @@ public record DestinationRes(
                 destination.getReviewCount(),
                 destination.getAverageRating(),
                 destination.getImageUrl(),
-                tagIdDtoList
+                tagIdDtoList,
+                Map.of(
+                        1, destination.getRatingCount1(),
+                        2, destination.getRatingCount2(),
+                        3, destination.getRatingCount3(),
+                        4, destination.getRatingCount4(),
+                        5, destination.getRatingCount5()
+                )
         );
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationRes.java
@@ -5,6 +5,7 @@ import com.se.Tlog.domain.Travel.domain.Location;
 
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 public record DestinationRes(
         String id,
@@ -27,6 +28,13 @@ public record DestinationRes(
                 .map(tagInfo -> TagIdDto.from(tagInfo.getId(), tagInfo.getWeight()))
                 .toList();
         System.out.println("destinationId = " + destination.getId());
+
+        Map<Integer, Integer> distribution = new TreeMap<>();
+        int[] ratingCount = destination.getRatingCount();
+        for (int i = 0; i < 5; i++) {
+            distribution.put(i+1, ratingCount[i]);
+        }
+
         return new DestinationRes(
                 destination.getId(),
                 destination.getName(),
@@ -41,13 +49,7 @@ public record DestinationRes(
                 destination.getAverageRating(),
                 destination.getImageUrl(),
                 tagIdDtoList,
-                Map.of(
-                        1, destination.getRatingCount1(),
-                        2, destination.getRatingCount2(),
-                        3, destination.getRatingCount3(),
-                        4, destination.getRatingCount4(),
-                        5, destination.getRatingCount5()
-                )
+                distribution
         );
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationRes.java
@@ -10,10 +10,14 @@ public record DestinationRes(
         String name,
         String address,
         Location location,
-        int rating,
         String city,
+        String district,
         boolean hasParking,
         boolean petFriendly,
+        int ratingSum,
+        int reviewCount,
+        float averageRating,
+        String imageUrl,
         List<TagIdDto> tags
 ) {
     public static DestinationRes from(Destination destination) {
@@ -26,10 +30,14 @@ public record DestinationRes(
                 destination.getName(),
                 destination.getAddress(),
                 destination.getLocation(),
-                destination.getRating(),
                 destination.getCity(),
+                destination.getDistrict(),
                 destination.isHasParking(),
                 destination.isPetFriendly(),
+                destination.getRatingSum(),
+                destination.getReviewCount(),
+                destination.getAverageRating(),
+                destination.getImageUrl(),
                 tagIdDtoList
         );
     }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Destination.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Destination.java
@@ -39,6 +39,12 @@ public class Destination {
 	private int reviewCount;
 	private float averageRating;
 
+	private int ratingCount1;
+	private int ratingCount2;
+	private int ratingCount3;
+	private int ratingCount4;
+	private int ratingCount5;
+
 	private String description;
 
 	public static void assertValidity(String name, DestinationRepositoryService destinationRepo) {
@@ -87,6 +93,11 @@ public class Destination {
 		this.ratingSum = 0;
 		this.reviewCount = 0;
 		this.averageRating = 0;
+		this.ratingCount1 = 0;
+		this.ratingCount2 = 0;
+		this.ratingCount3 = 0;
+		this.ratingCount4 = 0;
+		this.ratingCount5 = 0;
 	}
 
 	public void addTag(TagInfo tag) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Destination.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Destination.java
@@ -3,7 +3,6 @@ package com.se.Tlog.domain.Travel.domain;
 import java.util.ArrayList;
 import java.util.List;
 
-import jakarta.persistence.*;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,27 +14,33 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import com.se.Tlog.domain.Travel.domain.repository.DestinationRepositoryService;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
-import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "destinations")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Destination {
 	@Id
-	@Field("_id")
 	private String id;
 	private String name;
 	private String address;
 	private String city;
+	private String district;
 
 	private Location location;
 
 	private List<TagInfo> tags = new ArrayList<>();
 
-	private int rating;
 	private boolean hasParking;
 	private boolean petFriendly;
-	
+
+	private String imageUrl;
+
+	private int ratingSum;
+	private int reviewCount;
+	private float averageRating;
+
+	private String description;
+
 	public static void assertValidity(String name, DestinationRepositoryService destinationRepo) {
 		if (destinationRepo.exist(name))
 			throw new CustomException(ErrorType.ALREADY_EXISTS_DESTINATION);
@@ -43,36 +48,45 @@ public class Destination {
 	
 	public static Destination create(
 			String name, 
-			Location location, 
-			int rating, 
+			Location location,
 			String address,
 			List<TagInfo> tags,
-			String city, 
+			String city,
+			String district,
 			boolean hasParking,
 			boolean petFriendly,
+			String imageUrl,
+			String description,
 			DestinationRepositoryService validator) {
 		assertValidity(name, validator);
-		return new Destination(name, location, rating, address, tags, false, city, hasParking, petFriendly);
+		return new Destination(name, location,address, tags, false, city, district, hasParking, petFriendly, imageUrl, description);
 	}
 
 	private Destination(
 			String name, 
-			Location location, 
-			int rating, 
+			Location location,
 			String address,
 			List<TagInfo> tags, 
 			boolean verified,
-			String city, 
+			String city,
+			String district,
 			boolean hasParking,
-			boolean petFriendly) {
+			boolean petFriendly,
+			String imageUrl,
+			String description) {
 		this.name = name;
 		this.location = location;
-		this.rating = rating;
 		this.address = address;
 		this.tags = tags;
 		this.city = city;
+		this.district = district;
 		this.hasParking = hasParking;
 		this.petFriendly = petFriendly;
+		this.imageUrl = imageUrl;
+		this.description = description;
+		this.ratingSum = 0;
+		this.reviewCount = 0;
+		this.averageRating = 0;
 	}
 
 	public void addTag(TagInfo tag) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Destination.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Destination.java
@@ -39,11 +39,7 @@ public class Destination {
 	private int reviewCount;
 	private float averageRating;
 
-	private int ratingCount1;
-	private int ratingCount2;
-	private int ratingCount3;
-	private int ratingCount4;
-	private int ratingCount5;
+	private final int[] ratingCount = new int[5];
 
 	private String description;
 
@@ -93,11 +89,6 @@ public class Destination {
 		this.ratingSum = 0;
 		this.reviewCount = 0;
 		this.averageRating = 0;
-		this.ratingCount1 = 0;
-		this.ratingCount2 = 0;
-		this.ratingCount3 = 0;
-		this.ratingCount4 = 0;
-		this.ratingCount5 = 0;
 	}
 
 	public void addTag(TagInfo tag) {


### PR DESCRIPTION
## 작업 동기 및 이슈
- #92 

## 추가 및 변경사항
- 여행지에 아래 필드를 추가하였습니다. 
        ratingSum, reviewCount, averageRating, imageUrl, district 리뷰 평점을 관리하기 위해서 추가했고 district는 시/군/구 의 "구"를위해 추가하였습니다. 따라서 현재 시/구 에 대한 데이터가 있어서 검색에 좋을 것 같습니다.
- 또한 임시로 imageUrl을 Stirng으로 관리하는 방식으로 해두겠습니다!

## 테스트 결과
### 현재 swagger 응답 형식
<img width="1174" alt="스크린샷 2025-04-28 오후 10 06 36" src="https://github.com/user-attachments/assets/3b1d29aa-258e-403e-8c7f-507eff345a23" />

## 📌 기타
- 현재 get 응답에 대해서는 모든 필드를 반환하게 끔 했는데 사용자들의 여행지별 커스텀 태그에 대한 구성 및 개발이 끝나면 응답 포맷 반영해서 수정해두겠습니다!
- 이후 리뷰 생성 및 삭제 시 reviewCount, ratingSum, averageRating 업데이트 하는 방향으로 하겠습니다!
- rating을 관리하는 document를 추가로 만들어서 관리할려고 했으나 그러면 추가로 한번 더 조회해야 하는 불필요한 비용이 발생해서 destination에서 관리하는 방향으로 하였습니다. 그리고 하나의 document에 넣어도 크기가 작아서 문제없을 것 같습니다!
