### PR TITLE
Feature: 팀 정보에 팀장 정보 추가

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
@@ -38,11 +38,15 @@ public class TeamService {
 		if (!userRepository.existsById(request.creator()))
 			throw new CustomException(ErrorType.USER_NOT_FOUND);
 
-		Team newTeam = teamRepository.save(
-				Team.create(
-						request.name(),
-						repoService.makeInviteCode()));
-		newTeam.addUser(userRepository.findById(request.creator()).get(), repoService);
+		Team newTeam = Team.create(request.name(), repoService.makeInviteCode());
+		teamRepository.save(newTeam);
+		
+		// Team의 id가 생성된 후에야 초기화 작업이 가능함.
+		// 그러나 Team.create 후에 별도로 다시 initialize를 해야 하는 구조는 적절하지 않음!
+		// (초기화를 까먹는 휴먼 에러에 취약한 점 등)
+		teamDomainService.initializeTeam(
+		        newTeam, 
+		        userRepository.findById(request.creator()).get());
 		return newTeam.getId();
 	}
 	

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
@@ -1,5 +1,6 @@
 package com.se.Tlog.domain.Team.application;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -10,6 +11,7 @@ import com.se.Tlog.domain.Team.domain.TeamDomainService;
 import com.se.Tlog.domain.Team.domain.repository.TeamRepositoryService;
 import com.se.Tlog.domain.Team.repository.jpa.TeamRepository;
 import com.se.Tlog.domain.Team.repository.jpa.TeamUserRepository;
+import com.se.Tlog.domain.Team.repository.jpa.entity.TeamUserJpaEntity;
 import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
 import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
@@ -56,9 +58,14 @@ public class TeamService {
 
 		return teamUserRepository.findByUser_Id(userId)
 				.stream().map(teamUser -> {
-					List<UUID> members = teamUserRepository.findWithUserByTeamId(teamUser.getTeam().getId())
-							.stream().map(teamUserByTeam -> teamUserByTeam.getUser().getId()).toList();
-					return TeamResponseDto.from(teamUser.getTeam(), members);
+				    UUID teamLeader = null;
+				    List<UUID> members = new ArrayList<UUID>();
+				    for (TeamUserJpaEntity teamUserInTeam : teamUserRepository.findWithUserByTeamId(teamUser.getTeam().getId())) {
+				        if (teamUserInTeam.isLeader())
+                            teamLeader = teamUserInTeam.getUser().getId();
+                        members.add(teamUserInTeam.getUser().getId());
+				    }
+					return TeamResponseDto.from(teamUser.getTeam(), teamLeader, members);
 				})
 				.toList();
 	}
