### PR TITLE
Fix: 소셜로그인시 이름 정보가 누락되는 문제 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/AuthenticationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/AuthenticationService.java
@@ -40,7 +40,12 @@ public class AuthenticationService {
 	public void checkSsoAuthCode(SsoType type, String code) {
 		SsoOauthManager ssoOauthManager = Optional.ofNullable(ssoOauthManagers.get(type))
 				.orElseThrow(() -> new CustomException(ErrorType.UNSUPPORTED_SSO_LOGIN));
-		String token = ssoOauthManager.getAccessToken(code);
-		// 토큰 확인시 로그인, 회원가입 등등 처리
+		String rawResponse = ssoOauthManager.getAccessToken(code);
+		
+		System.out.println("소셜 로그인에 성공했습니다. : ");
+		System.out.println("\t type : " + type.toString());
+		System.out.println("\t response : " + rawResponse);
+		
+		// 토큰 확인 후 로그인, 회원가입 등등 처리
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
@@ -41,6 +41,7 @@ public class AuthController {
 	}
 
 	@GetMapping("/sso/callback/kakao")
+	@Operation(hidden = true)
 	public ResponseEntity<SuccessRes<?>> getSsoCallbackByKakao(
 			@RequestParam(name = "code", required = false) String code,
 			@RequestParam(name = "error", required = false) String error) {
@@ -48,6 +49,7 @@ public class AuthController {
 	}
 
 	@GetMapping("/sso/callback/google")
+	@Operation(hidden = true)
 	public ResponseEntity<SuccessRes<?>> getSsoCallbackByGoogle(
 			@RequestParam(name = "code", required = false) String code,
 			@RequestParam(name = "error", required = false) String error) {
@@ -67,7 +69,8 @@ public class AuthController {
 	@PostMapping("login/user")
 	@Operation(
 			summary = "SSO 로그인 요청",
-			description = "카카오 또는 구글 액세스 토큰을 이용하여 사용자 로그인을 처리합니다.",
+			description = "카카오 또는 구글 액세스 토큰을 이용하여 사용자 로그인을 처리합니다."
+			            + "<br/>카카오는 액세스 토큰, 구글은 ID 토큰을 사용합니다.",
 			tags = {"SSO Authentication"},
 			requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
 					description = "SSO 로그인 요청 데이터",

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/SsoUserInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/SsoUserInfo.java
@@ -1,31 +1,9 @@
 package com.se.Tlog.domain.User.controller.dto;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 public record SsoUserInfo(
         String providerId,
         String email,
         String nickname,
         String provider
 ) {
-    public static SsoUserInfo from(JsonNode jsonNode, String provider) {
-        System.out.println("jsonNode = " + jsonNode);
-
-        String providerId = jsonNode.path("id").asText();
-        String email = "";
-        String nickname = "";
-
-        switch (provider) {
-            case "kakao" -> {
-                JsonNode accountNode = jsonNode.path("kakao_account");
-                nickname = accountNode.path("profile").path("name").asText("");
-            }
-            case "google" -> {
-                email = jsonNode.path("email").asText("");
-                nickname = jsonNode.path("name").asText("");
-            }
-        }
-
-        return new SsoUserInfo(providerId, email, nickname, provider);
-    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/repository/api/GoogleSsoOauthManager.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/repository/api/GoogleSsoOauthManager.java
@@ -35,7 +35,7 @@ public class GoogleSsoOauthManager implements SsoOauthManager{
 		return GOOGLE_REQUEST_API +
 				"?client_id=" + GOOGLE_CLIENT_ID
 				+ "&redirect_uri=" + GOOGLE_CALLBACK
-				+ "&scope=" + "email"
+				+ "&scope=" + "email%20profile"
 				+ "&response_type=code";
 	}
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/repository/api/GoogleSsoService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/repository/api/GoogleSsoService.java
@@ -1,7 +1,5 @@
 package com.se.Tlog.domain.User.repository.api;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.javanet.NetHttpTransport;
@@ -14,8 +12,6 @@ import com.se.Tlog.global.response.error.ErrorType;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -24,22 +20,24 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class GoogleSsoService implements SsoService{
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     @Override
     public SsoUserInfo getUserInfo(String accessToken) {
-    	// Id Token을 사용하는 인증 방식입니다.
+    	// Id Token을 사용하는 인증 방식입니다. (일반 AccessToken과 다름)
     	
     	GoogleIdToken idToken = Optional.ofNullable(getIdToken(accessToken))
     			.orElseThrow(() -> new CustomException(ErrorType.GOOGLE_AUTH_FAIL));
-
-		Map<String, Object> map = new HashMap<String, Object>();
-		map.put("id", idToken.getPayload().getSubject());
-		map.put("email", idToken.getPayload().getEmail());
-		map.put("nickname", idToken.getPayload().get("name"));
 		
-        JsonNode jsonNode = objectMapper.valueToTree(map);
-        return SsoUserInfo.from(jsonNode, "google");
+    	// 구글의 ID 토큰 페이로드에 포함되는 항목과 이름에 관해서는 다음을 참고 :
+    	//      https://developers.google.com/identity/openid-connect/openid-connect?hl=ko#an-id-tokens-payload
+    	
+    	// 이메일 및 이름을 조회하기 위해서는, 소셜로그인을 실행하는 측(프론트 등)에서 scope 범위를 할당해서 로그인해야 함!
+        // 만약 프론트에서 scope가 제한된 ID 토큰을 보내주면, 서버에서 name을 조회할 수 있는 방법은 없음.
+        //    공식 문서 참고 : https://developers.google.com/identity/openid-connect/openid-connect?hl=ko#scope-param
+        return new SsoUserInfo(
+                idToken.getPayload().getSubject(),
+                idToken.getPayload().getEmail(), // 프론트에서 ID 토큰의 scope에 email을 포함해야 함.
+                idToken.getPayload().get("name").toString(), // 프론트에서 ID 토큰의 scope에 profile을 포함해야 함.
+                "google");
     }
     
     private GoogleIdToken getIdToken(String IdTokenString) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/repository/api/KakaoSsoService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/repository/api/KakaoSsoService.java
@@ -31,11 +31,19 @@ public class KakaoSsoService implements SsoService {
 
                 System.out.println("🔹 [DEBUG] Kakao API Response: " + response.getBody());
 
-                JsonNode jsonNode = objectMapper.readTree(response.getBody());
-                // 전화번호 정보 가져오기 (사용자가 동의했을 경우에만 존재)
-                // String phoneNumber = jsonNode.path("kakao_account").path("phone_number").asText(null);
-
-                return SsoUserInfo.from(jsonNode,"kakao");
+                JsonNode rootResponseNode = objectMapper.readTree(response.getBody());
+                JsonNode profileNode = rootResponseNode.at("/kakao_account/profile");
+                
+                // 이메일 및 전화번호 등 기타 정보는 프론트 앱이 비즈 앱으로 등록되어야 조회할 수 있습니다.
+                //    자세한 사항은 공식문서 및 카카오 동의항목 설정 페이지 참고 (Kakao Developers)
+                //    https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info-response
+                //    https://developers.kakao.com/console/app/1197999/product/login/scope
+                return new SsoUserInfo(
+                        rootResponseNode.path("id").asText(),
+                        "", // profileNode.path("email").asText(""), // 이메일
+                            // profileNode.path("phone_number").asText(""), // 전화번호
+                        profileNode.path("nickname").asText(""),
+                        "kakao");
             } catch (RestClientResponseException e){
                 System.err.println("❌ [ERROR] Kakao API 호출 실패: " + e.getStatusCode() + " / " + e.getResponseBodyAsString());
                 throw new CustomException(ErrorType.KAKAO_AUTH_FAIL);


### PR DESCRIPTION
## 작업 동기 및 이슈
- #119 

## 문제상황
- 소셜로그인 토큰을 받아 로그인을 시도하면,
  유저 정보에 이름이 누락됩니다.

## 원인
- 소셜로그인 성공시 반환되는 결과 데이터는 카카오와 구글에 따라 상이합니다.
  이름 키가 nickname인 경우, 그리고 name인 경우가 있어
  데이터 파싱 과정에서 이를 놓치면서 조회를 못한 것으로 보입니다.
  - **참고 :**
    ![카카오 페이로드 규격](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token-response-id-token)
    ![구글 페이로드 규격](https://developers.google.com/identity/openid-connect/openid-connect?hl=ko#an-id-tokens-payload)

## 추가 및 변경사항
### 1) 소셜로그인 후 응답 데이터 파싱 로직 수정
- (fb5ecf7c1037baf5b9a455d64d4129ec1a170ba1) 파싱 방식 변경
  - 기존에는 응답 데이터를 파싱한 후, ObjectMapper로 각기 매핑했습니다.
  - 이제 ObjectMapper를 거치지 않고, 각자 규격에 맞추어 이름, id, email 등을 추출한 후
    바로 SsoUesrInfo를 생성해 반환하도록 변경했습니다.

-  (b82efb4ee6cfd4ce62d94a240b65a472f8aa0d7e) SsoUesrInfo.from() 메서드 제거 
    - 각 SsoService에서 미리 데이터를 모두 파싱하므로, SsoUserInfo DTO에서 파싱하는 메서드는 사용되지 않습니다.

### 2) (웹용 API) 구글 소셜로그인 URL 생성시 name 정보를 제외하는 문제 수정
- (0c7d00005c62f71751152f124afdf0fad08b8501) 인증 성공시 반환되는 ID 토큰에 사용자 정보도 포함되도록 변경

### 3) 기타 문서화 및 로깅
- Callback용 API는 Swagger UI에서 숨김 처리되었습니다.
- (웹용 API) 소셜로그인 성공시 Spring 로그에 반환토큰이 출력됩니다.

## 테스트 결과
- 이상 무.
  최종 login API로 토큰을 전달한 후, 생성된 유저 정보를 확인하면
  이름, 이메일 정보가 모두 잘 저장되어 있습니다.

## 📌 기타

소셜로그인 응답 데이터에 포함되는 정보는 생각보다 적습니다.
구글 및 카카오 정책에 따라, 어떤 정보는 사용자 동의를 거치면 되지만, 어떤 정보는 앱 심의를 거쳐야 합니다.

- 구글의 경우
  기본적으로 로그인 절차에서 미리 사용할 정보에 대한 scope를 설정하도록 되어있습니다.
  그렇지 않으면, 이미 응답으로 받은 ID 토큰에는 해당 정보가 빠진 채로 전달받게 됩니다.

  - 공식 문서 참고 : https://developers.google.com/identity/openid-connect/openid-connect?hl=ko#scope-param

- 카카오의 경우
  이름을 제외한 이메일 및 전화번호 등 대부분의 정보는 프론트 앱이 비즈 앱으로 등록되어야 조회할 수 있습니다.
  <img src="https://github.com/user-attachments/assets/914e7498-e6ca-4d7d-a92c-6680cdcb7285" width="300"/>
  <img src="https://github.com/user-attachments/assets/c3532c18-d604-454d-9ce8-a49236349f47" width="300"/>

  - 자세한 사항은 공식문서 및 카카오 동의항목 설정 페이지 참고 (Kakao Developers)
    https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info-response
    https://developers.kakao.com/console/app/1197999/product/login/scope