### PR TITLE
Feature: 프론트앤드 요구사항 반영 및 응답 포맷 수정(Team 기능)

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/TlogApplication.java
+++ b/tlog-was/src/main/java/com/se/Tlog/TlogApplication.java
@@ -4,11 +4,13 @@ import com.se.Tlog.config.rabbitmq.RabbitMqChatProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
 @SpringBootApplication
 @EnableConfigurationProperties(RabbitMqChatProperties.class)
 @EnableMongoAuditing
+@EnableJpaAuditing
 public class TlogApplication {
 
 	public static void main(String[] args) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/domain/Review.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/domain/Review.java
@@ -3,11 +3,13 @@ package com.se.Tlog.domain.Review.domain;
 
 import com.se.Tlog.domain.Review.controller.dto.ReviewCreateDto;
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
@@ -16,6 +18,7 @@ import java.util.List;
 @Document(collection = "reviews")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Review {
 
 	@Id

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
@@ -4,16 +4,17 @@ import java.util.List;
 import java.util.UUID;
 
 import com.se.Tlog.domain.ApplicationService;
-import com.se.Tlog.domain.Team.controller.dto.CreateTeamRequestDto;
-import com.se.Tlog.domain.Team.controller.dto.TeamResponseDto;
-import com.se.Tlog.domain.Team.controller.dto.TeamUserRequestDto;
+import com.se.Tlog.domain.Team.controller.dto.*;
 import com.se.Tlog.domain.Team.domain.Team;
 import com.se.Tlog.domain.Team.domain.TeamDomainService;
 import com.se.Tlog.domain.Team.domain.repository.TeamRepositoryService;
 import com.se.Tlog.domain.Team.repository.jpa.TeamRepository;
 import com.se.Tlog.domain.Team.repository.jpa.TeamUserRepository;
+import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
 import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.domain.Wishlist.application.ShoppingCartService;
+import com.se.Tlog.domain.Wishlist.domain.OwnerType;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 
@@ -28,6 +29,8 @@ public class TeamService {
 	
 	private final TeamDomainService teamDomainService;
 	private final TeamRepositoryService repoService;
+
+	private final ShoppingCartService shoppingCartService;
 	
 	public UUID createTeam(CreateTeamRequestDto request) {
 		if (request.name() == null)
@@ -49,13 +52,10 @@ public class TeamService {
 
 		return teamUserRepository.findByUser_Id(userId)
 				.stream().map(teamUser -> {
-					List<UUID> members = teamUserRepository.findByTeam_Id(teamUser.getTeam().getId())
+					List<UUID> members = teamUserRepository.findWithUserByTeamId(teamUser.getTeam().getId())
 							.stream().map(teamUserByTeam -> teamUserByTeam.getUser().getId()).toList();
-					return new TeamResponseDto(
-							teamUser.getTeam().getId(),
-							teamUser.getTeam().getName(),
-							members);
-					})
+					return TeamResponseDto.from(teamUser.getTeam(), members);
+				})
 				.toList();
 	}
 	
@@ -67,7 +67,8 @@ public class TeamService {
 		teamRepository.deleteById(teamId);
 	}
 	
-	public void inviteUser(TeamUserRequestDto request) {
+	/*public void inviteUser(TeamUserRequestDto request) {
+
 		if (!teamRepository.existsById(request.teamId()))
 			throw new CustomException(ErrorType.TEAM_NOT_FOUND);
 		if (!userRepository.existsById(request.userId()))
@@ -76,27 +77,36 @@ public class TeamService {
 		Team team = teamRepository.findById(request.teamId()).get();
 		User user = userRepository.findById(request.userId()).get();
 		teamDomainService.inviteUser(team, user);
-	}
+	}*/
 	
-	public void joinTeam(TeamUserRequestDto request) {
-		if (!teamRepository.existsById(request.teamId()))
-			throw new CustomException(ErrorType.TEAM_NOT_FOUND);
-		if (!userRepository.existsById(request.userId()))
-			throw new CustomException(ErrorType.USER_NOT_FOUND);
-		
-		Team team = teamRepository.findById(request.teamId()).get();
-		User user = userRepository.findById(request.userId()).get();
+	public void joinTeamByInviteCode(TeamUserRequestDto request) {
+		Team team = teamRepository.findByInviteCode(request.inviteCode())
+				.orElseThrow(() -> new CustomException(ErrorType.TEAM_NOT_FOUND));
+		User user = userRepository.findById(request.userId())
+				.orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
+
 		team.addUser(user, repoService);
 	}
 	
 	public void leaveTeam(UUID teamId, UUID userId) {
-		if (!teamRepository.existsById(teamId))
-			throw new CustomException(ErrorType.TEAM_NOT_FOUND);
-		if (!userRepository.existsById(userId))
-			throw new CustomException(ErrorType.USER_NOT_FOUND);
-		
-		Team team = teamRepository.findById(teamId).get();
-		User user = userRepository.findById(userId).get();
+		Team team = teamRepository.findById(teamId)
+				.orElseThrow(() -> new CustomException(ErrorType.TEAM_NOT_FOUND));
+		User user = userRepository.findById(userId)
+				.orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
+
 		team.deleteUser(user, repoService);
+	}
+
+	public TeamDetailDto getTeamDetails(UUID teamId) {
+		Team team = teamRepository.findById(teamId)
+				.orElseThrow(() -> new CustomException(ErrorType.TEAM_NOT_FOUND));
+		List<TeamMemberDto> memberDtoList = teamUserRepository.findWithUserByTeamId(team.getId())
+				.stream().map(teamUser -> {
+					return TeamMemberDto.from(teamUser.getUser());
+				}).toList();
+
+		List<SimpleDestinationRes> wishList = shoppingCartService.getCartData(team.getId(), OwnerType.TEAM);
+
+		return TeamDetailDto.from(team, memberDtoList, wishList);
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/TeamController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/TeamController.java
@@ -70,7 +70,30 @@ public class TeamController {
 		return ResponseEntity.ok(SuccessRes.from(
 				teamService.getTeamOfUser(userId)));
 	}
-	
+
+	@GetMapping("/{teamId}/details")
+	@Operation(
+			summary = "특정 팀 상세 정보 조회",
+			description = "특정 팀의 상세 정보와 장바구니 여행지 목록을 함께 반환합니다.",
+			tags = {"팀 관리"},
+			security = @SecurityRequirement(
+					name = "JwtAuthScheme",
+					scopes = {"scope1", "scope2"}
+			),
+			parameters = {
+					@Parameter(name = "teamId", description = "조회할 팀의 UUID", required = true)
+			},
+			responses = {
+					@ApiResponse(responseCode = "200", description = "팀 상세 정보 반환 성공"),
+					@ApiResponse(responseCode = "404", description = "존재하지 않는 팀입니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류")
+			}
+	)
+	public ResponseEntity<?> getTeamDetails(@PathVariable UUID teamId) {
+		return ResponseEntity.
+				ok(SuccessRes.from(teamService.getTeamDetails(teamId)));
+	}
+
 	@DeleteMapping("/{teamId}")
 	@Operation (
 			summary = "팀 삭제",
@@ -91,8 +114,8 @@ public class TeamController {
 		teamService.deleteTeam(teamId);
 		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
 	}
-	
-	@PostMapping("/member/invite")
+
+	/*@PostMapping("/member/invite")
 	@Operation (
 			summary = "팀원 초대",
     		description = "새로운 팀원을 초대합니다.",
@@ -108,9 +131,9 @@ public class TeamController {
 	public ResponseEntity<SuccessRes<?>> inviteUser(@RequestBody TeamUserRequestDto request) {
 		teamService.inviteUser(request);
 		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
-	}
-	
-	@PostMapping("/member")
+	}*/
+
+	@PostMapping("/join")
 	@Operation (
 			summary = "팀원 가입",
     		description = "특정 유저를 팀에 추가합니다.",
@@ -124,10 +147,10 @@ public class TeamController {
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
 	public ResponseEntity<SuccessRes<?>> addUser(@RequestBody TeamUserRequestDto request) {
-		teamService.joinTeam(request);
+		teamService.joinTeamByInviteCode(request);
 		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
 	}
-	
+
 	@DeleteMapping("/member/{teamId}/{userId}")
 	@Operation (
 			summary = "팀원 삭제",

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
@@ -1,0 +1,31 @@
+package com.se.Tlog.domain.Team.controller.dto;
+
+import com.se.Tlog.domain.Team.domain.Team;
+import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public record TeamDetailDto(
+        UUID teamId,
+        String teamName,
+        //String teamTBTI,
+        long inviteCode,
+        LocalDate startDate,
+        LocalDate endDate,
+        List<TeamMemberDto> members,
+        List<SimpleDestinationRes> wishlist
+) {
+    public static TeamDetailDto from(Team team, List<TeamMemberDto> members, List<SimpleDestinationRes> wishlist) {
+        return new TeamDetailDto(
+                team.getId(),
+                team.getName(),
+                team.getInviteCode(),
+                team.getCreatedAt().toLocalDate(),
+                LocalDate.now(),
+                members,
+                wishlist
+        );
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamMemberDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamMemberDto.java
@@ -1,0 +1,18 @@
+package com.se.Tlog.domain.Team.controller.dto;
+
+import com.se.Tlog.domain.User.domain.User;
+
+import java.util.UUID;
+
+public record TeamMemberDto(
+        UUID userId,
+        String name
+        // profile, tbti
+) {
+    public static TeamMemberDto from(User user) {
+        return new TeamMemberDto(
+                user.getId(),
+                user.getName()
+        );
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamResponseDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamResponseDto.java
@@ -3,13 +3,20 @@ package com.se.Tlog.domain.Team.controller.dto;
 import java.util.List;
 import java.util.UUID;
 
+import com.se.Tlog.domain.Team.domain.Team;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "팀 정보를 표시하는 DTO입니다.")
 public record TeamResponseDto(
 		UUID teamId,
 		String teamName,
-		List<UUID> memberIdList
+		List<UUID> memberIdList //유저들 id + profile 예정
 		) {
-
+	public static TeamResponseDto from(Team team, List<UUID> memberIdList) {
+		return new TeamResponseDto(
+				team.getId(),
+				team.getName(),
+				memberIdList
+		);
+	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamUserRequestDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamUserRequestDto.java
@@ -6,8 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "기본적인 팀원 관리 요청에 사용되는 DTO. 팀 초대, 팀원으로 추가, 팀 방출에 사용됩니다.")
 public record TeamUserRequestDto(
-		@Schema(description = "처리할 팀의 id")
-		UUID teamId,
+		@Schema(description = "처리할 팀의 code")
+		long inviteCode,
 		
 		@Schema(description = "처리할 유저의 id")
 		UUID userId

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/Team.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/Team.java
@@ -1,5 +1,6 @@
 package com.se.Tlog.domain.Team.domain;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import com.se.Tlog.domain.Team.domain.repository.TeamRepositoryService;
@@ -7,20 +8,20 @@ import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Slf4j
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 public class Team {
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)
@@ -31,6 +32,10 @@ public class Team {
 	private String name;
 	
 	// private Tbti tbti;
+
+	@CreatedDate
+	@Column(updatable = false)
+	private LocalDateTime createdAt;
 	
 	private Team(String name, Long inviteCode) {
 		this.name = name;

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/TeamRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/TeamRepository.java
@@ -1,5 +1,6 @@
 package com.se.Tlog.domain.Team.repository.jpa;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +10,7 @@ import com.se.Tlog.domain.Team.domain.Team;
 
 @Repository
 public interface TeamRepository extends JpaRepository<Team, UUID> {
-	public boolean existsByInviteCode(long InviteCode);
+	boolean existsByInviteCode(long InviteCode);
+
+	Optional<Team> findByInviteCode(long inviteCode);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/TeamUserRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/TeamUserRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.se.Tlog.domain.Team.repository.jpa.entity.TeamUserJpaEntity;
@@ -18,6 +20,8 @@ public interface TeamUserRepository extends JpaRepository<TeamUserJpaEntity, Lon
 	@Transactional
 	public void deleteByTeam_Id(UUID teamId);
 	public List<TeamUserJpaEntity> findByUser_Id(UUID userId);
-	public List<TeamUserJpaEntity> findByTeam_Id(UUID teamId);
 	public long countByTeam_Id(UUID teamId);
+
+	@Query("select tu from TeamUserJpaEntity tu join fetch tu.user where tu.team.id = :teamId")
+	List<TeamUserJpaEntity> findWithUserByTeamId(@Param("teamId") UUID teamId);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/entity/TeamUserJpaEntity.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/entity/TeamUserJpaEntity.java
@@ -5,19 +5,14 @@ import java.util.UUID;
 import com.se.Tlog.domain.Team.domain.Team;
 import com.se.Tlog.domain.User.domain.User;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+
+import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @Table(
@@ -31,12 +26,12 @@ public class TeamUserJpaEntity {
 	@GeneratedValue(strategy = GenerationType.UUID)
 	private UUID id;
 	
-	@ManyToOne
+	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "team_id")
 	@NonNull
 	private Team team;
 	
-	@ManyToOne
+	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "user_id")
 	@NonNull
 	private User user;


### PR DESCRIPTION
## 작업 동기 및 이슈
- #98 

## 추가 및 변경사항
- 팀에서 팀원을 초대하는 구조에서 사용자들이 팀 코드를 입력하여 팀에 들어가는 코드로 수정
- 팀 상세 조회 코드 작성 (프론트앤드 화면대로 응답포맷 수정) -> 아직 사용자, 팀 TBTI 와 사용자 프로필 구현되지 않아 추후 반영 예정
- TeamService 에서 데이터 확인하고 받아오는 과정에서 db 2번 접근하는 코드를 db 한 번 접근하는 코드로 수정
## 테스트 결과

### 팀 상세 조회시 응답 포맷

<img width="907" alt="스크린샷 2025-05-01 오후 5 15 59" src="https://github.com/user-attachments/assets/93305ddc-1a2b-488c-b57d-d57d895596e8" />


## 📌 기타
- 팀 생성,조회,상세조회, 팀원 가입 api 이상 없고 여행지 장바구니(팀) 도 잘 됐습니다!
- 팀 조회 할 때 figma에는 사용자들의 프로필도 나오는데 추후 사용자 프로필을 넣는다면 응답포맷에 반영해야 할 것 같습니다.(팀장도 표시가 되어야 하는지 모르겠는데 프론트앤드에 추후 물어봐야 할 것 같습니다)
- 팀 상세 조회에서는 팀,개인 TBTI 와 팀원들 프로필도 표시되어야 할 것 같습니다!