@@ -105,9 +112,9 @@ public class TeamService {
 		Team team = teamRepository.findById(teamId)
 				.orElseThrow(() -> new CustomException(ErrorType.TEAM_NOT_FOUND));
 		List<TeamMemberDto> memberDtoList = teamUserRepository.findWithUserByTeamId(team.getId())
-				.stream().map(teamUser -> {
-					return TeamMemberDto.from(teamUser.getUser());
-				}).toList();
+				.stream().map(teamUser -> 
+				        TeamMemberDto.from(teamUser.getUser(), teamUser.isLeader())
+		        ).toList();
 
 		List<SimpleDestinationRes> wishList = shoppingCartService.getCartData(team.getId(), OwnerType.TEAM);
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
@@ -56,7 +56,7 @@ public class TeamService {
 		if (!userRepository.existsById(userId))
 			throw new CustomException(ErrorType.USER_NOT_FOUND);
 
-		return teamUserRepository.findByUser_Id(userId)
+		return teamUserRepository.findWithTeamByUserId(userId)
 				.stream().map(teamUser -> {
 				    UUID teamLeader = null;
 				    List<UUID> members = new ArrayList<UUID>();

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
@@ -58,14 +58,14 @@ public class TeamService {
 
 		return teamUserRepository.findWithTeamByUserId(userId)
 				.stream().map(teamUser -> {
-				    UUID teamLeader = null;
+				    String teamLeaderName = null;
 				    List<UUID> members = new ArrayList<UUID>();
 				    for (TeamUserJpaEntity teamUserInTeam : teamUserRepository.findWithUserByTeamId(teamUser.getTeam().getId())) {
 				        if (teamUserInTeam.isLeader())
-                            teamLeader = teamUserInTeam.getUser().getId();
+				            teamLeaderName = teamUserInTeam.getUser().getName();
                         members.add(teamUserInTeam.getUser().getId());
 				    }
-					return TeamResponseDto.from(teamUser.getTeam(), teamLeader, members);
+					return TeamResponseDto.from(teamUser.getTeam(), teamLeaderName, members);
 				})
 				.toList();
 	}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamMemberDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamMemberDto.java
@@ -6,13 +6,15 @@ import java.util.UUID;
 
 public record TeamMemberDto(
         UUID userId,
-        String name
+        String name,
+        boolean isLeader
         // profile, tbti
 ) {
-    public static TeamMemberDto from(User user) {
+    public static TeamMemberDto from(User user, boolean isLeader) {
         return new TeamMemberDto(
                 user.getId(),
-                user.getName()
+                user.getName(),
+                isLeader
         );
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamResponseDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamResponseDto.java
@@ -10,12 +10,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record TeamResponseDto(
 		UUID teamId,
 		String teamName,
+		UUID teamLeaderId,
 		List<UUID> memberIdList //유저들 id + profile 예정
 		) {
-	public static TeamResponseDto from(Team team, List<UUID> memberIdList) {
+	public static TeamResponseDto from(Team team, UUID teamLeader, List<UUID> memberIdList) {
 		return new TeamResponseDto(
 				team.getId(),
 				team.getName(),
+				teamLeader,
 				memberIdList
 		);
 	}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamResponseDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamResponseDto.java
@@ -10,14 +10,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record TeamResponseDto(
 		UUID teamId,
 		String teamName,
-		UUID teamLeaderId,
+		String teamLeaderName,
 		List<UUID> memberIdList //유저들 id + profile 예정
 		) {
-	public static TeamResponseDto from(Team team, UUID teamLeader, List<UUID> memberIdList) {
+	public static TeamResponseDto from(Team team, String teamLeaderName, List<UUID> memberIdList) {
 		return new TeamResponseDto(
 				team.getId(),
 				team.getName(),
-				teamLeader,
+				teamLeaderName,
 				memberIdList
 		);
 	}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/Team.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/Team.java
@@ -58,10 +58,17 @@ public class Team {
 		if (repoService.isExistInTeam(this.getId(), user.getId()))
 			throw new CustomException(ErrorType.ALREADY_EXIST_IN_TEAM);
 		
-		repoService.addUserToTeam(id, user.getId());
+		repoService.addUserToTeam(this.id, user.getId());
 		// 기타 팀원 추가시 처리내용
 		
 		log.info("팀원을 팀 " + this.name + "에 추가합니다. : " + user.getName());
+	}
+	
+	public void setLeader(User user, TeamRepositoryService repoService) {
+	    if (!repoService.isExistInTeam(this.id, user.getId()))
+            throw new CustomException(ErrorType.TEAM_USER_NOT_FOUND);
+	    
+	    repoService.setLeader(this.id, user.getId());
 	}
 	
 	public void deleteUser(User user, TeamRepositoryService repoService) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/Team.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/Team.java
@@ -76,6 +76,8 @@ public class Team {
 			throw new CustomException(ErrorType.TEAM_USER_NOT_FOUND);
 		if (repoService.countMemberInTeam(id) == 1)
 			throw new CustomException(ErrorType.TEAM_CANNOT_BE_ORPHAN);
+		if (repoService.isLeader(id, user.getId()))
+		    throw new CustomException(ErrorType.CANNOT_REMOVE_TEAM_LEADER);
 		
 		repoService.deleteUserInTeam(this.id, user.getId());
 		// 기타 팀원 삭제 후 처리내용

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/TeamDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/TeamDomainService.java
@@ -21,6 +21,10 @@ public class TeamDomainService {
 	private final TeamRepositoryService repoService;
 	private final WishlistService wishlistService;
 	
+	public void initializeTeam(Team rawTeam, User teamLeader) {
+	    rawTeam.addUser(teamLeader, repoService);
+	}
+	
 	public void deleteTeamData(Team team) {
 		// 팀 삭제시 각종 처리...
 		wishlistService.deleteWishlist(new WishlistOwnerDto(OwnerType.TEAM, team.getId()));

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/TeamDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/TeamDomainService.java
@@ -23,6 +23,7 @@ public class TeamDomainService {
 	
 	public void initializeTeam(Team rawTeam, User teamLeader) {
 	    rawTeam.addUser(teamLeader, repoService);
+	    rawTeam.setLeader(teamLeader, repoService);
 	}
 	
 	public void deleteTeamData(Team team) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/repository/TeamRepositoryService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/repository/TeamRepositoryService.java
@@ -6,6 +6,7 @@ public interface TeamRepositoryService {
 	public boolean isExistInTeam(UUID teamId, UUID userId);
 	public long countMemberInTeam(UUID teamId);
 	public void addUserToTeam(UUID teamId, UUID userId);
+    public void setLeader(UUID teamId, UUID userId);
 	public void deleteUserInTeam(UUID teamId, UUID userId);
 	public void deleteTeamUsers(UUID teamId);
 	public long makeInviteCode();

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/repository/TeamRepositoryService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/repository/TeamRepositoryService.java
@@ -7,6 +7,7 @@ public interface TeamRepositoryService {
 	public long countMemberInTeam(UUID teamId);
 	public void addUserToTeam(UUID teamId, UUID userId);
     public void setLeader(UUID teamId, UUID userId);
+    public boolean isLeader(UUID teamId, UUID userId);
 	public void deleteUserInTeam(UUID teamId, UUID userId);
 	public void deleteTeamUsers(UUID teamId);
 	public long makeInviteCode();

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/TeamRepositoryServiceImplement.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/TeamRepositoryServiceImplement.java
@@ -42,6 +42,22 @@ public class TeamRepositoryServiceImplement implements TeamRepositoryService {
 				.build();
 		teamUserRepository.save(teamUser);
 	}
+	
+	@Override
+	public void setLeader(UUID teamId, UUID userId) {
+	    TeamUserJpaEntity oldLeader = teamUserRepository.findByTeam_IdAndIsLeaderTrue(teamId).orElse(null);
+        TeamUserJpaEntity newLeader = teamUserRepository.findByTeam_IdAndUser_Id(teamId, userId)
+                .orElseThrow(() -> new CustomException(ErrorType.TEAM_USER_NOT_FOUND));
+   
+        if (oldLeader != null) {
+            if (oldLeader.getUser().getId() == userId)
+    	        return;
+            oldLeader.setLeader(false);
+            teamUserRepository.save(oldLeader);
+	    }
+        newLeader.setLeader(true);
+        teamUserRepository.save(newLeader);
+	}
 
 	@Override
 	public void deleteUserInTeam(UUID teamId, UUID userId) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/TeamRepositoryServiceImplement.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/TeamRepositoryServiceImplement.java
@@ -59,6 +59,13 @@ public class TeamRepositoryServiceImplement implements TeamRepositoryService {
         teamUserRepository.save(newLeader);
 	}
 
+    @Override
+    public boolean isLeader(UUID teamId, UUID userId) {
+        TeamUserJpaEntity teamUser = teamUserRepository.findByTeam_IdAndUser_Id(teamId, userId)
+                .orElseThrow(() -> new CustomException(ErrorType.TEAM_USER_NOT_FOUND));
+        return teamUser.isLeader();
+    }
+
 	@Override
 	public void deleteUserInTeam(UUID teamId, UUID userId) {
 		teamUserRepository.deleteByTeam_IdAndUser_Id(teamId, userId);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/TeamUserRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/TeamUserRepository.java
@@ -1,6 +1,7 @@
 package com.se.Tlog.domain.Team.repository.jpa;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,6 +22,8 @@ public interface TeamUserRepository extends JpaRepository<TeamUserJpaEntity, Lon
 	public void deleteByTeam_Id(UUID teamId);
 	public List<TeamUserJpaEntity> findByUser_Id(UUID userId);
 	public long countByTeam_Id(UUID teamId);
+	Optional<TeamUserJpaEntity> findByTeam_IdAndUser_Id(UUID teamId, UUID userId);
+	Optional<TeamUserJpaEntity> findByTeam_IdAndIsLeaderTrue(UUID teamId);
 
 	@Query("select tu from TeamUserJpaEntity tu join fetch tu.user where tu.team.id = :teamId")
 	List<TeamUserJpaEntity> findWithUserByTeamId(@Param("teamId") UUID teamId);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/TeamUserRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/TeamUserRepository.java
@@ -20,10 +20,12 @@ public interface TeamUserRepository extends JpaRepository<TeamUserJpaEntity, Lon
 	public void deleteByTeam_IdAndUser_Id(UUID teamId, UUID userId);
 	@Transactional
 	public void deleteByTeam_Id(UUID teamId);
-	public List<TeamUserJpaEntity> findByUser_Id(UUID userId);
 	public long countByTeam_Id(UUID teamId);
 	Optional<TeamUserJpaEntity> findByTeam_IdAndUser_Id(UUID teamId, UUID userId);
 	Optional<TeamUserJpaEntity> findByTeam_IdAndIsLeaderTrue(UUID teamId);
+	
+	@Query("select tu from TeamUserJpaEntity tu join fetch tu.team where tu.user.id = :userId")
+    List<TeamUserJpaEntity> findWithTeamByUserId(@Param("userId") UUID userId);
 
 	@Query("select tu from TeamUserJpaEntity tu join fetch tu.user where tu.team.id = :teamId")
 	List<TeamUserJpaEntity> findWithUserByTeamId(@Param("teamId") UUID teamId);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/entity/TeamUserJpaEntity.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/entity/TeamUserJpaEntity.java
@@ -36,9 +36,16 @@ public class TeamUserJpaEntity {
 	@NonNull
 	private User user;
 	
+	private boolean isLeader;
+	
+	public void setLeader(boolean isLeader) {
+	    this.isLeader = isLeader;
+	}
+	
 	@Builder
-	public TeamUserJpaEntity(Team team, User user) {
+	public TeamUserJpaEntity(Team team, User user, boolean isLeader) {
 		this.team = team;
 		this.user = user;
+		this.isLeader = isLeader;
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -12,6 +12,7 @@ public enum ErrorType {
     CONTENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "Content 내용이 비어있습니다."),
     TEAM_NAME_NOT_FOUND(HttpStatus.BAD_REQUEST, "팀 이름이 비어있습니다."),
     TEAM_CANNOT_BE_ORPHAN(HttpStatus.BAD_REQUEST, "팀에 최소 1명 이상의 팀원이 필요합니다."),
+    CANNOT_REMOVE_TEAM_LEADER(HttpStatus.BAD_REQUEST, "팀장을 퇴출시킬 수 없습니다."),
     ROLE_MISMATCH(HttpStatus.BAD_REQUEST,"Role 값을 잘못 입력하였습니다."),
     INVALID_FIREBASE_TOKEN(HttpStatus.BAD_REQUEST,"클라이언트 FCM Token이 유효하지 않습니다!"),
     SCRAP_UNSUPPORTED_TO_TEAM(HttpStatus.BAD_REQUEST, "팀에는 스크랩 기능을 지원하지 않습니다!"),


### PR DESCRIPTION
## 작업 동기 및 이슈
- #100 

## 추가 및 변경사항
팀에는 팀장 정보도 포함됩니다.
### 1) DB 변경
- 팀원을 저장하는 TeamUser 엔티티(`TeamUserJpaEntity`)는 `isLeader` 필드를 함께 가집니다.
- 팀장을 반환하는 repository 쿼리가 추가되었습니다.
### 2) DTO 변경
- 팀 정보를 반환하는 DTO에 팀장 정보가 포함되었습니다.
- 기본 정보를 담는 `TeamResponseDto`의 사례 :
  팀 정보 내에 `teamLeaderId`가 추가되었습니다.
  <img src="https://github.com/user-attachments/assets/752b3fd4-1203-44a0-9ab8-8fa345e27622" width="450"/>
- 세부 정보를 담는 `TeamDetailDto`의 사례 :
  멤버 정보에 `isLeader`가 추가되었습니다.
  <img src="https://github.com/user-attachments/assets/10e207f2-436c-488d-8cf0-594fcc0d71d9" width="400"/>
### 3) 비즈니스 규칙 추가
- 팀을 생성한 사람은 팀장으로 등록됩니다.
- 팀장은 팀에서 퇴출이 불가합니다.
  <img src="https://github.com/user-attachments/assets/b998fea9-1a06-4fac-9402-b6dbe133a9e3"/>

## 테스트 결과
- 이상 무.
  반환 예시는 이전 문단을 참고해주세요!

## 📌 기타
