### PR TITLE
Fix: 여행지 및 팀원 조회시 N+1 쿼리 문제 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/application/CourseService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/application/CourseService.java
@@ -17,6 +17,7 @@ import com.se.Tlog.domain.Course.repository.mongo.CourseRepository;
 import com.se.Tlog.domain.Team.repository.jpa.TeamRepository;
 import com.se.Tlog.domain.Travel.application.CustomTagService;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.domain.TagCount;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
@@ -49,20 +50,24 @@ public class CourseService {
      * @return
      */
     private Map<String, DestinationSummaryRes> getAllDestinationByCourse(List<Course> courses) {
-        return destinationRepository.findAllById(
+        // DTO 변환을 위한 DB 로딩
+        List<Destination> destinations = destinationRepository.findAllById(
                 // course에서 요구하는 모든 여행지 id 수집
                 courses.stream()
                 .flatMap(course -> course.getDates().stream())
                 .flatMap(date -> date.getDestinations().stream())
                 .distinct()
-                .collect(Collectors.toList())
-        ).stream()
-        .map(destination -> {
-            // 여행지 -> dto 변환
-            // 쿼리를 일일이 요청하게 되어, 성능 상 문제가 될 수 있음. (이 구조를 사용하는 모든 부분을 포함해 점검할 것!)
-            List<TagCount> topTags = customTagService.getTopTags(destination.getId(), 3);
-            return DestinationSummaryRes.from(destination, topTags);
-        }).collect(Collectors.toMap(DestinationSummaryRes::id, d -> d));
+                .collect(Collectors.toList()));
+        Map<String, List<TagCount>> tagCountMap = customTagService.getAllTopTags(
+                destinations.stream().map(Destination::getId).toList(),
+                3);
+        
+        // 여행지 -> DTO 변환
+        return destinations.stream()
+                .map(destination -> DestinationSummaryRes.from(
+                        destination, 
+                        tagCountMap.get(destination.getId())))
+                .collect(Collectors.toMap(DestinationSummaryRes::id, d -> d));
     }
     
     /**

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
@@ -1,7 +1,9 @@
 package com.se.Tlog.domain.Team.application;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import com.se.Tlog.domain.ApplicationService;
@@ -56,18 +58,30 @@ public class TeamService {
 		if (!userRepository.existsById(userId))
 			throw new CustomException(ErrorType.USER_NOT_FOUND);
 
-		return teamUserRepository.findWithTeamByUserId(userId)
-				.stream().map(teamUser -> {
-				    String teamLeaderName = null;
-				    List<UUID> members = new ArrayList<UUID>();
-				    for (TeamUserJpaEntity teamUserInTeam : teamUserRepository.findWithUserByTeamId(teamUser.getTeam().getId())) {
-				        if (teamUserInTeam.isLeader())
-				            teamLeaderName = teamUserInTeam.getUser().getName();
-                        members.add(teamUserInTeam.getUser().getId());
-				    }
-					return TeamResponseDto.from(teamUser.getTeam(), teamLeaderName, members);
-				})
-				.toList();
+		// DB 일괄 조회
+		Map<UUID, List<TeamUserJpaEntity>> membersOfTeam = new HashMap<UUID, List<TeamUserJpaEntity>>();
+		for (TeamUserJpaEntity teamUser : teamUserRepository.findAllMembersByUserIds(userId)) {
+		    List<TeamUserJpaEntity> members = membersOfTeam.getOrDefault(
+		            teamUser.getTeam().getId(),
+		            new ArrayList<TeamUserJpaEntity>());
+            members.add(teamUser);
+	        membersOfTeam.putIfAbsent(
+	                teamUser.getTeam().getId(), 
+	                members);
+		}
+		
+		// DTO 변환
+		return membersOfTeam.values().stream().map(teamMembers -> {
+		    String teamLeaderName = null;
+		    List<UUID> members = new ArrayList<UUID>();
+		    for (TeamUserJpaEntity teamUserInTeam : teamMembers) {
+		        if (teamUserInTeam.isLeader())
+		            teamLeaderName = teamUserInTeam.getUser().getName();
+                members.add(teamUserInTeam.getUser().getId());
+		    }
+			return TeamResponseDto.from(teamMembers.get(0).getTeam(), teamLeaderName, members);
+		})
+		.toList();
 	}
 	
 	public void deleteTeam(UUID teamId) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/TeamUserRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/TeamUserRepository.java
@@ -29,4 +29,14 @@ public interface TeamUserRepository extends JpaRepository<TeamUserJpaEntity, Lon
 
 	@Query("select tu from TeamUserJpaEntity tu join fetch tu.user where tu.team.id = :teamId")
 	List<TeamUserJpaEntity> findWithUserByTeamId(@Param("teamId") UUID teamId);
+	
+	@Query("select tu "
+	+ "from TeamUserJpaEntity tu "
+	+ "join fetch tu.user "
+	+ "join fetch tu.team "
+	+ "where tu.team.id in "
+	    + "(select tu.team.id "
+	    + "from TeamUserJpaEntity tu "
+	    + "where tu.user.id = :userId)")
+    List<TeamUserJpaEntity> findAllMembersByUserIds(@Param("userId") UUID userId);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/CustomTagService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/CustomTagService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -29,5 +31,20 @@ public class CustomTagService {
                         .limit(limit)
                         .toList()
                 ).orElse(List.of());
+    }
+    
+    public Map<String, List<TagCount>> getAllTopTags(List<String> destinationIds, int limit) {
+        Map<String, List<TagCount>> tagCountMap = 
+                customTagDocumentRepository.findAllByDestinationIdIn(destinationIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        CustomTagDocument::getDestinationId,
+                        doc -> doc.getCustomTags().stream()
+                            .sorted(Comparator.comparing(TagCount::getCount).reversed())
+                            .limit(limit)
+                            .toList()));
+        for (String desId : destinationIds)
+            tagCountMap.putIfAbsent(desId, List.of());
+        return tagCountMap;
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @ApplicationService
 @RequiredArgsConstructor
@@ -56,13 +57,16 @@ public class DestinationService {
 
     public Page<DestinationSummaryRes> getAllDestinations(Pageable pageable) {
         Page<Destination> destinationPage = destinationRepository.findAllWithActiveTags(pageable);
+        Map<String, List<TagCount>> tagCountMap = customTagService.getAllTopTags(
+                destinationPage.map(Destination::getId).toList(),
+                3);
 
         List<DestinationSummaryRes> destinationResList = destinationPage
                 .stream()
-                .map(destination -> {
-                            List<TagCount> topTags = customTagService.getTopTags(destination.getId(), 3);
-                            return DestinationSummaryRes.from(destination, topTags);
-                }).toList();
+                .map(destination -> DestinationSummaryRes.from(
+                        destination,
+                        tagCountMap.get(destination.getId())))
+                .toList();
 
         return new PageImpl<>(destinationResList, pageable, destinationPage.getTotalElements());
     }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/CustomTagDocumentRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/CustomTagDocumentRepository.java
@@ -4,9 +4,11 @@ import com.se.Tlog.domain.Travel.domain.CustomTagDocument;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface CustomTagDocumentRepository extends MongoRepository<CustomTagDocument,String> {
     Optional<CustomTagDocument> findByDestinationId(String destinationId);
+    List<CustomTagDocument> findAllByDestinationIdIn(List<String> destinationIds);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ScrapService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ScrapService.java
@@ -1,11 +1,13 @@
 package com.se.Tlog.domain.Wishlist.application;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Travel.application.CustomTagService;
 import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
+import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.domain.TagCount;
 import com.se.Tlog.domain.Wishlist.domain.OwnerType;
 import com.se.Tlog.domain.Wishlist.domain.WishlistService;
@@ -23,15 +25,21 @@ public class ScrapService {
 	private final CustomTagService customTagService;
 	
 	public List<SimpleDestinationRes> getScrapData(UUID userId) {
-		return wishlistService.getWishlistData(
-				new WishlistOwnerDto(
-						OwnerType.USER,
-						userId),
-				WishlistType.SCRAP)
-				.stream().map(destination -> {
-					List<TagCount> topTags = customTagService.getTopTags(destination.getId(), 3);
-					return SimpleDestinationRes.from(destination, topTags);
-				}).toList();
+	    List<Destination> destinations = 
+	            wishlistService.getWishlistData(
+	                    new WishlistOwnerDto(
+                                OwnerType.USER,
+                                userId),
+                        WishlistType.SCRAP);
+        Map<String, List<TagCount>> tagCountMap = customTagService.getAllTopTags(
+                destinations.stream().map(Destination::getId).toList(),
+                3);
+        
+		return destinations.stream()
+		        .map(destination ->  SimpleDestinationRes.from(
+		                destination, 
+		                tagCountMap.get(destination.getId())))
+		        .toList();
 	}
 	
 	private void updateScrap(UpdateType updateType, UUID userId, String destinationId) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ShoppingCartService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ShoppingCartService.java
@@ -1,11 +1,13 @@
 package com.se.Tlog.domain.Wishlist.application;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Travel.application.CustomTagService;
 import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
+import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.domain.TagCount;
 import com.se.Tlog.domain.Wishlist.domain.OwnerType;
 import com.se.Tlog.domain.Wishlist.domain.WishlistService;
@@ -23,15 +25,21 @@ public class ShoppingCartService {
 	private final CustomTagService customTagService;
 
 	public List<SimpleDestinationRes> getCartData(UUID ownerId, OwnerType ownerType) {
-		return wishlistService.getWishlistData(
-				new WishlistOwnerDto(
-						ownerType,
-						ownerId),
-				WishlistType.SHOPPING_CART)
-				.stream().map(destination -> {
-					List<TagCount> topTags = customTagService.getTopTags(destination.getId(), 3);
-					return SimpleDestinationRes.from(destination, topTags);
-				}).toList();
+	    List<Destination> destinations = 
+                wishlistService.getWishlistData(
+                        new WishlistOwnerDto(
+                                ownerType,
+                                ownerId),
+                        WishlistType.SHOPPING_CART);
+        Map<String, List<TagCount>> tagCountMap = customTagService.getAllTopTags(
+                destinations.stream().map(Destination::getId).toList(),
+                3);
+        
+        return destinations.stream()
+                .map(destination ->  SimpleDestinationRes.from(
+                        destination, 
+                        tagCountMap.get(destination.getId())))
+                .toList();
 	}
 	
 	private void updateCart(UpdateType updateType, UUID ownerId, OwnerType ownerType, String destinationId) {


### PR DESCRIPTION
## 작업 동기 및 이슈
- #108 

## 문제 상황
- **N+1 쿼리 문제가 발생하는 지점을 다음과 같이 발견했습니다 :**
  1) **Destination - CustomTag 연관관계**
     - Destination 조회
     - Course 조회
     - Scrap / ShoppingCart 조회
  2) **Team - TeamUser 연관관계**
     - Team 조회
  
- **실제 쿼리 :**
  - <img src="https://github.com/user-attachments/assets/de3c9be4-a501-4d73-8753-fcad37afab1b" width="700"/>

## 변경사항

연관된 데이터 조회시 각 엔티티마다 개별 조회하지 않고,
여러개의 엔티티에 대해 일괄 조회하도록 변경했습니다.
- **Destination - CustomTag**
  - 쿼리 추가 : `CustomTagRepository.findAllByDestinationIdIn()`
  - 서비스 기능 추가 : `CustomTagService.getAllTopTags()`
- **Team - TeamUser** 
  - 쿼리 추가 : `TeamUserRepository.findAllMembersByUserIds()`

## 테스트 결과
 - 이상 무.
   이제 모든 엔티티의 내부 데이터가 단일 쿼리로 일괄 조회됩니다.
 - <img src="https://github.com/user-attachments/assets/73aab46b-4ab1-427f-b7d9-564d2a320d59" width="700"/>

## 📌 기타

**추가 :**
성능을 확인한 결과,
`Destination 조회 -> CustomTag 조회`와 같이 2 단계로 조회하는 것과
`DB에서 미리 조인하여, 한번에 DestinationSummaryRes로 조회`하는 것에 성능 차이가 꽤 있었습니다.
(물론 N+1 문제에 비하면 둘 다 준수한 성능이긴 하나,)
더 성능이 요구된다면, **쿼리에서 미리 다 조인해 가져오는 것**도 좋은 방법일 것입니다!