### PR TITLE
Feature: 커스텀 태그 작성 및 프론트앤드 응답 포맷 요구사항 반영

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/CustomTagService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/CustomTagService.java
@@ -1,0 +1,33 @@
+package com.se.Tlog.domain.Travel.application;
+
+import com.se.Tlog.domain.Travel.domain.CustomTagDocument;
+import com.se.Tlog.domain.Travel.domain.TagCount;
+import com.se.Tlog.domain.Travel.repository.mongo.CustomTagDocumentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CustomTagService {
+    private final CustomTagDocumentRepository customTagDocumentRepository;
+
+    public void addCustomTag(String destinationId, String tagName) {
+        CustomTagDocument customTag = customTagDocumentRepository.findByDestinationId(destinationId)
+                .orElseGet(() -> CustomTagDocument.create(destinationId));
+
+        customTag.addOrIncrement(tagName);
+        customTagDocumentRepository.save(customTag);
+    }
+
+    public List<TagCount> getTopTags(String destinationId, int limit) {
+        return customTagDocumentRepository.findByDestinationId(destinationId)
+                .map(doc -> doc.getCustomTags().stream()
+                        .sorted(Comparator.comparing(TagCount::getCount).reversed())
+                        .limit(limit)
+                        .toList()
+                ).orElse(List.of());
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -1,9 +1,11 @@
 package com.se.Tlog.domain.Travel.application;
 
 import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationDetailsRes;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationDto;
-import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
 import com.se.Tlog.domain.Travel.domain.Destination;
+import com.se.Tlog.domain.Travel.domain.TagCount;
 import com.se.Tlog.domain.Travel.domain.TagInfo;
 import com.se.Tlog.domain.Travel.domain.repository.DestinationRepositoryService;
 import com.se.Tlog.domain.Travel.domain.repository.TagRepositoryService;
@@ -24,6 +26,7 @@ public class DestinationService {
     private final DestinationRepositoryService destinationRepoService;
     private final DestinationRepository destinationRepository;
     private final TagRepositoryService tagRepoService;
+    private final CustomTagService customTagService;
 
     public void createDestination(DestinationDto destinationDto) {
     	Destination.assertValidity(destinationDto.getName(), destinationRepoService);
@@ -45,19 +48,24 @@ public class DestinationService {
         destinationRepository.save(destination);
     }
 
-    public Page<DestinationRes> getAllDestinations(Pageable pageable) {
+    public Page<DestinationSummaryRes> getAllDestinations(Pageable pageable) {
         Page<Destination> destinationPage = destinationRepository.findAllWithActiveTags(pageable);
-        List<DestinationRes> destinationResList = destinationPage
+
+        List<DestinationSummaryRes> destinationResList = destinationPage
                 .stream()
-                .map(DestinationRes::from).toList();
+                .map(destination -> {
+                            List<TagCount> topTags = customTagService.getTopTags(destination.getId(), 3);
+                            return DestinationSummaryRes.from(destination, topTags);
+                }).toList();
 
         return new PageImpl<>(destinationResList, pageable, destinationPage.getTotalElements());
     }
 
-    public DestinationRes getDestinationById(String id) {
+    public DestinationDetailsRes getDestinationById(String id) {
         Destination destination = destinationRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorType.DESTINATION_NOT_FOUND));
 
-        return DestinationRes.from(destination);
+        List<TagCount> topTags = customTagService.getTopTags(destination.getId(), 3);
+        return DestinationDetailsRes.from(destination, topTags);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/CustomTagController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/CustomTagController.java
@@ -1,0 +1,44 @@
+package com.se.Tlog.domain.Travel.controller;
+
+import com.se.Tlog.domain.Travel.application.CustomTagService;
+import com.se.Tlog.domain.Travel.controller.dto.AddCustomTagsReq;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/custom-tags")
+@RequiredArgsConstructor
+public class CustomTagController {
+    private final CustomTagService customTagService;
+
+
+    @PostMapping("/{destinationId}")
+    @Operation(
+            summary = "특정 여행지에 커스텀 태그를 추가합니다.",
+            description = "특정 id 여행지의 커스텀 태그를 생성합니다.",
+            tags = {"Travel 도메인"},
+            security = @SecurityRequirement(
+                    name = "JwtAuthScheme",
+                    scopes = {"scope1", "scope2"}),
+            parameters = {@Parameter(name = "destinationId", description = "특정 destinaion의 UUID 입니다.")},
+            responses = {
+                    @ApiResponse( responseCode = "200", description = "성공"),
+                    @ApiResponse( responseCode = "400", description = "존재하지 않는 여행지입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    public ResponseEntity<?> addCustomTag(@RequestBody AddCustomTagsReq addCustomTagsReq,
+            @Parameter(description = "특정 destination의 UUID 입니다.") @PathVariable String destinationId) {
+        customTagService.addCustomTag(destinationId,addCustomTagsReq.tagName());
+        return ResponseEntity
+                .status(SuccessType.CUSTOM_TAG_CREATED.getStatus())
+                .body(SuccessRes.from(SuccessType.CUSTOM_TAG_CREATED));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
@@ -1,8 +1,9 @@
 package com.se.Tlog.domain.Travel.controller;
 
 import com.se.Tlog.domain.Travel.application.DestinationService;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationDetailsRes;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationDto;
-import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
 import io.swagger.v3.oas.annotations.Operation;
@@ -55,7 +56,7 @@ public class DestinationController {
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류")
             }
     )
-    public ResponseEntity<Page<DestinationRes>> getAllDestinations(@PageableDefault(size = 10) Pageable pageable) {
+    public ResponseEntity<Page<DestinationSummaryRes>> getAllDestinations(@PageableDefault(size = 10) Pageable pageable) {
         return ResponseEntity.ok(destinationService.getAllDestinations(pageable));
     }
 
@@ -74,7 +75,7 @@ public class DestinationController {
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류")
             }
     )
-    public ResponseEntity<DestinationRes> getDestinationById(
+    public ResponseEntity<DestinationDetailsRes> getDestinationById(
             @Parameter(description = "특정 destination의 UUID 입니다.") @PathVariable String id) {
         return ResponseEntity.ok(destinationService.getDestinationById(id));
     }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/AddCustomTagsReq.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/AddCustomTagsReq.java
@@ -1,0 +1,6 @@
+package com.se.Tlog.domain.Travel.controller.dto;
+
+public record AddCustomTagsReq(
+        String tagName
+) {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationDetailsRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationDetailsRes.java
@@ -2,12 +2,13 @@ package com.se.Tlog.domain.Travel.controller.dto;
 
 import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.domain.Location;
+import com.se.Tlog.domain.Travel.domain.TagCount;
 
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-public record DestinationRes(
+public record DestinationDetailsRes(
         String id,
         String name,
         String address,
@@ -20,22 +21,18 @@ public record DestinationRes(
         int reviewCount,
         float averageRating,
         String imageUrl,
-        List<TagIdDto> tags,
+        List<TagCount> topTags,
         Map<Integer,Integer> ratingDistribution
+        //상위 리뷰 2개 포함
 ) {
-    public static DestinationRes from(Destination destination) {
-        List<TagIdDto> tagIdDtoList = destination.getTags().stream().filter(tagInfo -> !tagInfo.isDeleted())
-                .map(tagInfo -> TagIdDto.from(tagInfo.getId(), tagInfo.getWeight()))
-                .toList();
-        System.out.println("destinationId = " + destination.getId());
-
+    public static DestinationDetailsRes from(Destination destination,List<TagCount> topTags) {
         Map<Integer, Integer> distribution = new TreeMap<>();
         int[] ratingCount = destination.getRatingCount();
         for (int i = 0; i < 5; i++) {
             distribution.put(i+1, ratingCount[i]);
         }
 
-        return new DestinationRes(
+        return new DestinationDetailsRes(
                 destination.getId(),
                 destination.getName(),
                 destination.getAddress(),
@@ -48,7 +45,7 @@ public record DestinationRes(
                 destination.getReviewCount(),
                 destination.getAverageRating(),
                 destination.getImageUrl(),
-                tagIdDtoList,
+                topTags,
                 distribution
         );
     }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationDto.java
@@ -1,5 +1,6 @@
 package com.se.Tlog.domain.Travel.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,17 +12,28 @@ import com.se.Tlog.domain.Travel.domain.Location;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "여행지 생성 요청 DTO")
 public class DestinationDto {
 
+    @Schema(description = "여행지 이름입니다.")
     private String name;
+    @Schema(description = "여행지 주소입니다.")
     private String address;
+    @Schema(description = "여행지 위치 입니다.")
     private Location location;
+    @Schema(description = "여행지의 구체적인 위치 시입니다.")
     private String city;
+    @Schema(description = "여행지 구체적인 구 입니다.")
     private String district;
+    @Schema(description = "여행지 주차가 가능 여부입니다.")
     private boolean hasParking;
+    @Schema(description = "여행지 애완동물 동반 가능 여부입니다.")
     private boolean petFriendly;
+    @Schema(description = "여행지 이미지 url입니다.")
     private String imageUrl;
+    @Schema(description = "여행지 부가적인 설명입니다.")
     private String description;
+    @Schema(description = "여행지 고정 태그입니다.")
     private List<TagIdDto> tags;
     
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationSummaryRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationSummaryRes.java
@@ -1,0 +1,32 @@
+package com.se.Tlog.domain.Travel.controller.dto;
+
+import com.se.Tlog.domain.Travel.domain.Destination;
+import com.se.Tlog.domain.Travel.domain.Location;
+import com.se.Tlog.domain.Travel.domain.TagCount;
+
+import java.util.List;
+
+public record DestinationSummaryRes(
+        String id,
+        String name,
+        String city,
+        Location location,
+        int reviewCount,
+        float averageRating,
+        String imageUrl,
+        List<TagCount> tagCountList
+        ) {
+
+    public static DestinationSummaryRes from(Destination destination, List<TagCount> topTags) {
+        return new DestinationSummaryRes(
+                destination.getId(),
+                destination.getName(),
+                destination.getCity(),
+                destination.getLocation(),
+                destination.getReviewCount(),
+                destination.getAverageRating(),
+                destination.getImageUrl(),
+                topTags
+        );
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/SimpleDestinationRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/SimpleDestinationRes.java
@@ -1,0 +1,25 @@
+package com.se.Tlog.domain.Travel.controller.dto;
+
+
+import com.se.Tlog.domain.Travel.domain.Destination;
+import com.se.Tlog.domain.Travel.domain.TagCount;
+
+import java.util.List;
+
+public record SimpleDestinationRes(
+        String id,
+        String name,
+        String imageUrl,
+        String description,
+        List<TagCount> tagCountList
+) {
+    public static SimpleDestinationRes from(Destination destination, List<TagCount> topTags) {
+        return new SimpleDestinationRes(
+                destination.getId(),
+                destination.getName(),
+                destination.getImageUrl(),
+                destination.getDescription(),
+                topTags
+        );
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/CustomTagDocument.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/CustomTagDocument.java
@@ -1,0 +1,45 @@
+package com.se.Tlog.domain.Travel.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Document(collection = "customtags")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomTagDocument {
+    @Id
+    private String id;
+
+    private String destinationId;
+    private List<TagCount> customTags = new ArrayList<>();
+
+    public void addOrIncrement(String tagName) {
+        String normalizedTagName = tagName.trim().toLowerCase();
+
+        TagCount existing = customTags.stream()
+                .filter(t -> t.getTagName().equals(normalizedTagName))
+                .findFirst()
+                .orElse(null);
+
+        if (existing != null) {
+            existing.increment();
+            return;
+        }
+
+        customTags.add(TagCount.create(normalizedTagName));
+    }
+
+    public static CustomTagDocument create(String destinationId) {
+        return new CustomTagDocument(destinationId);
+    }
+
+    private CustomTagDocument(String destinationId) {
+        this.destinationId = destinationId;
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/TagCount.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/TagCount.java
@@ -1,0 +1,22 @@
+package com.se.Tlog.domain.Travel.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TagCount {
+    private String tagName;
+    private int count;
+
+    public void increment() {
+        this.count +=1;
+    }
+
+    public static TagCount create(String tagName) {
+        return new TagCount(tagName, 1);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/CustomTagDocumentRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/CustomTagDocumentRepository.java
@@ -1,0 +1,12 @@
+package com.se.Tlog.domain.Travel.repository.mongo;
+
+import com.se.Tlog.domain.Travel.domain.CustomTagDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CustomTagDocumentRepository extends MongoRepository<CustomTagDocument,String> {
+    Optional<CustomTagDocument> findByDestinationId(String destinationId);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ScrapService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ScrapService.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.UUID;
 
 import com.se.Tlog.domain.ApplicationService;
-import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
+import com.se.Tlog.domain.Travel.application.CustomTagService;
+import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
+import com.se.Tlog.domain.Travel.domain.TagCount;
 import com.se.Tlog.domain.Wishlist.domain.OwnerType;
 import com.se.Tlog.domain.Wishlist.domain.WishlistService;
 import com.se.Tlog.domain.Wishlist.domain.WishlistType;
@@ -18,14 +20,18 @@ import com.se.Tlog.domain.Wishlist.domain.UpdateType;
 @RequiredArgsConstructor
 public class ScrapService {
 	private final WishlistService wishlistService;
+	private final CustomTagService customTagService;
 	
-	public List<DestinationRes> getScrapData(UUID userId) {
+	public List<SimpleDestinationRes> getScrapData(UUID userId) {
 		return wishlistService.getWishlistData(
 				new WishlistOwnerDto(
 						OwnerType.USER,
 						userId),
 				WishlistType.SCRAP)
-				.stream().map(DestinationRes::from).toList();
+				.stream().map(destination -> {
+					List<TagCount> topTags = customTagService.getTopTags(destination.getId(), 3);
+					return SimpleDestinationRes.from(destination, topTags);
+				}).toList();
 	}
 	
 	private void updateScrap(UpdateType updateType, UUID userId, String destinationId) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ShoppingCartService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ShoppingCartService.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.UUID;
 
 import com.se.Tlog.domain.ApplicationService;
-import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
+import com.se.Tlog.domain.Travel.application.CustomTagService;
+import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
+import com.se.Tlog.domain.Travel.domain.TagCount;
 import com.se.Tlog.domain.Wishlist.domain.OwnerType;
 import com.se.Tlog.domain.Wishlist.domain.WishlistService;
 import com.se.Tlog.domain.Wishlist.domain.WishlistType;
@@ -18,14 +20,18 @@ import com.se.Tlog.domain.Wishlist.domain.UpdateType;
 @RequiredArgsConstructor
 public class ShoppingCartService {
 	private final WishlistService wishlistService;
+	private final CustomTagService customTagService;
 
-	public List<DestinationRes> getCartData(UUID ownerId, OwnerType ownerType) {
+	public List<SimpleDestinationRes> getCartData(UUID ownerId, OwnerType ownerType) {
 		return wishlistService.getWishlistData(
 				new WishlistOwnerDto(
 						ownerType,
 						ownerId),
 				WishlistType.SHOPPING_CART)
-				.stream().map(DestinationRes::from).toList();
+				.stream().map(destination -> {
+					List<TagCount> topTags = customTagService.getTopTags(destination.getId(), 3);
+					return SimpleDestinationRes.from(destination, topTags);
+				}).toList();
 	}
 	
 	private void updateCart(UpdateType updateType, UUID ownerId, OwnerType ownerType, String destinationId) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ScrapController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ScrapController.java
@@ -3,6 +3,7 @@ package com.se.Tlog.domain.Wishlist.contoller;
 import java.util.List;
 import java.util.UUID;
 
+import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -12,7 +13,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
 import com.se.Tlog.domain.Wishlist.application.ScrapService;
 import com.se.Tlog.global.response.error.ErrorRes;
 import com.se.Tlog.global.response.success.SuccessRes;
@@ -48,7 +48,7 @@ public class ScrapController {
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
-	public ResponseEntity<SuccessRes<List<DestinationRes>>> getScrapList(@PathVariable(name = "userId") UUID userId) {
+	public ResponseEntity<SuccessRes<List<SimpleDestinationRes>>> getScrapList(@PathVariable(name = "userId") UUID userId) {
 		return ResponseEntity.ok(SuccessRes.from(
 				scrapService.getScrapData(userId)));
 	}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ShoppingCartController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ShoppingCartController.java
@@ -3,6 +3,7 @@ package com.se.Tlog.domain.Wishlist.contoller;
 import java.util.List;
 import java.util.UUID;
 
+import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -12,7 +13,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import com.se.Tlog.domain.Travel.controller.dto.DestinationRes;
 import com.se.Tlog.domain.Wishlist.application.ShoppingCartService;
 import com.se.Tlog.domain.Wishlist.domain.OwnerType;
 import com.se.Tlog.global.response.error.ErrorRes;
@@ -49,7 +49,7 @@ public class ShoppingCartController {
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
-	public ResponseEntity<SuccessRes<List<DestinationRes>>> getCartOfUser(@PathVariable(name = "userId") UUID userId) {
+	public ResponseEntity<SuccessRes<List<SimpleDestinationRes>>> getCartOfUser(@PathVariable(name = "userId") UUID userId) {
 		return ResponseEntity.ok(SuccessRes.from(
 				shoppingCartService.getCartData(userId, OwnerType.USER)));
 	}
@@ -100,7 +100,7 @@ public class ShoppingCartController {
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
-	public ResponseEntity<SuccessRes<List<DestinationRes>>> getCartOfTeam(@PathVariable(name = "teamId") UUID teamId) {
+	public ResponseEntity<SuccessRes<List<SimpleDestinationRes>>> getCartOfTeam(@PathVariable(name = "teamId") UUID teamId) {
 		return ResponseEntity.ok(SuccessRes.from(
 				shoppingCartService.getCartData(teamId, OwnerType.TEAM)));
 	}

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/success/SuccessType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/success/SuccessType.java
@@ -23,8 +23,8 @@ public enum SuccessType {
     TAG_CREATED(HttpStatus.CREATED, "새로운 태그 등록을 성공하였습니다."),
     DESTINATION_CREATED(HttpStatus.CREATED,"새로운 여행지 등록을 성공하였습니다."),
     USER_CREATED(HttpStatus.CREATED, "사용자 회원가입을 성공하였습니다."),
-    FOLLOW_SUCCESS(HttpStatus.CREATED, "팔로우를 성공하였습니다.");
-
+    FOLLOW_SUCCESS(HttpStatus.CREATED, "팔로우를 성공하였습니다."),
+    CUSTOM_TAG_CREATED(HttpStatus.CREATED, "새로운 커스텀 태그 등록을 성공하였습니다.");
     private final HttpStatus status;
     private final String message;
 


### PR DESCRIPTION
## 작업 동기 및 이슈
- #94 

## 추가 및 변경사항
- CusotmTag 작성함에 따른 프론트앤드 요구사항 대로 응답포맷 수정
- CustomTag document 작성 및 controller, service , repository 작성

## 테스트 결과

### 여행지 전체 조회시 응답 (커스텀 태그 없는 경우)
<img width="1236" alt="스크린샷 2025-04-29 오후 6 43 27" src="https://github.com/user-attachments/assets/e063e980-26ce-4dea-ba60-ba4a0f7db793" />

### 여행지 상세 조회시 응답 
<img width="1163" alt="스크린샷 2025-04-29 오후 6 44 33" src="https://github.com/user-attachments/assets/fc6ef3ff-8359-47c8-8bfd-b0d90b3cc01b" />

### 여행지 태그 생성시 카운트 반영 및 mongoDB 반영 확인
<img width="870" alt="스크린샷 2025-04-29 오후 6 46 50" src="https://github.com/user-attachments/assets/a5a0b0ce-c47e-4c02-94c2-34fdf013953d" />
<img width="741" alt="스크린샷 2025-04-29 오후 6 48 33" src="https://github.com/user-attachments/assets/42f95878-0859-4fec-8e3d-b2ed404d01cf" />

### 유저 장바구니 조회
<img width="1374" alt="스크린샷 2025-04-29 오후 6 53 37" src="https://github.com/user-attachments/assets/ee61b887-f2aa-4ae3-932c-3a65991a22f0" />

### 유저 스크랩 조회
<img width="1416" alt="스크린샷 2025-04-29 오후 6 52 14" src="https://github.com/user-attachments/assets/8378fb7a-6e37-4ffe-920d-7a794148721b" />

### 여행지 상세 조회시 상위 3개의 커스텀 태그 포함된 것 확인
<img width="912" alt="스크린샷 2025-04-29 오후 6 48 57" src="https://github.com/user-attachments/assets/cfaa280f-f9da-425e-a4d7-6cd7d83ef434" />

## 📌 기타
- 여행지 상세 보기 응답 포맷에 상위 리뷰 2개 추가해야 하는데 리뷰 도메인 기능 개발할 때 수정하겠습니다.
- scrap, shoppingCart , destination  api 응답포맷 전부 확인했는데 잘 반영되었습니다.
