### PR TITLE
Feature: Admin 미검수 여행지 조회 및 간단한 검수 기능

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/config/security/WebSecurityConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/security/WebSecurityConfig.java
@@ -9,6 +9,8 @@ import com.se.Tlog.global.security.filter.JwtExceptionFilter;
 import com.se.Tlog.global.util.jwt.AccessTokenProvider;
 import com.se.Tlog.global.util.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -22,6 +24,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
+
+@Slf4j
 
 @Configuration
 @EnableWebSecurity(debug = true)
@@ -54,7 +58,9 @@ public class WebSecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorizeHttpRequest ->{
                     authorizeHttpRequest
+                            //.requestMatchers("/api/admin/**").hasRole(Role.ADMIN.toString()) // Admin 전용 역할 제한 필요!!
                             .requestMatchers("/test/**").permitAll();
+                    log.error("서비스 API접근시 JWT 관련 Role 구분이 이루어지지 않았습니다!");
 
 
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/application/AdminService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/application/AdminService.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Admin.controller.dto.DestinationApproveReq;
 import com.se.Tlog.domain.Travel.application.DestinationService;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
 import com.se.Tlog.global.exception.CustomException;
@@ -28,11 +29,13 @@ public class AdminService {
                 pageable);
     }
     
-    public void approveDestination(String destinationId) {
-        redisUtil.removeDestinationIdFromTaggingQueue(destinationId)
+    public void approveDestination(DestinationApproveReq approveReqest) {
+        redisUtil.removeDestinationIdFromTaggingQueue(approveReqest.destinationId())
             .orElseThrow(() -> new CustomException(ErrorType.ALREADY_APPROVED_DESTINATION));
         
-        // destination 관련 검수 처리
-        log.warn("Destination 검수 처리 로직이 아직 없습니다. : id {" + destinationId + "}");
+        // 기타 destination 관련 검수 처리
+        destinationService.addFixedTagsToDestination(
+                approveReqest.destinationId(), 
+                approveReqest.fixedTags());
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/application/AdminService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/application/AdminService.java
@@ -5,11 +5,11 @@ import org.springframework.data.domain.Pageable;
 
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Admin.controller.dto.DestinationApproveReq;
+import com.se.Tlog.domain.Admin.controller.dto.UnapprovedDestinationDto;
 import com.se.Tlog.domain.Travel.application.DestinationService;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
-import com.se.Tlog.global.exception.CustomException;
-import com.se.Tlog.global.response.error.ErrorType;
-import com.se.Tlog.global.util.redis.RedisUtil;
+import com.se.Tlog.domain.Travel.domain.TagCount;
+import com.se.Tlog.domain.Travel.repository.mongo.UnapprovedDestinationRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,23 +19,28 @@ import lombok.extern.slf4j.Slf4j;
 @ApplicationService
 @RequiredArgsConstructor
 public class AdminService {
-    private final RedisUtil redisUtil;
+    private final UnapprovedDestinationRepository unapprovedDestinationRepository;
     private final DestinationService destinationService;
     
-    public Page<DestinationSummaryRes> getUnApprovedDestinations(Pageable pageable) {
-        return destinationService.getDestinationByIds(
-                // 현재 여행지의 TaggingQueue는 아직 관리자가 검수하지 않은 여행지 리스트로도 활용중에 있습니다.
-                redisUtil.getAllDestinationIdFromTaggingQueue(), 
-                pageable);
+    public Page<UnapprovedDestinationDto> getUnApprovedDestinations(Pageable pageable) {
+        return unapprovedDestinationRepository.findAll(pageable)
+                .map(dest -> 
+                        new UnapprovedDestinationDto(
+                                dest.getId(),
+                                dest.getSubmitter(),
+                                DestinationSummaryRes.from(
+                                        dest.getDestination(), 
+                                        dest.getCustomTags().stream().map(TagCount::create).toList())
+                        )
+                );
     }
     
     public void approveDestination(DestinationApproveReq approveReqest) {
-        redisUtil.removeDestinationIdFromTaggingQueue(approveReqest.destinationId())
-            .orElseThrow(() -> new CustomException(ErrorType.ALREADY_APPROVED_DESTINATION));
-        
-        // 기타 destination 관련 검수 처리
-        destinationService.addFixedTagsToDestination(
-                approveReqest.destinationId(), 
+        // DDD 구조 개선점 : 
+        //   도메인 간의 결합을 낮추기 위해, Spring Event를 도입하여 해결할 수 있습니다.
+        //   오류 발생시 중단/피드백이 필요하다면 동기 방식의 이벤트로 설정할 수 있습니다.
+        destinationService.assignDestination(
+                approveReqest.id(), 
                 approveReqest.fixedTags());
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/application/AdminService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/application/AdminService.java
@@ -1,0 +1,38 @@
+package com.se.Tlog.domain.Admin.application;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Travel.application.DestinationService;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import com.se.Tlog.global.util.redis.RedisUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
+@ApplicationService
+@RequiredArgsConstructor
+public class AdminService {
+    private final RedisUtil redisUtil;
+    private final DestinationService destinationService;
+    
+    public Page<DestinationSummaryRes> getUnApprovedDestinations(Pageable pageable) {
+        return destinationService.getDestinationByIds(
+                // 현재 여행지의 TaggingQueue는 아직 관리자가 검수하지 않은 여행지 리스트로도 활용중에 있습니다.
+                redisUtil.getAllDestinationIdFromTaggingQueue(), 
+                pageable);
+    }
+    
+    public void approveDestination(String destinationId) {
+        redisUtil.removeDestinationIdFromTaggingQueue(destinationId)
+            .orElseThrow(() -> new CustomException(ErrorType.ALREADY_APPROVED_DESTINATION));
+        
+        // destination 관련 검수 처리
+        log.warn("Destination 검수 처리 로직이 아직 없습니다. : id {" + destinationId + "}");
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/AdminController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/AdminController.java
@@ -6,11 +6,12 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.se.Tlog.domain.Admin.application.AdminService;
+import com.se.Tlog.domain.Admin.controller.dto.DestinationApproveReq;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
 import com.se.Tlog.global.response.error.ErrorRes;
 import com.se.Tlog.global.response.success.SuccessRes;
@@ -49,7 +50,7 @@ public class AdminController {
                 adminService.getUnApprovedDestinations(pageable)));
     }
     
-    @PostMapping("/destinations/{destinationId}")
+    @PostMapping("/destinations")
     @Operation (
             summary = "여행지 검수하기",
             description = "특정 여행지를 검수합니다.",
@@ -59,8 +60,8 @@ public class AdminController {
                             content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
     )
     public ResponseEntity<SuccessRes<?>> approvedDestination(
-            @PathVariable(name = "destinationId") String destinationId) {
-        adminService.approveDestination(destinationId);
+            @RequestBody DestinationApproveReq approveReqest) {
+        adminService.approveDestination(approveReqest);
         return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/AdminController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/AdminController.java
@@ -1,0 +1,66 @@
+package com.se.Tlog.domain.Admin.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.se.Tlog.domain.Admin.application.AdminService;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+@Tag(name = "관리자 작업")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
+public class AdminController {
+    private final AdminService adminService;
+    
+    @GetMapping("/destinations")
+    @Operation (
+            summary = "검수되지 않은 여행지 조회",
+            description = "검수되지 않은 모든 여행지를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공. 검수되지 않은 여행지가 반환됩니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<Page<DestinationSummaryRes>>> getUnApprovedDestinations(
+            @PageableDefault Pageable pageable) {
+        return ResponseEntity.ok(SuccessRes.from(
+                adminService.getUnApprovedDestinations(pageable)));
+    }
+    
+    @PostMapping("/destinations/{destinationId}")
+    @Operation (
+            summary = "여행지 검수하기",
+            description = "특정 여행지를 검수합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공. 별도로 반환되는 정보는 없습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<?>> approvedDestination(
+            @PathVariable(name = "destinationId") String destinationId) {
+        adminService.approveDestination(destinationId);
+        return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/AdminController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/AdminController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.se.Tlog.domain.Admin.application.AdminService;
 import com.se.Tlog.domain.Admin.controller.dto.DestinationApproveReq;
-import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+import com.se.Tlog.domain.Admin.controller.dto.UnapprovedDestinationDto;
 import com.se.Tlog.global.response.error.ErrorRes;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
@@ -44,7 +44,7 @@ public class AdminController {
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
                             content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
     )
-    public ResponseEntity<SuccessRes<Page<DestinationSummaryRes>>> getUnApprovedDestinations(
+    public ResponseEntity<SuccessRes<Page<UnapprovedDestinationDto>>> getUnApprovedDestinations(
             @PageableDefault Pageable pageable) {
         return ResponseEntity.ok(SuccessRes.from(
                 adminService.getUnApprovedDestinations(pageable)));

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/DevAdminController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/DevAdminController.java
@@ -1,0 +1,90 @@
+package com.se.Tlog.domain.Admin.controller;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+import com.se.Tlog.global.util.redis.RedisUtil;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Schema(description = "여행지들의 id를 전달하는 데이터타입입니다.")
+record DestinationsDto(
+        @Schema(description = "여행지 id 리스트")
+        List<String> ids) {
+}
+
+@Controller
+@Profile("dev")
+@RequestMapping("/api/test/admin")
+@RequiredArgsConstructor
+@Tag(name = "관리자 작업")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
+public class DevAdminController {
+    private final RedisUtil redisUtil;
+    
+    @PostMapping("/destinations")
+    @Operation (
+            summary = "[개발환경 전용] 검수되지 않은 여행지 추가",
+            description = "[개발환경 전용] 여행지를 검수되지 않은 상태로 등록합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<?>> addUnApprovedDestinations(@RequestBody DestinationsDto destinations) {
+        for (String id : destinations.ids())
+            redisUtil.pushDestinationIdToTaggingQueue(id);
+        return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+    }
+    
+    @GetMapping("/destinations")
+    @Operation (
+            summary = "[개발환경 전용] 검수되지 않은 여행지 ID의 DB 직접 조회",
+            description = "[개발환경 전용] 검수되지 않은 여행지에 대한 DB 데이터를 그대로 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<List<String>>> getUnApprovedDestinations() {
+        return ResponseEntity.ok(SuccessRes.from(
+                redisUtil.getAllDestinationIdFromTaggingQueue()));
+    }
+
+    @DeleteMapping("/destinations")
+    @Operation (
+            summary = "[개발환경 전용] 검수되지 않은 여행지 리스트에서 삭제",
+            description = "[개발환경 전용] 검수되지 않은 여행지 리스트에서 특정 id를 제거합니다.<br>DB에 없어 처리되지 않은 ID가 반환됩니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공. DB에 없어 처리되지 않은 ID가 반환됩니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<DestinationsDto>> deleteUnApprovedDestinations(@RequestBody DestinationsDto destinations) {
+        DestinationsDto response = new DestinationsDto(new ArrayList<String>());
+        for (String id : destinations.ids())
+            if (!redisUtil.removeDestinationIdFromTaggingQueue(id).isPresent())
+                response.ids().add(id);
+        return ResponseEntity.ok(SuccessRes.from(response));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/DevAdminController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/DevAdminController.java
@@ -2,6 +2,7 @@ package com.se.Tlog.domain.Admin.controller;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
@@ -12,10 +13,16 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.se.Tlog.domain.Admin.controller.dto.UnapprovedDestinationDto;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationDto;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+import com.se.Tlog.domain.Travel.domain.Destination;
+import com.se.Tlog.domain.Travel.domain.TagCount;
+import com.se.Tlog.domain.Travel.domain.UnapprovedDestination;
+import com.se.Tlog.domain.Travel.domain.repository.DestinationRepositoryService;
+import com.se.Tlog.domain.Travel.repository.mongo.UnapprovedDestinationRepository;
 import com.se.Tlog.global.response.error.ErrorRes;
 import com.se.Tlog.global.response.success.SuccessRes;
-import com.se.Tlog.global.response.success.SuccessType;
-import com.se.Tlog.global.util.redis.RedisUtil;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -25,9 +32,21 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-@Schema(description = "여행지들의 id를 전달하는 데이터타입입니다.")
-record DestinationsDto(
-        @Schema(description = "여행지 id 리스트")
+@Schema(description = "미검수 여행지를 추가하는 데이터타입입니다.")
+record AddUnapprovedDestinationDto(
+        @Schema(description = "생성한 사용자의 id")
+        UUID submitter,
+        
+        @Schema(description = "여행지 데이터")
+        DestinationDto destination,
+        
+        @Schema(description = "커스텀 태그")
+        List<String> customTags) {
+}
+
+@Schema(description = "미검수 여행지 데이터를 가리키는 데이터타입입니다.")
+record UnapprovedDestinationsDto(
+        @Schema(description = "지칭할 데이터 고유 id 리스트")
         List<String> ids) {
 }
 
@@ -40,7 +59,8 @@ record DestinationsDto(
         name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
         scopes = {"scope1", "scope2"})
 public class DevAdminController {
-    private final RedisUtil redisUtil;
+    private final UnapprovedDestinationRepository unapprovedDestinationRepository;
+    private final DestinationRepositoryService destinationRepositoryService;
     
     @PostMapping("/destinations")
     @Operation (
@@ -51,40 +71,66 @@ public class DevAdminController {
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
                             content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
     )
-    public ResponseEntity<SuccessRes<?>> addUnApprovedDestinations(@RequestBody DestinationsDto destinations) {
-        for (String id : destinations.ids())
-            redisUtil.pushDestinationIdToTaggingQueue(id);
-        return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+    public ResponseEntity<SuccessRes<UnapprovedDestinationDto>> addUnApprovedDestinations(@RequestBody AddUnapprovedDestinationDto request) {
+        // DDD 구조와 관련해서, Destination의 생성 로직을 리팩토링할 필요가 있음.
+        UnapprovedDestination addedDestination = unapprovedDestinationRepository.save(
+                UnapprovedDestination.create(
+                        request.submitter(),
+                        Destination.create(
+                                request.destination().getName(),
+                                request.destination().getLocation(),
+                                request.destination().getAddress(),
+                                new ArrayList<>(),
+                                request.destination().getCity(),
+                                request.destination().getDistrict(),
+                                request.destination().isHasParking(),
+                                request.destination().isPetFriendly(),
+                                request.destination().getDescription(),
+                                request.destination().getImageUrl(),
+                                destinationRepositoryService), // Admin에서 Destination 도메인의 repository를 접근해야만 하는 복잡성 개선 필요.
+                        request.customTags()));
+        
+        return ResponseEntity.ok(SuccessRes.from(
+                new UnapprovedDestinationDto(
+                        addedDestination.getId(), 
+                        addedDestination.getSubmitter(), 
+                        DestinationSummaryRes.from(
+                                addedDestination.getDestination(), 
+                                addedDestination.getCustomTags().stream().map(TagCount::create).toList()))
+        ));
     }
     
     @GetMapping("/destinations")
     @Operation (
-            summary = "[개발환경 전용] 검수되지 않은 여행지 ID의 DB 직접 조회",
+            summary = "[개발환경 전용] 검수되지 않은 여행지 데이터 DB 직접 조회",
             description = "[개발환경 전용] 검수되지 않은 여행지에 대한 DB 데이터를 그대로 조회합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "처리 성공."),
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
                             content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
     )
-    public ResponseEntity<SuccessRes<List<String>>> getUnApprovedDestinations() {
+    public ResponseEntity<SuccessRes<List<UnapprovedDestination>>> getUnApprovedDestinations() {
         return ResponseEntity.ok(SuccessRes.from(
-                redisUtil.getAllDestinationIdFromTaggingQueue()));
+                unapprovedDestinationRepository.findAll()));
     }
 
     @DeleteMapping("/destinations")
     @Operation (
             summary = "[개발환경 전용] 검수되지 않은 여행지 리스트에서 삭제",
-            description = "[개발환경 전용] 검수되지 않은 여행지 리스트에서 특정 id를 제거합니다.<br>DB에 없어 처리되지 않은 ID가 반환됩니다.",
+            description = "[개발환경 전용] 검수되지 않은 여행지 리스트에서 특정 항목을 제거합니다.<br>DB에 존재하지 않는 항목은 처리되지 않으며, 처리되지 않은 ID 목록이 다시 반환됩니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "처리 성공. DB에 없어 처리되지 않은 ID가 반환됩니다."),
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
                             content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
     )
-    public ResponseEntity<SuccessRes<DestinationsDto>> deleteUnApprovedDestinations(@RequestBody DestinationsDto destinations) {
-        DestinationsDto response = new DestinationsDto(new ArrayList<String>());
-        for (String id : destinations.ids())
-            if (!redisUtil.removeDestinationIdFromTaggingQueue(id).isPresent())
+    public ResponseEntity<SuccessRes<UnapprovedDestinationsDto>> deleteUnApprovedDestinations(@RequestBody UnapprovedDestinationsDto destinations) {
+        UnapprovedDestinationsDto response = new UnapprovedDestinationsDto(new ArrayList<String>());
+        for (String id : destinations.ids()) {
+            if (!unapprovedDestinationRepository.existsById(id))
                 response.ids().add(id);
+            else 
+                unapprovedDestinationRepository.deleteById(id);
+        }
         return ResponseEntity.ok(SuccessRes.from(response));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/dto/DestinationApproveReq.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/dto/DestinationApproveReq.java
@@ -1,0 +1,17 @@
+package com.se.Tlog.domain.Admin.controller.dto;
+
+import java.util.List;
+
+import com.se.Tlog.domain.Travel.controller.dto.AddFixedTagDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "여행지 검수 완료 처리의 데이터 형식입니다.")
+public record DestinationApproveReq(
+        @Schema(description = "검수할 여행지의 ID입니다.")
+        String destinationId,
+        
+        @Schema(description = "여행지에 추가할 고유 태그 정보(커스텀 태그가 아님)입니다.")
+        List<AddFixedTagDto> fixedTags) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/dto/DestinationApproveReq.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/dto/DestinationApproveReq.java
@@ -8,8 +8,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "여행지 검수 완료 처리의 데이터 형식입니다.")
 public record DestinationApproveReq(
-        @Schema(description = "검수할 여행지의 ID입니다.")
-        String destinationId,
+        @Schema(description = "(여행지 id가 아닌) 미검수 데이터에 대한 고유 id입니다.")
+        String id,
         
         @Schema(description = "여행지에 추가할 고유 태그 정보(커스텀 태그가 아님)입니다.")
         List<AddFixedTagDto> fixedTags) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/dto/UnapprovedDestinationDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/dto/UnapprovedDestinationDto.java
@@ -1,0 +1,21 @@
+package com.se.Tlog.domain.Admin.controller.dto;
+
+import java.util.UUID;
+
+import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "검수되지 않은 여행지 데이터입니다.")
+public record UnapprovedDestinationDto(
+        @Schema(description = "(여행지 id가 아닌) 미검수 데이터에 대한 고유 id입니다.")
+        String id,
+        
+        @Schema(description = "여행지 생성 요청자 id입니다.")
+        UUID submitter,
+        
+        @Schema(description = "내부 여행지 데이터입니다.")
+        DestinationSummaryRes destination
+        ) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -10,13 +10,13 @@ import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
 import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.domain.TagCount;
 import com.se.Tlog.domain.Travel.domain.TagInfo;
+import com.se.Tlog.domain.Travel.domain.UnapprovedDestination;
 import com.se.Tlog.domain.Travel.domain.repository.DestinationRepositoryService;
 import com.se.Tlog.domain.Travel.domain.repository.TagRepositoryService;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
-
+import com.se.Tlog.domain.Travel.repository.mongo.UnapprovedDestinationRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
-import com.se.Tlog.global.util.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -32,16 +32,12 @@ public class DestinationService {
     private final DestinationRepositoryService destinationRepoService;
     private final TagRepositoryService tagRepositoryService;
     private final DestinationRepository destinationRepository;
+    private final UnapprovedDestinationRepository unapprovedDestinationRepository;
     private final CustomTagService customTagService;
     private final ReviewDomainService reviewDomainService;
-    private final RedisUtil redisUtil;
 
-    public void createDestination(DestinationDto destinationDto) {
-    	Destination.assertValidity(destinationDto.getName(), destinationRepoService);
-
-        List<String> customTags = destinationDto.getCustomTags();
-
-        Destination destination = Destination.create(
+    public void generateNewDestination(DestinationDto destinationDto) {
+        Destination destinationData = Destination.create(
         		destinationDto.getName(),
                 destinationDto.getLocation(),
                 destinationDto.getAddress(),
@@ -53,9 +49,23 @@ public class DestinationService {
                 destinationDto.getDescription(),
                 destinationDto.getImageUrl(),
                 destinationRepoService);
-        String destinationId = destinationRepository.save(destination).getId();
-        customTagService.addCustomTag(destinationId, customTags);
-        redisUtil.pushDestinationIdToTaggingQueue(destinationId);
+        
+        UnapprovedDestination newDestination = UnapprovedDestination.create(
+                destinationDto.getCreater(), destinationData, destinationDto.getCustomTags());
+        unapprovedDestinationRepository.save(newDestination);
+    }
+    
+    public void assignDestination(String unapprovedDestinationId, List<AddFixedTagDto> fixedTags) {
+        // 이 로직은 Travel 도메인보다도, admin에서만 활용되는 usecase임.. 구조 개선을 위해 고려해볼 것.
+        UnapprovedDestination unapprovedDestination = unapprovedDestinationRepository.findById(unapprovedDestinationId)
+                .orElseThrow(() -> new CustomException(ErrorType.ALREADY_APPROVED_DESTINATION));
+        unapprovedDestinationRepository.deleteById(unapprovedDestinationId);
+        
+        String destinationId = destinationRepository.save(unapprovedDestination.getDestination()).getId();
+        customTagService.addCustomTag(destinationId, unapprovedDestination.getCustomTags());
+        destinationRepoService.addFixedTags(
+                destinationId, 
+                TagInfo.createAll(fixedTags, tagRepositoryService));
     }
 
     public Page<DestinationSummaryRes> getAllDestinations(Pageable pageable) {
@@ -89,11 +99,5 @@ public class DestinationService {
         List<DestinationReviewDto> top2Reviews = reviewDomainService.getTop2Reviews(destination.getId());
 
         return DestinationDetailsRes.from(destination, topTags, top2Reviews);
-    }
-
-    public void addFixedTagsToDestination(String destinationId, List<AddFixedTagDto> fixedTags) {
-        destinationRepoService.addFixedTags(
-                destinationId, 
-                TagInfo.createAll(fixedTags, tagRepositoryService));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -59,6 +59,10 @@ public class DestinationService {
         return convertToDto(destinationRepository.findAllWithActiveTags(pageable));
     }
     
+    public Page<DestinationSummaryRes> getDestinationByIds(List<String> ids, Pageable pageable) {
+        return convertToDto(destinationRepository.findAllByIdIn(ids, pageable));
+    }
+    
     private Page<DestinationSummaryRes> convertToDto(Page<Destination> destinationPage) {
         Map<String, List<TagCount>> tagCountMap = customTagService.getAllTopTags(
                 destinationPage.map(Destination::getId).toList(),

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -3,6 +3,7 @@ package com.se.Tlog.domain.Travel.application;
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Review.controller.dto.DestinationReviewDto;
 import com.se.Tlog.domain.Review.domain.service.ReviewDomainService;
+import com.se.Tlog.domain.Travel.controller.dto.AddFixedTagDto;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationDetailsRes;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationDto;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
@@ -10,6 +11,7 @@ import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.domain.TagCount;
 import com.se.Tlog.domain.Travel.domain.TagInfo;
 import com.se.Tlog.domain.Travel.domain.repository.DestinationRepositoryService;
+import com.se.Tlog.domain.Travel.domain.repository.TagRepositoryService;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
 
 import com.se.Tlog.global.exception.CustomException;
@@ -28,6 +30,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class DestinationService {
     private final DestinationRepositoryService destinationRepoService;
+    private final TagRepositoryService tagRepositoryService;
     private final DestinationRepository destinationRepository;
     private final CustomTagService customTagService;
     private final ReviewDomainService reviewDomainService;
@@ -88,7 +91,9 @@ public class DestinationService {
         return DestinationDetailsRes.from(destination, topTags, top2Reviews);
     }
 
-    public void addFixedTagsToDestination(String destinationId,List<TagInfo> fixedTags) {
-        destinationRepoService.addFixedTags(destinationId, fixedTags);
+    public void addFixedTagsToDestination(String destinationId, List<AddFixedTagDto> fixedTags) {
+        destinationRepoService.addFixedTags(
+                destinationId, 
+                TagInfo.createAll(fixedTags, tagRepositoryService));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -56,7 +56,10 @@ public class DestinationService {
     }
 
     public Page<DestinationSummaryRes> getAllDestinations(Pageable pageable) {
-        Page<Destination> destinationPage = destinationRepository.findAllWithActiveTags(pageable);
+        return convertToDto(destinationRepository.findAllWithActiveTags(pageable));
+    }
+    
+    private Page<DestinationSummaryRes> convertToDto(Page<Destination> destinationPage) {
         Map<String, List<TagCount>> tagCountMap = customTagService.getAllTopTags(
                 destinationPage.map(Destination::getId).toList(),
                 3);
@@ -68,7 +71,7 @@ public class DestinationService {
                         tagCountMap.get(destination.getId())))
                 .toList();
 
-        return new PageImpl<>(destinationResList, pageable, destinationPage.getTotalElements());
+        return new PageImpl<>(destinationResList, destinationPage.getPageable(), destinationPage.getTotalElements());
     }
 
     public DestinationDetailsRes getDestinationById(String id) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
@@ -39,7 +39,7 @@ public class DestinationController {
             }
     )
     public ResponseEntity<?> createDestination(@RequestBody DestinationDto destinationDto) {
-        destinationService.createDestination(destinationDto);
+        destinationService.generateNewDestination(destinationDto);
         return ResponseEntity
                 .status(SuccessType.DESTINATION_CREATED.getStatus())
                 .body(SuccessRes.from(SuccessType.DESTINATION_CREATED));

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/AddFixedTagDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/AddFixedTagDto.java
@@ -1,0 +1,13 @@
+package com.se.Tlog.domain.Travel.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "여행지에 태그를 추가하는 요청 DTO입니다.")
+public record AddFixedTagDto(
+        @Schema(description = "추가하려는 태그의 id입니다.")
+        String tagId,
+        
+        @Schema(description = "태그 가중치")
+        int tagWeight) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.UUID;
 
 import com.se.Tlog.domain.Travel.domain.Location;
 
@@ -15,6 +16,8 @@ import com.se.Tlog.domain.Travel.domain.Location;
 @Schema(description = "여행지 생성 요청 DTO")
 public class DestinationDto {
 
+    @Schema(description = "여행지 생성을 요청한 사용자 id입니다.")
+    private UUID creater;
     @Schema(description = "여행지 이름입니다.")
     private String name;
     @Schema(description = "여행지 주소입니다.")

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Destination.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Destination.java
@@ -94,10 +94,6 @@ public class Destination {
 	public void addTag(TagInfo tag) {
 		this.tags.add(tag);
 	}
-	
-	public void verify() {
-		// verified logic
-	}
 
 	public void addFixedTags(List<TagInfo> fixedTags) {
 		this.tags.addAll(fixedTags);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/TagInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/TagInfo.java
@@ -1,5 +1,10 @@
 package com.se.Tlog.domain.Travel.domain;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.se.Tlog.domain.Travel.controller.dto.AddFixedTagDto;
 import com.se.Tlog.domain.Travel.domain.repository.TagRepositoryService;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
@@ -17,9 +22,27 @@ public class TagInfo { // 여행지가 갖고 있는 태그 정보
     private int weight;
     private boolean isDeleted;
     
+    // 추후 CreateFixedTagDto로 입력받도록 변경 예정
     public static TagInfo create(String tagId, int tagWeight, TagRepositoryService validator) {
     	if (!validator.existById(tagId))
     		throw new CustomException(ErrorType.NOT_FOUND_TAG);
         return new TagInfo(tagId, tagWeight, false);
+    }
+    
+    /**
+     * 태그 생성 요청 중 유효한 요청에 대해서만 생성해 반환합니다.
+     * <br>실패 상황 1. 주어진 id의 태그가 없을 경우
+     * @param createTagRequests
+     * @param tagRepositoryService
+     * @return
+     */
+    public static List<TagInfo> createAll(List<AddFixedTagDto> createTagRequests, TagRepositoryService tagRepositoryService) {
+        Set<String> validTagIds = tagRepositoryService.getExistSet(
+                createTagRequests.stream().map(AddFixedTagDto::tagId).toList());
+        
+        return createTagRequests.stream()
+            .filter(dto -> validTagIds.contains(dto.tagId()))
+            .map(dto -> new TagInfo(dto.tagId(), dto.tagWeight(), false))
+            .collect(Collectors.toList());
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/UnapprovedDestination.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/UnapprovedDestination.java
@@ -1,0 +1,37 @@
+package com.se.Tlog.domain.Travel.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "destinations_unapproved")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UnapprovedDestination {
+    @Id
+    private String id;
+    private UUID submitter;
+    private Destination destination;
+    private List<String> customTags = new ArrayList<String>();
+    
+    public static UnapprovedDestination create(UUID submitter, Destination destination, List<String> customTags) {
+        if (submitter == null || destination == null)
+            throw new IllegalArgumentException();
+        
+        return new UnapprovedDestination(submitter, destination, customTags);
+    }
+    
+    private UnapprovedDestination(UUID submitter, Destination description, List<String> customTags) {
+        this.submitter = submitter;
+        this.destination = description;
+        if (customTags != null)
+            this.customTags.addAll(customTags);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/repository/TagRepositoryService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/repository/TagRepositoryService.java
@@ -1,6 +1,15 @@
 package com.se.Tlog.domain.Travel.domain.repository;
 
+import java.util.List;
+import java.util.Set;
+
 public interface TagRepositoryService {
-	public boolean existById(String tagId);
-	public boolean existByName(String tagName);
+	boolean existById(String tagId);
+	boolean existByName(String tagName);
+	/**
+	 * 주어진 id 중 실제 존재하는 id만을 Set으로 반환합니다.
+	 * @param tagIds
+	 * @return
+	 */
+	Set<String> getExistSet(List<String> tagIds);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/service/DestinationDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/service/DestinationDomainService.java
@@ -3,7 +3,6 @@ package com.se.Tlog.domain.Travel.domain.service;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
-import com.se.Tlog.global.util.redis.RedisUtil;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,7 +11,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class DestinationDomainService {
     private final DestinationRepository destinationRepository;
-    private final RedisUtil redisUtil;
 
 
     public void validateExists(String destinationId) {
@@ -22,6 +20,6 @@ public class DestinationDomainService {
     }
 
     public boolean isApproved(String destinationId) {
-        return redisUtil.isInTaggingQueue(destinationId);
+        return destinationRepository.existsById(destinationId);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/service/DestinationDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/service/DestinationDomainService.java
@@ -3,6 +3,8 @@ package com.se.Tlog.domain.Travel.domain.service;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
+import com.se.Tlog.global.util.redis.RedisUtil;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,11 +12,16 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class DestinationDomainService {
     private final DestinationRepository destinationRepository;
+    private final RedisUtil redisUtil;
 
 
     public void validateExists(String destinationId) {
         if (!destinationRepository.existsById(destinationId)) {
             throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);
         }
+    }
+
+    public boolean isApproved(String destinationId) {
+        return redisUtil.isInTaggingQueue(destinationId);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/TagRepositoryServiceImplement.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/TagRepositoryServiceImplement.java
@@ -1,7 +1,12 @@
 package com.se.Tlog.domain.Travel.repository;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Component;
 
+import com.se.Tlog.domain.Travel.domain.Tag;
 import com.se.Tlog.domain.Travel.domain.repository.TagRepositoryService;
 import com.se.Tlog.domain.Travel.repository.mongo.TagRepository;
 
@@ -21,4 +26,11 @@ public class TagRepositoryServiceImplement implements TagRepositoryService {
 	public boolean existByName(String tagName) {
 		return tagRepository.existsByName(tagName);
 	}
+
+    @Override
+    public Set<String> getExistSet(List<String> tagIds) {
+        return tagRepository.findAllById(tagIds).stream()
+                .map(Tag::getId)
+                .collect(Collectors.toSet());
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/DestinationRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/DestinationRepository.java
@@ -1,5 +1,7 @@
 package com.se.Tlog.domain.Travel.repository.mongo;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -17,4 +19,5 @@ public interface DestinationRepository extends MongoRepository<Destination, Stri
     @Query("{'tags.isDeleted' :  false}")
     Page<Destination> findAllWithActiveTags(Pageable pageable);
 
+    Page<Destination> findAllByIdIn(List<String> ids, Pageable pageable);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/UnapprovedDestinationRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/UnapprovedDestinationRepository.java
@@ -1,0 +1,10 @@
+package com.se.Tlog.domain.Travel.repository.mongo;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import com.se.Tlog.domain.Travel.domain.UnapprovedDestination;
+
+@Repository
+public interface UnapprovedDestinationRepository extends MongoRepository<UnapprovedDestination, String>{
+}

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -30,6 +30,9 @@ public enum ErrorType {
     INVALID_COURSE_OWNER(HttpStatus.BAD_REQUEST,"여행 코스 소유자가 잘못 기입되었습니다."),
     INVALID_COURSE_DURATION(HttpStatus.BAD_REQUEST,"여행 코스의 기간이 잘못 기입되었습니다."),
     INVALID_COURSE_DATE(HttpStatus.BAD_REQUEST,"여행지를 등록하려는 날짜가 여행 코스의 기간을 벗어납니다."),
+    
+    // 어드민 관련 검증
+    ALREADY_APPROVED_DESTINATION(HttpStatus.BAD_REQUEST, "해당 여행지는 이미 관리자의 검수가 완료되었습니다."),
 
     // 인증
     // 401

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisProperties.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisProperties.java
@@ -3,5 +3,10 @@ package com.se.Tlog.global.util.redis;
 public interface RedisProperties {
     String REFRESH_TOKEN_PREFIX = "refresh_token:";
     String ACCESS_TOKEN_PREFIX = "access_token:";
-    String PENDING_TAGGING_DESTINATION = "pending:tagging:destination";
+    /*
+     * 25.05.22
+     * 태그 처리되지 않고 검수되지 않은 여행지는
+     * Redis로 기록되지 않고 별도의 DB공간에 기록되도록 변경되었습니다. 
+     * String PENDING_TAGGING_DESTINATION = "pending:tagging:destination";
+     */ 
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisUtil.java
@@ -5,7 +5,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import static com.se.Tlog.global.util.redis.RedisProperties.PENDING_TAGGING_DESTINATION;
 
 @Component
@@ -36,10 +40,53 @@ public class RedisUtil {
             return false;
         }
     }
+    
+    /**
+     * TaggingQueue는 새로 추가되었으나 태그처리가 안된 여행지를 저장합니다.
+     * <br>그러나 관리자 검수가 안된 것을 저장하는 용도로도 사용하고 있습니다.
+     * @param destinationId
+     */
     public void pushDestinationIdToTaggingQueue(String destinationId) {
-        redisTemplate.opsForList().rightPush(PENDING_TAGGING_DESTINATION, destinationId);
+        redisTemplate.opsForSet().add(PENDING_TAGGING_DESTINATION, destinationId);
     }
+    /**
+     * TaggingQueue는 새로 추가되었으나 태그처리가 안된 여행지를 저장합니다.
+     * <br>그러나 관리자 검수가 안된 것을 저장하는 용도로도 사용하고 있습니다.
+     * @return
+     */
     public String popDestinationIdFromTaggingQueue() {
-        return (String) redisTemplate.opsForList().leftPop(PENDING_TAGGING_DESTINATION);
+        return (String) redisTemplate.opsForSet().pop(PENDING_TAGGING_DESTINATION);
+    }
+    /**
+     * TaggingQueue에서 주어진 destinationId가 있으면 제거합니다.
+     * <br>
+     * <br>TaggingQueue는 새로 추가되었으나 태그처리가 안된 여행지를 저장합니다.
+     * <br>그러나 관리자 검수가 안된 것을 저장하는 용도로도 사용하고 있습니다.
+     * @return 제거에 성공하면 해당 destinationId를 반환하며,
+     * <br> 없을 경우 null을 반환합니다.
+     */
+    public Optional<String> removeDestinationIdFromTaggingQueue(String destinationId) {
+        if (1 == redisTemplate.opsForSet().remove(PENDING_TAGGING_DESTINATION, destinationId))
+            return Optional.of(destinationId);
+        else
+            return Optional.ofNullable((String)null);
+    }
+    /**
+     * TaggingQueue는 새로 추가되었으나 태그처리가 안된 여행지를 저장합니다.
+     * <br>그러나 관리자 검수가 안된 것을 저장하는 용도로도 사용하고 있습니다.
+     * @return
+     */
+    public List<String> getAllDestinationIdFromTaggingQueue() {
+        return redisTemplate.opsForSet().members(PENDING_TAGGING_DESTINATION)
+        .stream().map(desId -> (String)desId).collect(Collectors.toList());
+    }
+    /**
+     * TaggingQueue는 새로 추가되었으나 태그처리가 안된 여행지를 저장합니다.
+     * <br>그러나 관리자 검수가 안된 것을 저장하는 용도로도 사용하고 있습니다.
+     * @param destinationId
+     * @return
+     */
+    public boolean isInTaggingQueue(String destinationId) {
+        return !redisTemplate.opsForSet().isMember(PENDING_TAGGING_DESTINATION, destinationId);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisUtil.java
@@ -5,12 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import static com.se.Tlog.global.util.redis.RedisProperties.PENDING_TAGGING_DESTINATION;
 
 @Component
 @RequiredArgsConstructor
@@ -39,54 +34,5 @@ public class RedisUtil {
         }else{
             return false;
         }
-    }
-    
-    /**
-     * TaggingQueue는 새로 추가되었으나 태그처리가 안된 여행지를 저장합니다.
-     * <br>그러나 관리자 검수가 안된 것을 저장하는 용도로도 사용하고 있습니다.
-     * @param destinationId
-     */
-    public void pushDestinationIdToTaggingQueue(String destinationId) {
-        redisTemplate.opsForSet().add(PENDING_TAGGING_DESTINATION, destinationId);
-    }
-    /**
-     * TaggingQueue는 새로 추가되었으나 태그처리가 안된 여행지를 저장합니다.
-     * <br>그러나 관리자 검수가 안된 것을 저장하는 용도로도 사용하고 있습니다.
-     * @return
-     */
-    public String popDestinationIdFromTaggingQueue() {
-        return (String) redisTemplate.opsForSet().pop(PENDING_TAGGING_DESTINATION);
-    }
-    /**
-     * TaggingQueue에서 주어진 destinationId가 있으면 제거합니다.
-     * <br>
-     * <br>TaggingQueue는 새로 추가되었으나 태그처리가 안된 여행지를 저장합니다.
-     * <br>그러나 관리자 검수가 안된 것을 저장하는 용도로도 사용하고 있습니다.
-     * @return 제거에 성공하면 해당 destinationId를 반환하며,
-     * <br> 없을 경우 null을 반환합니다.
-     */
-    public Optional<String> removeDestinationIdFromTaggingQueue(String destinationId) {
-        if (1 == redisTemplate.opsForSet().remove(PENDING_TAGGING_DESTINATION, destinationId))
-            return Optional.of(destinationId);
-        else
-            return Optional.ofNullable((String)null);
-    }
-    /**
-     * TaggingQueue는 새로 추가되었으나 태그처리가 안된 여행지를 저장합니다.
-     * <br>그러나 관리자 검수가 안된 것을 저장하는 용도로도 사용하고 있습니다.
-     * @return
-     */
-    public List<String> getAllDestinationIdFromTaggingQueue() {
-        return redisTemplate.opsForSet().members(PENDING_TAGGING_DESTINATION)
-        .stream().map(desId -> (String)desId).collect(Collectors.toList());
-    }
-    /**
-     * TaggingQueue는 새로 추가되었으나 태그처리가 안된 여행지를 저장합니다.
-     * <br>그러나 관리자 검수가 안된 것을 저장하는 용도로도 사용하고 있습니다.
-     * @param destinationId
-     * @return
-     */
-    public boolean isInTaggingQueue(String destinationId) {
-        return !redisTemplate.opsForSet().isMember(PENDING_TAGGING_DESTINATION, destinationId);
     }
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #9 

## 추가 및 변경사항
### 1) Redis 내 미검수 여행지 관리
- (92df2796cd5f09039d71644ac0f3bc104ecac729)**TaggingQueue**
  - 현재 TaggingQueue 풀은 새로 생성되어 태깅 처리가 되지 않은 여행지 풀로 사용중입니다.
  해당 큐를 **미검수 여행지 풀**로도 사용하도록 확장했습니다.
  - **Redis List 형태에서 Redis Set 형태로 변환**했습니다.
  - 기타 **getAll, remove, isIn 등의 연산이 추가**되었습니다.
### 2) WebSecurityConfig : Admin API의 토큰 인증
- API 접근시 토큰 인증 로직 추가
- 아직 개발중임을 감안, 기능은 죽여두고 Error 로그로 경고만 출력하도록 두었습니다.
  (2504793ae2deac19f315e9eb48ff27c9615faac2)
### 3) 여행지 id들을 DTO로 반환
- ae408f8a3f61f78f7a533925a296afd0b96bb159 DestinationService에서 id 리스트를 Dto 리스트로 반환하는 로직이 작성되었습니다.
  - a7dfbe754d56372f894745f749fffd4d9f75b9f1 이 과정에서 일부 로직 개선
  - 89459972cd18fcd4f36cb81dda0d6eb39c9301b8 DestinationRepository 내 일괄 조회 쿼리 추가됨.
### 4) 여행지의 검수 상태 관련 로직
- 여행지 검수 상태는 Destination 내부에 저장되지 않으며,
  Redis의 미검수 여행지로 등록되었는지에 따라 달라집니다.
- 71d62c3814dc8f9997a391a8ee2a494cb5fe2b1e 검수 로직은 여행지 도메인에서 삭제되었으며, Admin 도메인으로 이관되었습니다.
- 3f6d012a3033b1cd9d1233f573d5aa1c7192ba2f 검수 상태 확인은 DestinationDomainService 내 isApproved() 메소드로 지원됩니다.
### 5) 태그 추가시 유효성 검증
- 태그 추가를 위한 정보 생성에 TagInfo가 사용됨.
- 2762ed2a6bbce01883c7862f2cfd07c401fb6265 TagInfo를 일괄 생성하는 createAll() 메서드가 추가되었습니다.
- a20765c63d4129652390025a08404689b0ea4874 태그 유효성 일괄 검증을 위한 지원 메소드가 추가되었습니다.
### 6) Admin 도메인 기능 추가
- **미검수 여행지 조회 기능**
  아직 검수되지 않은 여행지를 조회합니다.
- **여행지 검수 기능**
  여행지를 검수합니다.
  - 현재 검수 과정에서 함께 처리되는 작업으로
  태그(고정태그) 설정 과정이 포함되어 있습니다.
### 참고) 개발용 API 지원
- 46c25269641c33e8fba5bf51ac0851c5b74fcad8 개발환경인 **dev 프로필**에서만 활성화되는 API가 포함됩니다.
  - Redis 미검수 여행지 id 리스트 조회
  - Redis 미검수 여행지 id 추가
  - Redis 미검수 여행지 id 삭제

## 테스트 결과
- 5개 API 테스트, 이상 무.
  <img src="https://github.com/user-attachments/assets/635a57f6-75c0-4af3-b9bc-a8b2d37b2d22" width=500/>

## 📌 추후 작업사항
- 관리자 여행지 거부 기능
- 관리자 여행지 수정 기능
- 관리자 리뷰 검수 기능
- TagInfo.create()의 인자값으로 DTO를 받도록 변경 예정

