### PR TITLE
Feature : 여행지 상세 및 리뷰 조회에 사용자 프로필 이미지 포함 및 토큰 응답 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
@@ -9,14 +9,15 @@ import com.se.Tlog.domain.Review.repository.mongo.ReviewRepository;
 
 import com.se.Tlog.domain.Travel.application.CustomTagService;
 import com.se.Tlog.domain.Travel.domain.service.DestinationDomainService;
+import com.se.Tlog.domain.User.controller.dto.UserProfileInfo;
+import com.se.Tlog.domain.User.domain.service.UserDomainService;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 
+import java.util.*;
+import java.util.stream.Collectors;
 
 
 @ApplicationService
@@ -25,6 +26,8 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final CustomTagService customTagService;
     private final DestinationDomainService destinationDomainService;
+    private final UserDomainService userDomainService;
+
     public Slice<DestinationReviewDto> getReviewsByDestinationId(String destinationId, SortType sortType, Pageable pageable) {
         destinationDomainService.validateExists(destinationId);
 
@@ -33,8 +36,21 @@ public class ReviewService {
                 pageable.getPageSize(),
                 getSort(sortType)
         );
-        return reviewRepository.findByDestinationId(destinationId, sortedPageable)
-                .map(DestinationReviewDto::from);
+        Slice<Review> reviews = reviewRepository.findByDestinationId(destinationId, sortedPageable);
+        Set<UUID> uniqueUserIds = reviews.stream()
+                .map(Review::getUserId)
+                .map(UUID::fromString)
+                .collect(Collectors.toSet());
+
+        Map<UUID,UserProfileInfo> userProfiles = userDomainService.getUserProfile(uniqueUserIds);
+
+        List<DestinationReviewDto> dtoList = reviews.getContent().stream().map(review -> {
+            UUID userId = UUID.fromString(review.getUserId());
+            UserProfileInfo userProfileInfo = userProfiles.get(userId);
+            return DestinationReviewDto.from(review, userProfileInfo);
+        }).toList();
+
+        return new SliceImpl<>(dtoList, sortedPageable, reviews.hasNext());
     }
 
     public void createReview(ReviewCreateDto reviewCreateDto) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/controller/dto/DestinationReviewDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/controller/dto/DestinationReviewDto.java
@@ -1,24 +1,30 @@
 package com.se.Tlog.domain.Review.controller.dto;
 
 import com.se.Tlog.domain.Review.domain.Review;
