### PR TITLE
Refact : 여행지 추가 할 때 고정태그가 아닌 커스텀 태그를 담는 방식으로 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -14,6 +14,7 @@ import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
 
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
+import com.se.Tlog.global.util.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -29,6 +30,7 @@ public class DestinationService {
     private final DestinationRepository destinationRepository;
     private final CustomTagService customTagService;
     private final ReviewDomainService reviewDomainService;
+    private final RedisUtil redisUtil;
 
     public void createDestination(DestinationDto destinationDto) {
     	Destination.assertValidity(destinationDto.getName(), destinationRepoService);
@@ -49,6 +51,7 @@ public class DestinationService {
                 destinationRepoService);
         String destinationId = destinationRepository.save(destination).getId();
         customTagService.addCustomTag(destinationId, customTags);
+        redisUtil.pushDestinationIdToTaggingQueue(destinationId);
     }
 
     public Page<DestinationSummaryRes> getAllDestinations(Pageable pageable) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -10,7 +10,6 @@ import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.domain.TagCount;
 import com.se.Tlog.domain.Travel.domain.TagInfo;
 import com.se.Tlog.domain.Travel.domain.repository.DestinationRepositoryService;
-import com.se.Tlog.domain.Travel.domain.repository.TagRepositoryService;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
 
 import com.se.Tlog.global.exception.CustomException;
@@ -20,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @ApplicationService
@@ -27,20 +27,19 @@ import java.util.List;
 public class DestinationService {
     private final DestinationRepositoryService destinationRepoService;
     private final DestinationRepository destinationRepository;
-    private final TagRepositoryService tagRepoService;
     private final CustomTagService customTagService;
     private final ReviewDomainService reviewDomainService;
 
     public void createDestination(DestinationDto destinationDto) {
     	Destination.assertValidity(destinationDto.getName(), destinationRepoService);
-        List<TagInfo> tagInfoList = destinationDto.getTags().stream()
-                .map(tagIdDto -> TagInfo.create(tagIdDto.tagId(), tagIdDto.weight(),tagRepoService))
-                .toList();
+
+        List<String> customTags = destinationDto.getCustomTags();
+
         Destination destination = Destination.create(
         		destinationDto.getName(),
                 destinationDto.getLocation(),
                 destinationDto.getAddress(),
-                tagInfoList,
+                new ArrayList<>(),
                 destinationDto.getCity(),
                 destinationDto.getDistrict(),
                 destinationDto.isHasParking(),
@@ -48,7 +47,8 @@ public class DestinationService {
                 destinationDto.getDescription(),
                 destinationDto.getImageUrl(),
                 destinationRepoService);
-        destinationRepository.save(destination);
+        String destinationId = destinationRepository.save(destination).getId();
+        customTagService.addCustomTag(destinationId, customTags);
     }
 
     public Page<DestinationSummaryRes> getAllDestinations(Pageable pageable) {
@@ -72,5 +72,9 @@ public class DestinationService {
         List<DestinationReviewDto> top2Reviews = reviewDomainService.getTop2Reviews(destination.getId());
 
         return DestinationDetailsRes.from(destination, topTags, top2Reviews);
+    }
+
+    public void addFixedTagsToDestination(String destinationId,List<TagInfo> fixedTags) {
+        destinationRepoService.addFixedTags(destinationId, fixedTags);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationDto.java
@@ -33,7 +33,7 @@ public class DestinationDto {
     private String imageUrl;
     @Schema(description = "여행지 부가적인 설명입니다.")
     private String description;
-    @Schema(description = "여행지 고정 태그입니다.")
-    private List<TagIdDto> tags;
+    @Schema(description = "여행지 커스텀 태그입니다.")
+    private List<String> customTags;
     
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Destination.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Destination.java
@@ -98,4 +98,8 @@ public class Destination {
 	public void verify() {
 		// verified logic
 	}
+
+	public void addFixedTags(List<TagInfo> fixedTags) {
+		this.tags.addAll(fixedTags);
+	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/repository/DestinationRepositoryService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/repository/DestinationRepositoryService.java
@@ -1,5 +1,10 @@
 package com.se.Tlog.domain.Travel.domain.repository;
 
+import com.se.Tlog.domain.Travel.domain.TagInfo;
+
+import java.util.List;
+
 public interface DestinationRepositoryService {
-	public boolean exist(String name);
+	boolean exist(String name);
+	void addFixedTags(String id, List<TagInfo> fixedTags);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/DestinationRepositoryServiceImplement.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/DestinationRepositoryServiceImplement.java
@@ -1,5 +1,9 @@
 package com.se.Tlog.domain.Travel.repository;
 
+import com.se.Tlog.domain.Travel.domain.Destination;
+import com.se.Tlog.domain.Travel.domain.TagInfo;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
 import org.springframework.stereotype.Component;
 
 import com.se.Tlog.domain.Travel.domain.repository.DestinationRepositoryService;
@@ -7,13 +11,24 @@ import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class DestinationRepositoryServiceImplement implements DestinationRepositoryService {
-	private final DestinationRepository destinationRepository;
+    private final DestinationRepository destinationRepository;
 
-	@Override
-	public boolean exist(String name) {
-		return destinationRepository.existsByName(name);
-	}
+    @Override
+    public boolean exist(String name) {
+        return destinationRepository.existsByName(name);
+    }
+
+    @Override
+    public void addFixedTags(String id, List<TagInfo> fixedTags) {
+        Destination destination = destinationRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorType.DESTINATION_NOT_FOUND));
+
+        destination.addFixedTags(fixedTags);
+		destinationRepository.save(destination);
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisProperties.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisProperties.java
@@ -3,4 +3,5 @@ package com.se.Tlog.global.util.redis;
 public interface RedisProperties {
     String REFRESH_TOKEN_PREFIX = "refresh_token:";
     String ACCESS_TOKEN_PREFIX = "access_token:";
+    String PENDING_TAGGING_DESTINATION = "pending:tagging:destination";
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisUtil.java
@@ -6,6 +6,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
+import static com.se.Tlog.global.util.redis.RedisProperties.PENDING_TAGGING_DESTINATION;
 
 @Component
 @RequiredArgsConstructor
@@ -34,5 +35,11 @@ public class RedisUtil {
         }else{
             return false;
         }
+    }
+    public void pushDestinationIdToTaggingQueue(String destinationId) {
+        redisTemplate.opsForList().rightPush(PENDING_TAGGING_DESTINATION, destinationId);
+    }
+    public String popDestinationIdFromTaggingQueue() {
+        return (String) redisTemplate.opsForList().leftPop(PENDING_TAGGING_DESTINATION);
     }
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #104 

## 추가 및 변경사항
- 여행지 추가할 때 사용자로부터 커스텀태그를 받는 구조로 변경
- 고정태그 여행지에 추가하는 로직 추가 (추후 변경 가능성 있음)
- 추가 되는지 로컬에서 테스트 완료
- List 구조로 추가된 여행지 id 레디스에서 관리하는 방향으로 작성

## 테스트
### 여행지 추가시 id 레디스에 저장 
<img width="510" alt="스크린샷 2025-05-07 오후 6 22 14" src="https://github.com/user-attachments/assets/33c99d62-b2cd-41b7-8dfb-81f4c173309d" />


## 📌 기타
- 현재는 레디스에 저장되어 있기만 하지만 추후 어드민에서 레디스에 있는 여행지 id를 일정 개수를 pop하여 수동으로 태깅해서 일괄 처리하거나 AI 여행지 태깅 시스템과 연동하여 스케쥴러로 일정 기간마다 처리하는 방안으로 구현하는 것이 좋을 것 같습니다. 