### PR TITLE
Fix: 쿼리 로깅이 표시되지 않는 문제 수정

### DIFF
--- a/tlog-was/src/main/resources/application.yml
+++ b/tlog-was/src/main/resources/application.yml
@@ -93,7 +93,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        show-sql: true
+        show_sql: true
   rabbitmq:
     username: ${RABBITMQ_USERNAME}
     password: ${RABBITMQ_PASSWORD}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #110 
- SQL 관련 쿼리가 로그로 표시되지 않고 있습니다!

## 추가 및 변경사항
- application properties 설정 오류인 것으로 확인했습니다.

## 테스트 결과
- 이상 무.
  SQL 쿼리 로그가 함께 표시됩니다.
  
- ![image](https://github.com/user-attachments/assets/2326509a-a329-4446-b158-30429e42ba0c)


## 📌 기타