+import com.se.Tlog.domain.User.controller.dto.UserProfileInfo;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record DestinationReviewDto(
         String id,
         String userId,
         String username,
+        String userProfileImageUrl,
         int rating,
         String content,
+        List<String> reviewImageUrl,
         LocalDateTime createdAt
 ) {
-    public static DestinationReviewDto from(Review review) {
+    public static DestinationReviewDto from(Review review, UserProfileInfo userProfileInfo) {
         return new DestinationReviewDto(
                 review.getId(),
                 review.getUserId(),
                 review.getUsername(),
+                userProfileInfo.imageUrl(),
                 review.getRating(),
                 review.getContent(),
+                review.getImageUrlList(),
                 review.getCreatedAt()
         );
     }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/domain/service/ReviewDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/domain/service/ReviewDomainService.java
@@ -1,25 +1,39 @@
 package com.se.Tlog.domain.Review.domain.service;
 
 import com.se.Tlog.domain.Review.controller.dto.DestinationReviewDto;
+import com.se.Tlog.domain.Review.domain.Review;
 import com.se.Tlog.domain.Review.repository.mongo.ReviewRepository;
+import com.se.Tlog.domain.User.controller.dto.UserProfileInfo;
+import com.se.Tlog.domain.User.domain.service.UserDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ReviewDomainService {
     private final ReviewRepository reviewRepository;
+    private final UserDomainService userDomainService;
 
     public List<DestinationReviewDto> getTop2Reviews(String destinationId) {
         Pageable sortedPageable = PageRequest.of(0, 2, Sort.by(Sort.Order.desc("rating")).and(Sort.by(Sort.Order.desc("createAt"))));
+        Slice<Review> reviews = reviewRepository.findByDestinationId(destinationId, sortedPageable);
+        Set<UUID> uniqueUserIds = reviews.stream()
+                .map(Review::getUserId)
+                .map(UUID::fromString)
+                .collect(Collectors.toSet());
+        Map<UUID,UserProfileInfo> userProfiles = userDomainService.getUserProfile(uniqueUserIds);
 
-        return reviewRepository.findByDestinationId(destinationId, sortedPageable)
-                .map(DestinationReviewDto::from)
-                .getContent();
+        return reviews.stream().map(review -> {
+            UUID userId = UUID.fromString(review.getUserId());
+            UserProfileInfo userProfileInfo = userProfiles.get(userId);
+            return DestinationReviewDto.from(review, userProfileInfo);
+        }).toList();
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -1,5 +1,7 @@
 package com.se.Tlog.domain.User.application;
 
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
 import com.se.Tlog.domain.User.repository.api.SsoService;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.domain.ApplicationService;
@@ -50,9 +52,19 @@ public class SsoAuthService {
 
         redisUtil.save(refreshKey, refreshToken, refreshTokenProvider.getRefreshTokenDuration());
 
+        String customToken = null;
+        if(!ssoUserInfo.provider().equals("google")){
+            try{
+                customToken = FirebaseAuth.getInstance().createCustomToken(user.getId().toString());
+            }catch (FirebaseAuthException e) {
+                throw new CustomException(ErrorType.FIREBASE_CUSTOM_TOKEN_ISSUE_FAIL);
+            }
+        }
+
         return TokenDto.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .firebaseCustomToken(customToken)
                 .build();
     }
     public void logout(String accessToken,String refreshToken) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
@@ -19,6 +19,8 @@ import com.se.Tlog.global.response.success.SuccessType;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -89,7 +91,9 @@ public class AuthController {
 		return ResponseEntity.ok()
 				.header("Authorization",tokenDto.accessToken())
 				.header("Set-Cookie",tokenDto.refreshToken())
-				.body(SuccessRes.from(SuccessType.LOGIN_SSO_SUCCESS));
+				.body(SuccessRes.of(SuccessType.LOGIN_SSO_SUCCESS, Map.of(
+						"firebaseCustomToken", tokenDto.firebaseCustomToken()
+				)));
 	}
 
 	@PostMapping("/logout")

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/TokenDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/TokenDto.java
@@ -5,5 +5,6 @@ import lombok.Builder;
 @Builder
 public record TokenDto(
         String accessToken,
-        String refreshToken
+        String refreshToken,
+        String firebaseCustomToken
 ) { }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/UserProfileInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/UserProfileInfo.java
@@ -1,0 +1,13 @@
+package com.se.Tlog.domain.User.controller.dto;
+
+import com.se.Tlog.domain.User.domain.User;
+
+public record UserProfileInfo(
+        String imageUrl
+) {
+    public static UserProfileInfo of(User user){
+        return new UserProfileInfo(
+                user.getProfileImage()
+        );
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/service/UserDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/service/UserDomainService.java
@@ -1,7 +1,9 @@
 package com.se.Tlog.domain.User.domain.service;
 
 
+import com.se.Tlog.domain.User.controller.dto.UserProfileInfo;
 import com.se.Tlog.domain.User.controller.dto.UserSummaryDto;
+import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.domain.Wishlist.domain.OwnerType;
 import com.se.Tlog.domain.Wishlist.domain.WishlistService;
@@ -12,7 +14,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +29,15 @@ public class UserDomainService {
         return userRepository.findAllById(uuidList).stream()
                 .map(UserSummaryDto::from)
                 .toList();
+    }
+    public Map<UUID,UserProfileInfo> getUserProfile(Set<UUID> userIds) {
+        List<User> users = userRepository.findByIdIn(userIds);
+        if(users.size() != userIds.size()){
+            throw new CustomException(ErrorType.USER_NOT_FOUND);
+        }
+
+        return users.stream()
+                .collect(Collectors.toMap(User::getId, UserProfileInfo::of));
     }
     
     public void deleteUserAccount(UUID userId) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/repository/jpa/UserRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/repository/jpa/UserRepository.java
@@ -5,11 +5,14 @@ import org.springframework.stereotype.Repository;
 
 import com.se.Tlog.domain.User.domain.User;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByProviderUserInfo(String providerUserInfo);
     boolean existsBySnsId(String snsId); // 또는 snsId
+    List<User> findByIdIn(Set<UUID> userIds);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -76,6 +76,7 @@ public enum ErrorType {
     FIREBASE_INITIALIZE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. Firebase 라이브러리 초기화 에러."),
     FIREBASE_INITIALIZE_FAIL_KEY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러. Firebase Key 파일을 찾지 못했습니다."),
     BLACKLIST_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"블랙리스트 등록에 실패했습니다."),
+    FIREBASE_CUSTOM_TOKEN_ISSUE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "Firebase 커스텀 토큰 발급 실패"),
     // 외부 소셜 로그인 처리 중 에러
     SSO_ACCESSTOKEN_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "외부 인증 서버로부터 인증을 받는데 실패했습니다."),
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),


### PR DESCRIPTION
## 작업 동기 및 이슈
- #122 

## 추가 및 변경사항
- 특정 여행지 조회시 사용자의 프로필 이미지가 포함되게끔 수정되었습니다.
- 특정 여행지 리뷰 조회시 사용자의 프로필 이미지가 포함되게끔 수정되었습니다.
- 구글을 제외한 나머지 소셜 로그인의 경우 파이어베이스의 커스텀 토큰이 필요하다고 하여 로그인시 커스텀 토큰을 응답 body에 포함시켰습니다!

## 테스트 결과
### 커스텀 토큰 발급
<img width="1401" alt="스크린샷 2025-05-26 오후 6 01 34" src="https://github.com/user-attachments/assets/b492997f-c723-476a-a225-331882b7cc8a" />

### 리뷰 dto 사용자 프로필 반영
<img width="805" alt="스크린샷 2025-05-26 오후 6 27 22" src="https://github.com/user-attachments/assets/b9529f77-33e1-4b37-9b09-8ce989fd7deb" />


## 📌 기타
