### PR TITLE
Feature: 여행 코스 생성/조회 기능

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/application/CourseService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/application/CourseService.java
@@ -1,16 +1,23 @@
 package com.se.Tlog.domain.Course.application;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Course.controller.dto.CourseDateDto;
+import com.se.Tlog.domain.Course.controller.dto.CourseResponseDto;
 import com.se.Tlog.domain.Course.controller.dto.CreateCourseRequestDto;
 import com.se.Tlog.domain.Course.domain.Course;
 import com.se.Tlog.domain.Course.domain.CourseDate;
 import com.se.Tlog.domain.Course.domain.OwnerType;
 import com.se.Tlog.domain.Course.repository.mongo.CourseRepository;
 import com.se.Tlog.domain.Team.repository.jpa.TeamRepository;
+import com.se.Tlog.domain.Travel.application.CustomTagService;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+import com.se.Tlog.domain.Travel.domain.TagCount;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.global.exception.CustomException;
@@ -24,6 +31,7 @@ public class CourseService {
     private final UserRepository  userRepository;
     private final TeamRepository teamRepository;
     private final DestinationRepository destinationRepository;
+    private final CustomTagService customTagService; // Destination을 조회하는데 Custom Tag를 별도로 참조해야 하는 구조는 추후 수정 예정
     private final CourseRepository courseRepository;
     
     private void validateOwner(UUID ownerId, OwnerType ownerType) {
@@ -33,6 +41,59 @@ public class CourseService {
         if (ownerType == OwnerType.TEAM)
             if (!teamRepository.existsById(ownerId))
                 throw new CustomException(ErrorType.TEAM_NOT_FOUND);
+    }
+    
+    /**
+     * 코스와 관련된 모든 여행지 정보를 <여행지id, dto> 맵으로 반환합니다.
+     * @param courses
+     * @return
+     */
+    private Map<String, DestinationSummaryRes> getAllDestinationByCourse(List<Course> courses) {
+        return destinationRepository.findAllById(
+                // course에서 요구하는 모든 여행지 id 수집
+                courses.stream()
+                .flatMap(course -> course.getDates().stream())
+                .flatMap(date -> date.getDestinations().stream())
+                .distinct()
+                .collect(Collectors.toList())
+        ).stream()
+        .map(destination -> {
+            // 여행지 -> dto 변환
+            // 쿼리를 일일이 요청하게 되어, 성능 상 문제가 될 수 있음. (이 구조를 사용하는 모든 부분을 포함해 점검할 것!)
+            List<TagCount> topTags = customTagService.getTopTags(destination.getId(), 3);
+            return DestinationSummaryRes.from(destination, topTags);
+        }).collect(Collectors.toMap(DestinationSummaryRes::id, d -> d));
+    }
+    
+    /**
+     * 여행 코스 정보를 조회합니다.
+     * @param ownerId
+     * @param ownerType
+     * @return
+     */
+    public List<CourseResponseDto> getCourseList(UUID ownerId, OwnerType ownerType) {
+        validateOwner(ownerId, ownerType);
+        
+        // DB Read
+        List<Course> courses = courseRepository.findAllByOwnerIdAndOwnerType(ownerId, ownerType);
+        Map<String, DestinationSummaryRes> destinations = getAllDestinationByCourse(courses);
+        
+        // DB Document -> DTO
+        List<CourseResponseDto> courseResponses = new ArrayList<CourseResponseDto>();
+        for (Course course : courses) {
+            List<CourseDateDto> dateDtos = new ArrayList<CourseDateDto>();
+            for (CourseDate date : course.getDates()) {
+                // 날짜별로 여행지를 표시할 때, 지역 단위로 그룹화됩니다.
+                dateDtos.add(CourseDateDto.groupByCity(
+                        date.getDestinations()
+                        .stream()
+                        .map(destinations::get)
+                        .collect(Collectors.toList())));
+            }
+            courseResponses.add(CourseResponseDto.from(course, dateDtos));
+        }
+        
+        return courseResponses;
     }
     
     public String createCourse(UUID ownerId, OwnerType ownerType, CreateCourseRequestDto request) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/application/CourseService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/application/CourseService.java
@@ -1,0 +1,61 @@
+package com.se.Tlog.domain.Course.application;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Course.controller.dto.CreateCourseRequestDto;
+import com.se.Tlog.domain.Course.domain.Course;
+import com.se.Tlog.domain.Course.domain.CourseDate;
+import com.se.Tlog.domain.Course.domain.OwnerType;
+import com.se.Tlog.domain.Course.repository.mongo.CourseRepository;
+import com.se.Tlog.domain.Team.repository.jpa.TeamRepository;
+import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
+import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class CourseService {
+    private final UserRepository  userRepository;
+    private final TeamRepository teamRepository;
+    private final DestinationRepository destinationRepository;
+    private final CourseRepository courseRepository;
+    
+    private void validateOwner(UUID ownerId, OwnerType ownerType) {
+        if (ownerType == OwnerType.USER)
+            if (!userRepository.existsById(ownerId))
+                throw new CustomException(ErrorType.USER_NOT_FOUND);
+        if (ownerType == OwnerType.TEAM)
+            if (!teamRepository.existsById(ownerId))
+                throw new CustomException(ErrorType.TEAM_NOT_FOUND);
+    }
+    
+    public String createCourse(UUID ownerId, OwnerType ownerType, CreateCourseRequestDto request) {
+        validateOwner(ownerId, ownerType);
+        
+        // verify existence of all destinations
+        List<String> distinctDestinationIds = request.destinationIds().stream()
+            .flatMap(desList -> desList.stream())
+            .distinct()
+            .toList();
+        if (distinctDestinationIds.size()
+            != destinationRepository.findAllById(distinctDestinationIds).size())
+            throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);
+        
+        Course newCourse = Course.create( 
+                ownerId,
+                ownerType,
+                request.startDate(),
+                request.endDate(),
+                request.destinationIds().stream()
+                    .map(desList -> CourseDate.create(desList))
+                    .collect(Collectors.toList()));
+        courseRepository.save(newCourse);
+        return newCourse.getId();
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/controller/CourseController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/controller/CourseController.java
@@ -1,15 +1,18 @@
 package com.se.Tlog.domain.Course.controller;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.se.Tlog.domain.Course.application.CourseService;
+import com.se.Tlog.domain.Course.controller.dto.CourseResponseDto;
 import com.se.Tlog.domain.Course.controller.dto.CreateCourseRequestDto;
 import com.se.Tlog.domain.Course.domain.OwnerType;
 import com.se.Tlog.global.response.error.ErrorRes;
@@ -33,6 +36,21 @@ import lombok.RequiredArgsConstructor;
         scopes = {"scope1", "scope2"})
 public class CourseController {
     private final CourseService courseService;
+
+    @GetMapping("/user/{userId}")
+    @Operation (
+            summary = "유저 코스 리스트 조회",
+            description = "사용자가 보유한 코스들의 간략한 정보를 조회합니다.",
+            parameters = { @Parameter(name = "userId", description = "조회할 사용자의 id") },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공. 사용자의 코스 리스트를 반환합니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류. 조회에 실패했습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<List<CourseResponseDto>>> getCourseOfUser(@PathVariable(name = "userId") UUID userId) {
+        return ResponseEntity.ok(SuccessRes.from(
+                courseService.getCourseList(userId, OwnerType.USER)));
+    }
     
     @PostMapping("/user/{userId}")
     @Operation (
@@ -49,6 +67,21 @@ public class CourseController {
             @RequestBody CreateCourseRequestDto request) {
         return ResponseEntity.ok(SuccessRes.from(
                 courseService.createCourse(userId, OwnerType.USER, request)));
+    }
+    
+    @GetMapping("/team/{teamId}")
+    @Operation (
+            summary = "팀 코스 리스트 조회",
+            description = "팀이 보유한 코스들의 간략한 정보를 조회합니다.",
+            parameters = { @Parameter(name = "teamId", description = "조회할 팀의 id") },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공. 팀의 코스 리스트를 반환합니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류. 조회에 실패했습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<List<CourseResponseDto>>> getCourseOfTeam(@PathVariable(name = "teamId") UUID teamId) {
+        return ResponseEntity.ok(SuccessRes.from(
+                courseService.getCourseList(teamId, OwnerType.TEAM)));
     }
     
     @PostMapping("/team/{teamId}")

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/controller/CourseController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/controller/CourseController.java
@@ -1,0 +1,70 @@
+package com.se.Tlog.domain.Course.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.se.Tlog.domain.Course.application.CourseService;
+import com.se.Tlog.domain.Course.controller.dto.CreateCourseRequestDto;
+import com.se.Tlog.domain.Course.domain.OwnerType;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.success.SuccessRes;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/api/course")
+@RequiredArgsConstructor
+@Tag(name = "여행 코스")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
+public class CourseController {
+    private final CourseService courseService;
+    
+    @PostMapping("/user/{userId}")
+    @Operation (
+            summary = "유저 코스 생성",
+            description = "사용자의 새로운 코스를 생성합니다.",
+            parameters = { @Parameter(name = "userId", description = "코스를 생성할 사용자의 id") },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공. 생성된 여행 코스 id를 반환합니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류. 생성에 실패했습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<String>> createCourseOfUser(
+            @PathVariable(name = "userId") UUID userId,
+            @RequestBody CreateCourseRequestDto request) {
+        return ResponseEntity.ok(SuccessRes.from(
+                courseService.createCourse(userId, OwnerType.USER, request)));
+    }
+    
+    @PostMapping("/team/{teamId}")
+    @Operation (
+            summary = "팀 코스 생성",
+            description = "팀에 새로운 코스를 생성합니다.",
+            parameters = { @Parameter(name = "teamId", description = "코스를 생성할 팀의 id") },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공. 생성된 여행 코스 id를 반환합니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류. 생성에 실패했습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<String>> createCourseOfTeam(
+            @PathVariable(name = "teamId") UUID teamId,
+            @RequestBody CreateCourseRequestDto request) {
+        return ResponseEntity.ok(SuccessRes.from(
+                courseService.createCourse(teamId, OwnerType.TEAM, request)));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/controller/dto/CourseDateDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/controller/dto/CourseDateDto.java
@@ -1,0 +1,33 @@
+package com.se.Tlog.domain.Course.controller.dto;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "여행 코스 계획의 한 일자를 나타냅니다.")
+public record CourseDateDto(
+        // @Schema(description = "날짜의 번호를 나타냅니다. (n일차)")
+        // int day,
+        
+        @Schema(description = "이 날짜의 여행지. 특정 기준(지역별 등)으로 그룹화되어 있습니다.")
+        List<DestinationGroupDto> destinationGroups
+        ) {
+
+    public static CourseDateDto groupByCity(List<DestinationSummaryRes> rawDestinations) {
+        Map<String, DestinationGroupDto> groupDtoMap = new HashMap<String, DestinationGroupDto>();
+        
+        for (DestinationSummaryRes d : rawDestinations) {
+            String cityName = d.city();
+            if (!groupDtoMap.containsKey(cityName))
+                groupDtoMap.put(cityName, new DestinationGroupDto(cityName, new ArrayList<DestinationSummaryRes>()));
+            groupDtoMap.get(cityName).destinations().add(d);
+        }
+        
+        return new CourseDateDto(new ArrayList<DestinationGroupDto>(groupDtoMap.values()));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/controller/dto/CourseResponseDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/controller/dto/CourseResponseDto.java
@@ -1,0 +1,32 @@
+package com.se.Tlog.domain.Course.controller.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.se.Tlog.domain.Course.domain.Course;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "여행 코스 데이터입니다.")
+public record CourseResponseDto(
+        @Schema(description = "코스 데이터의 고유 id")
+        String id,
+        
+        @Schema(description = "코스의 1일차 날짜. ISO 8601(YYYY-MM-DD)규격을 따릅니다.")
+        LocalDate startDate,
+        
+        @Schema(description = "코스의 마지막 날짜. ISO 8601(YYYY-MM-DD)규격을 따릅니다.")
+        LocalDate endDate,
+    
+        @Schema(description = "날짜별 여행지 데이터")
+        List<CourseDateDto> dates
+        ) {
+    
+    public static CourseResponseDto from(Course course, List<CourseDateDto> courseDates) {
+        return new CourseResponseDto(
+                course.getId(), 
+                course.getStartDate(), 
+                course.getEndDate(),
+                courseDates);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/controller/dto/CreateCourseRequestDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/controller/dto/CreateCourseRequestDto.java
@@ -1,0 +1,17 @@
+package com.se.Tlog.domain.Course.controller.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "여행 코스 생성 데이터 규격입니다.")
+public record CreateCourseRequestDto(
+        LocalDate startDate,
+        LocalDate endDate,
+        
+        @Schema(description = "날짜별로 구분된 여행지 리스트입니다.")
+        List<List<String>> destinationIds
+        ) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/controller/dto/DestinationGroupDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/controller/dto/DestinationGroupDto.java
@@ -1,0 +1,16 @@
+package com.se.Tlog.domain.Course.controller.dto;
+
+import java.util.List;
+
+import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "특정 이름으로 그룹화된 여행지 집합을 나타냅니다.")
+public record DestinationGroupDto(
+        @Schema(description = "그룹 이름. 지역 기준으로 그룹화될 경우 지역 이름이 표시됩니다.")
+        String groupName,
+        
+        @Schema(description = "그룹에 속한 여행지 목록")
+        List<DestinationSummaryRes> destinations) {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/domain/Course.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/domain/Course.java
@@ -1,0 +1,84 @@
+package com.se.Tlog.domain.Course.domain;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "courses")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Course {
+    @Id
+    private String id;
+
+    private UUID ownerId;
+    private OwnerType ownerType;
+    
+    private LocalDate startDate;
+    private LocalDate endDate;
+    @Transient
+    private int duration;
+    
+    private List<CourseDate> dates;
+    
+    /**
+     * 특정 날짜(day일차)에 여행지를 추가합니다.
+     * <br/>day는 1부터 시작하는 날짜 값입니다.
+     * @param day 1부터 시작하는 날짜 값
+     * @param destinationId
+     */
+    public void addDestination(int day, String destinationId) {
+        if (day < 1 || duration < day)
+            throw new CustomException(ErrorType.INVALID_COURSE_DATE);
+        
+        while (dates.size() < day)
+            dates.add(CourseDate.create());
+        dates.get(day - 1).getDestinations().add(destinationId);
+    }
+    
+    private Course(
+            UUID ownerId, 
+            OwnerType ownerType, 
+            LocalDate startDate,
+            LocalDate endDate, 
+            List<CourseDate> dates) {
+        this.ownerId = ownerId;
+        this.ownerType = ownerType;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.duration = startDate.until(endDate).getDays() + 1;
+        if (dates == null)
+            dates = new ArrayList<CourseDate>();
+        this.dates = dates;
+    }
+    
+    public static Course create(
+            UUID ownerId,
+            OwnerType ownerType,
+            LocalDate startDate, 
+            LocalDate endDate,
+            List<CourseDate> dates) {
+        if (ownerType == null || ownerId == null)
+            throw new CustomException(ErrorType.INVALID_COURSE_OWNER);
+        if (startDate == null || endDate == null
+            || startDate.compareTo(endDate) > 0)
+            throw new CustomException(ErrorType.INVALID_COURSE_DURATION);
+        if (dates.size()
+            > startDate.until(endDate).getDays() + 1)
+            throw new CustomException(ErrorType.INVALID_COURSE_DATE);
+        
+        return new Course(ownerId, ownerType, startDate, endDate, dates);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/domain/CourseDate.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/domain/CourseDate.java
@@ -1,0 +1,30 @@
+package com.se.Tlog.domain.Course.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CourseDate {
+    // private int day;
+    
+    private List<String> destinations;
+    
+    private CourseDate(List<String> destinations) {
+        this.destinations = destinations;
+    }
+    
+    public static CourseDate create() {
+        return create(null);
+    }
+    
+    public static CourseDate create(List<String> destinations) {
+        if (destinations == null)
+            destinations = new ArrayList<String>();
+        return new CourseDate(destinations);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/domain/OwnerType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/domain/OwnerType.java
@@ -1,0 +1,6 @@
+package com.se.Tlog.domain.Course.domain;
+
+public enum OwnerType {
+	USER,
+	TEAM
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/repository/mongo/CourseRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/repository/mongo/CourseRepository.java
@@ -1,0 +1,10 @@
+package com.se.Tlog.domain.Course.repository.mongo;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import com.se.Tlog.domain.Course.domain.Course;
+
+@Repository
+public interface CourseRepository extends MongoRepository<Course, String> {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/repository/mongo/CourseRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/repository/mongo/CourseRepository.java
@@ -1,10 +1,15 @@
 package com.se.Tlog.domain.Course.repository.mongo;
 
+import java.util.List;
+import java.util.UUID;
+
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 import com.se.Tlog.domain.Course.domain.Course;
+import com.se.Tlog.domain.Course.domain.OwnerType;
 
 @Repository
 public interface CourseRepository extends MongoRepository<Course, String> {
+    List<Course> findAllByOwnerIdAndOwnerType(UUID ownerId, OwnerType ownerType);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -25,6 +25,11 @@ public enum ErrorType {
     // 보상 조건
     INVALID_REWARD_CRITERIA(HttpStatus.BAD_REQUEST,"제시된 보상 조건이 올바르지 않은 형식입니다."),
     NOT_FIT_ON_CRITERIA(HttpStatus.BAD_REQUEST, "사용자가 해당 보상 조건을 충족하지 않았습니다."),
+    
+    // 코스 관련 검증
+    INVALID_COURSE_OWNER(HttpStatus.BAD_REQUEST,"여행 코스 소유자가 잘못 기입되었습니다."),
+    INVALID_COURSE_DURATION(HttpStatus.BAD_REQUEST,"여행 코스의 기간이 잘못 기입되었습니다."),
+    INVALID_COURSE_DATE(HttpStatus.BAD_REQUEST,"여행지를 등록하려는 날짜가 여행 코스의 기간을 벗어납니다."),
 
     // 인증
     // 401


### PR DESCRIPTION
## 작업 동기 및 이슈
- #102 
- #103 
- 코스 조회시 city/지역별 그룹화 된 데이터 반환을 적용합니다.

## 추가 및 변경사항
### 1) Course 엔티티 추가
- 다음의 정보가 포함됩니다.
  - Owner 정보
  - 여행 기간
  - 날짜별 방문 여행지
    `CourseDate`라는 하위 데이터 타입으로 명시됩니다. (Embedded Document 형태로 Course에 포함됩니다.)
    _현재 단순히 여행지의 나열만 기록하고 있습니다._
### 2) MongoDB 내 courses 컬렉션 추가
- MongoDB에 courses 컬렉션이 도입되었습니다.
  - Course 엔티티와 연결됩니다.
- CourseRepository로 쿼리를 지원합니다.
### 3) Course 생성 기능
- 기초적인 여행 코스 데이터의 생성 기능입니다.
- 현재 소유자를 팀, 유저로 구분해 생성합니다.
  <img src="https://github.com/user-attachments/assets/1861cfa7-3676-4423-a099-75739d3f8e7d" width="300"/>
- 생성시 요구되는 DTO의 구조는 다음과 같습니다.
  <img src="https://github.com/user-attachments/assets/c8d4ccd6-e0b0-4897-a73d-98bf34954a03" width="300"/>
  - 여행 기간
  - 날짜별로 구분된 여행지 배열들
### 4) Course 조회 기능
- 여행 코스 데이터를 조회하는 기능입니다.
- 반환 데이터 형식은 다음과 같습니다.
  <img src="https://github.com/user-attachments/assets/92389d94-f30f-4f4a-8fb3-11dc4a4fc7d5" width="500"/>
  - 기본적인 여행 코스 정보(여행기간, 소유자 등)가 표시됩니다.
  - 여행지는 날짜 순서대로 배열로 표시됩니다.
    - 다시 각 날짜별로 여행지 그룹들이 배열로 표시됩니다.
      (여행지 그룹은 지역별로 구분된 묶음입니다.)

## 테스트 결과
- 기능 이상 무.
- 성능 상, 여행지가 매우 많을 경우 응답시간이 오래 걸리는 현상 확인.
  -> 원인 확인 및 쿼리 개선 작업 진행중에 있음!
       (정리되는대로 공유하겠습니다!)

## 📌 기타
- 쿼리 문제 보고:
  - 발생 원인은 이중 쿼리인 것으로 확인됩니다.
    ex) 여러 여행지 조회시, 여행지들을 일괄 조회하고
      다시 각 여행지별로 별도로 커스텀태그를 일일이 조회하는 문제
  <img src="https://github.com/user-attachments/assets/03699c76-fcbc-4bd0-9db7-e75b59622530"/>
