### PR TITLE
Feature: 알림 메시지 규격 추가

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/application/NotificationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/application/NotificationService.java
@@ -1,9 +1,12 @@
 package com.se.Tlog.domain.Notification.application;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Notification.controller.dto.AssignTokenRequestDto;
+import com.se.Tlog.domain.Notification.domain.LinkType;
+import com.se.Tlog.domain.Notification.domain.MessageGenerator;
 import com.se.Tlog.domain.Notification.repository.NotificationUtil;
 import com.se.Tlog.domain.Notification.repository.jpa.FcmTokenRepository;
 import com.se.Tlog.domain.Notification.repository.jpa.entity.UserFcmTokenJpaEntity;
@@ -14,12 +17,22 @@ import com.se.Tlog.global.response.error.ErrorType;
 
 import lombok.RequiredArgsConstructor;
 
+
+/** =====================================
+ * 
+ *   알림 전송 실패시 기본 정책 :
+ * 
+ *      모든 알림은 전송 실패시 무시하고 계속 진행합니다.
+ *
+ *  ===================================== */
+
 @ApplicationService
 @RequiredArgsConstructor
 public class NotificationService {
 	private final NotificationUtil notificationUtil;
 	private final FcmTokenRepository fcmTokenRepository;
 	private final UserRepository userRepository;
+	private final MessageGenerator messageGenerator;
 	
 	public void assignFirebaseToken(AssignTokenRequestDto request) {
 		Optional<User> user = userRepository.findById(request.userId());
@@ -35,4 +48,76 @@ public class NotificationService {
 			userFcmEntity.updateFirebaseToken(request.firebaseToken());
 		fcmTokenRepository.save(userFcmEntity);
 	}
+
+	public void sendDefaultStringMessage(UUID receiverId, String content) {
+        notificationUtil.sendNotification(
+                messageGenerator.getDefaultStringMessage(receiverId, content));
+    }
+    
+    public void sendMyPageLinkMessage(
+            UUID receiverId,
+            String content) {
+        notificationUtil.sendNotification(
+                messageGenerator.getLinkableMessage(
+                        receiverId,
+                        LinkType.PAGE_MYPAGE,
+                        "",
+                        content));
+    }
+	
+	public void sendDestinationLinkMessage(
+            UUID receiverId,
+            String destinationId,
+            String content) {
+        notificationUtil.sendNotification(
+                messageGenerator.getLinkableMessage(
+                        receiverId,
+                        LinkType.LINK_DESTINATION,
+                        destinationId,
+                        content));
+    }
+    
+    public void sendUserLinkMessage(
+            UUID receiverId,
+            UUID linkedUserId,
+            String content) {
+        notificationUtil.sendNotification(
+                messageGenerator.getLinkableMessage(
+                        receiverId,
+                        LinkType.LINK_DESTINATION,
+                        linkedUserId.toString(),
+                        content));
+    }
+	
+	public void sendDefaultSnsMessage(
+	        UUID receiverId, 
+            UUID actorId, 
+            String actorImage,
+            String content,
+            String objectId, // 게시물 id의 형식에 맞추어 변경 예정
+            String objectImage) {
+        notificationUtil.sendNotification(
+                messageGenerator.getDefaultSnsMessage(
+                        receiverId,
+                        actorId,
+                        actorImage,
+                        content,
+                        objectId,
+                        objectImage));
+    }
+	
+	public void sendFollowMessage(
+            UUID receiverId, 
+            UUID actorId, 
+            String actorImage,
+            String content,
+            boolean isFollowing) {
+        notificationUtil.sendNotification(
+                messageGenerator.getFollowMessage(
+                        receiverId,
+                        actorId,
+                        actorImage,
+                        content,
+                        isFollowing));
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/application/NotificationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/application/NotificationService.java
@@ -2,8 +2,6 @@ package com.se.Tlog.domain.Notification.application;
 
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Notification.controller.dto.AssignTokenRequestDto;
 import com.se.Tlog.domain.Notification.repository.NotificationUtil;
@@ -14,14 +12,14 @@ import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 
+import lombok.RequiredArgsConstructor;
+
 @ApplicationService
+@RequiredArgsConstructor
 public class NotificationService {
-	@Autowired
-	private NotificationUtil notificationUtil;
-	@Autowired
-	private FcmTokenRepository fcmTokenRepository;
-	@Autowired
-	private UserRepository userRepository;
+	private final NotificationUtil notificationUtil;
+	private final FcmTokenRepository fcmTokenRepository;
+	private final UserRepository userRepository;
 	
 	public void assignFirebaseToken(AssignTokenRequestDto request) {
 		Optional<User> user = userRepository.findById(request.userId());

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestFcmMessageByTokenDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestFcmMessageByTokenDto.java
@@ -1,11 +1,13 @@
 package com.se.Tlog.domain.Notification.controller.test;
 
 import java.util.List;
+import java.util.Map;
 
-import com.se.Tlog.domain.Notification.repository.dto.FcmKeyValuePairDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 record TestFcmMessageDto(
-		List<FcmKeyValuePairDto> payloads) {
+        @Schema(example = "{\"key1\": \"value1\", \"key2\": \"value2\"}")
+		Map<String, String> payloads) {
 	
 }
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestNotificationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestNotificationController.java
@@ -4,8 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,9 +17,7 @@ import com.se.Tlog.domain.Notification.repository.dto.FcmMessageDto;
 import com.se.Tlog.domain.Notification.repository.dto.FcmRequestDto;
 import com.se.Tlog.domain.Notification.repository.jpa.FcmTokenRepository;
 import com.se.Tlog.domain.Notification.repository.jpa.entity.UserFcmTokenJpaEntity;
-import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorRes;
-import com.se.Tlog.global.response.error.ErrorType;
 import com.se.Tlog.global.response.success.SuccessRes;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,22 +25,25 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 
 @Controller
-@RequestMapping("/test/notify")
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "springdoc.swagger-ui.enabled", havingValue = "true")
+// @Profile("dev") // 현재 활성화 기준이 Swagger 임을 감안.
+@RequestMapping("api/test/notify")
+@Tag(name = "알림")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
 public class TestNotificationController {
-	@Autowired
-	private NotificationUtil notificationUtil;
-	@Autowired
-	private FcmWrapper fcmWrapper;
-	@Autowired
-	private FcmTokenRepository repository;
-	
-	@Value("${springdoc.swagger-ui.enabled}")
-	private boolean swaggerTestEnabled;
+	private final NotificationUtil notificationUtil;
+	private final FcmWrapper fcmWrapper;
+	private final FcmTokenRepository repository;
 	
 	@PostMapping("/byUserId")
 	@Operation (
@@ -57,18 +57,12 @@ public class TestNotificationController {
     				+ "<br/> - 한 유저에게 단일 메세지 전송 : 1 userId, 1 message일 때"
     				+ "<br/> - 여러 유저에게 단일 메세지 전송 : N userId, 1 message일 때"
     				+ "<br/> - 여러 유저에게 여러 메세지 전송(메세지 수 만큼 전송합니다.) : N userId, M message일 때",
-			tags = {"알림"},
-			security = @SecurityRequirement(
-					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
-					scopes = {"scope1", "scope2"}),
 			responses = {
 					@ApiResponse(responseCode = "200", description = "처리 성공."),
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
 	public ResponseEntity<SuccessRes<String>> testFcmNotificationByUserId(@RequestBody TestFcmMessageByUserIdDto request) {
-		if (!swaggerTestEnabled)
-			throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
 		if (request.users().size() == 0)
 			return ResponseEntity.ok(SuccessRes.from("전송할 유저가 등록되지 않았습니다."));
 
@@ -113,18 +107,12 @@ public class TestNotificationController {
     				+ "<br/> - 한 클라이언트에게 단일 메세지 전송 : 1 token, 1 message일 때"
     				+ "<br/> - 여러 클라이언트에게 단일 메세지 전송 : N token, 1 message일 때"
     				+ "<br/> - 여러 클라이언트에게 여러 메세지 전송(메세지 수 만큼 전송합니다.) : N token, M message일 때",
-			tags = {"알림"},
-			security = @SecurityRequirement(
-					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
-					scopes = {"scope1", "scope2"}),
 			responses = {
 					@ApiResponse(responseCode = "200", description = "처리 성공."),
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
 	public ResponseEntity<SuccessRes<String>> testFcmNotificationByToken(@RequestBody TestFcmMessageByTokenDto request) {
-		if (!swaggerTestEnabled)
-			throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
 		if (request.tokens().size() == 0)
 			return ResponseEntity.ok(SuccessRes.from("전송할 토큰이 등록되지 않았습니다."));
 		

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestNotificationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestNotificationController.java
@@ -35,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @ConditionalOnProperty(name = "springdoc.swagger-ui.enabled", havingValue = "true")
 // @Profile("dev") // 현재 활성화 기준이 Swagger 임을 감안.
-@RequestMapping("api/test/notify")
+@RequestMapping("/api/test/notify")
 @Tag(name = "알림")
 @SecurityRequirement(
         name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
@@ -45,10 +45,10 @@ public class TestNotificationController {
 	private final FcmWrapper fcmWrapper;
 	private final FcmTokenRepository repository;
 	
-	@PostMapping("/byUserId")
+	@PostMapping("/by-user-id")
 	@Operation (
-			summary = "FCM 테스트 - UserId (dev 환경에서만 지원됨)",
-    		description = "FCM 기능을 테스트하는 API입니다. (Swagger UI를 사용하는 dev환경에서만 지원됩니다.)"
+			summary = "[개발환경 전용] FCM 테스트 - UserId",
+    		description = "[개발환경 전용] FCM 기능을 테스트하는 API입니다."
     				+ "<br/>"
     				+ "<br/> User 및 FcmToken은 DB에 별도 등록 필요."
     				+ "<br/> 요청 처리 결과를 반환합니다. (실패 사유 : 유저 또는 FCM 토큰이 DB에 등록되지 않음)"
@@ -96,10 +96,10 @@ public class TestNotificationController {
 		}
 	}
 	
-	@PostMapping("/byToken")
+	@PostMapping("/by-token")
 	@Operation (
-			summary = "FCM 테스트 - FcmToken (dev 환경에서만 지원됨)",
-    		description = "FCM 기능을 테스트하는 API입니다. (Swagger UI를 사용하는 dev환경에서만 지원됩니다.)"
+			summary = "[개발환경 전용] FCM 테스트 - FcmToken",
+    		description = "[개발환경 전용] FCM 기능을 테스트하는 API입니다."
     				+ "<br/>"
     				+ "<br/> 요청 처리 결과를 반환합니다. (실패 사유 : 토큰이 유효하지 않음)"
     				+ "<br/>"

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestNotificationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestNotificationController.java
@@ -79,7 +79,7 @@ public class TestNotificationController {
 		
 		if (request.users().size() == 1 && messages.size() == 1) {
 			boolean requested = notificationUtil.sendNotification(messages.get(0));
-			UserFcmTokenJpaEntity entity = repository.findByUserId(messages.get(0).userId());
+			UserFcmTokenJpaEntity entity = repository.findByUserId(messages.get(0).getUserId());
 			log.info("Send single message : " + (entity != null ? entity.getFcmToken() : "user not found"));
 			
 			return ResponseEntity.ok(SuccessRes.from("처리 결과 : " + (requested?"1":"0") + "/1"));
@@ -130,7 +130,7 @@ public class TestNotificationController {
 		if (request.tokens().size() == 1 && messages.size() == 1) {
 			try {
 				boolean successed = fcmWrapper.sendFcmMessage(messages.get(0)).get();	
-				log.info("Send single message : " + messages.get(0).fcmToken());
+				log.info("Send single message : " + messages.get(0).getFcmToken());
 				return ResponseEntity.ok(SuccessRes.from("처리 결과 : " + (successed?1:0) + "/1"));
 			} catch (Exception e) {
 				log.info("Send single message : fail");

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestNotificationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestNotificationController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.se.Tlog.domain.Notification.domain.MessageGenerator;
 import com.se.Tlog.domain.Notification.repository.FcmWrapper;
 import com.se.Tlog.domain.Notification.repository.NotificationUtil;
 import com.se.Tlog.domain.Notification.repository.dto.FcmMessageDto;
@@ -44,6 +45,7 @@ public class TestNotificationController {
 	private final NotificationUtil notificationUtil;
 	private final FcmWrapper fcmWrapper;
 	private final FcmTokenRepository repository;
+	private final MessageGenerator messageGenerator;
 	
 	@PostMapping("/by-user-id")
 	@Operation (
@@ -156,4 +158,36 @@ public class TestNotificationController {
 			}
 		}
 	}
+	
+    @PostMapping("/send-push-message")
+    @Operation (
+            summary = "[개발환경 전용] 알림 테스트 (Tlog 메시지 규격에 맞춰 동작)",
+            description = "[개발환경 전용] FCM 기능을 테스트하는 API입니다."
+                        + "<br> 한 알림을 여러 클라이언트에게 전송합니다."
+                        + "<br>"
+                        + "<br> - 페이로드는 메시지 규격에 맞아야 합니다."
+                        + "<br> - 토큰이 유효해 전송에 성공한 수를 반환합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<String>> testDefaultNotification(@RequestBody TestNotificationDto request) {
+        if (request.tokens().size() == 0)
+            return ResponseEntity.ok(SuccessRes.from("전송할 토큰이 등록되지 않았습니다."));
+        
+        FcmRequestDto parsedMessage = messageGenerator.getMessage(UUID.randomUUID(), request.data());
+        List<FcmMessageDto> validMessages = request.tokens().stream()
+                .filter(token -> (null != token))
+                .map(token -> new FcmMessageDto(token, parsedMessage.getPayload()))
+                .toList();
+        
+        int successCnt = 0;
+        try {
+            successCnt = fcmWrapper.sendFcmMessages(validMessages).get();
+        } catch (Exception e) {
+            
+        }
+        return ResponseEntity.ok(SuccessRes.from("처리 결과 : " + request.tokens().size() + "/" + successCnt));
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestNotificationDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/controller/test/TestNotificationDto.java
@@ -1,0 +1,10 @@
+package com.se.Tlog.domain.Notification.controller.test;
+
+import java.util.List;
+import java.util.Map;
+
+public record TestNotificationDto(
+        List<String> tokens,
+        Map<String, String> data) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/domain/LinkType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/domain/LinkType.java
@@ -1,0 +1,29 @@
+package com.se.Tlog.domain.Notification.domain;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+public enum LinkType {
+    PAGE_MAIN(1),
+    PAGE_MYPAGE(2),
+    LINK_DESTINATION(10),
+    LINK_POST(11),
+    LINK_USER_SNS(12),
+    LINK_CHAT_ROOM(13);
+    
+    private final int code;
+    LinkType(int code) { this.code = code; }
+    public String code() { return Integer.toString(code); }
+
+    static LinkType of(String code) {
+        try {
+            int parsedCode = Integer.parseInt(code);
+            for (LinkType m : LinkType.values())
+                if (m.code == parsedCode)
+                    return m;
+        } catch (Exception e) {
+        
+        }
+        throw new CustomException(ErrorType.INVALID_LINK_MESSAGE_TYPE);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/domain/MessageGenerator.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/domain/MessageGenerator.java
@@ -1,0 +1,121 @@
+package com.se.Tlog.domain.Notification.domain;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.se.Tlog.domain.Notification.repository.dto.FcmRequestDto;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MessageGenerator {
+    private static final String KEYWORD_MESSAGE_TYPE = "tlog-message-type";
+    private static final String KEYWORD_LINK_TYPE = "link-type";
+    private static final String KEYWORD_LINK_ADDRESS = "link-address";
+    private static final String KEYWORD_CONTENT = "content";
+    private static final String KEYWORD_ACTOR_ID = "actor-id";
+    private static final String KEYWORD_ACTOR_IMAGE = "actor-image";
+    private static final String KEYWORD_OBJECT_ID = "object-id";
+    private static final String KEYWORD_OBJECT_IMAGE = "object-image";
+    private static final String KEYWORD_FOLLOW_STATE = "is-following";
+    
+    // FCM 메시지 규격이 맞는지 확인하는 역할이므로
+    // receiverId가 굳이 필요없다 판단되면
+    // 추후 삭제할 예정입니다.
+    
+    public FcmRequestDto getMessage(UUID receiverId, Map<String, String> payload) {
+        try {
+            return 
+                    switch (MessageType.of(payload.get(KEYWORD_MESSAGE_TYPE))) {
+                    case DEFAULT_STRING_MESSAGE -> getDefaultStringMessage(
+                            receiverId, 
+                            payload.get(KEYWORD_CONTENT));
+                    case LINKABLE_MESSAGE -> getLinkableMessage(
+                            receiverId, 
+                            LinkType.of(payload.get(KEYWORD_LINK_TYPE)),
+                            payload.get(KEYWORD_LINK_ADDRESS),
+                            payload.get(KEYWORD_CONTENT));
+                    case DEFAULT_SNS_MESSAGE -> getDefaultSnsMessage(
+                            receiverId,
+                            UUID.fromString(payload.get(KEYWORD_ACTOR_ID)),
+                            payload.get(KEYWORD_ACTOR_IMAGE),
+                            payload.get(KEYWORD_CONTENT),
+                            payload.get(KEYWORD_OBJECT_ID),
+                            payload.get(KEYWORD_OBJECT_IMAGE));
+                    case FOLLOW_MESSAGE -> getFollowMessage(
+                            receiverId, 
+                            UUID.fromString(payload.get(KEYWORD_ACTOR_ID)),
+                            payload.get(KEYWORD_ACTOR_IMAGE),
+                            payload.get(KEYWORD_CONTENT),
+                            Boolean.getBoolean(payload.get(KEYWORD_FOLLOW_STATE)));
+                    };
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CustomException(ErrorType.INVALID_TLOG_MESSAGE);
+        }
+    }
+    
+    public FcmRequestDto getDefaultStringMessage(
+            UUID receiverId,
+            String content) {
+        return new FcmRequestDto(
+                receiverId, 
+                Map.of(
+                        KEYWORD_MESSAGE_TYPE, MessageType.DEFAULT_STRING_MESSAGE.code(),
+                        KEYWORD_CONTENT, content));
+    }
+    
+    public FcmRequestDto getLinkableMessage(
+            UUID receiverId,
+            LinkType linkType,
+            String linkAddress,
+            String content) {
+        return new FcmRequestDto(
+                receiverId, 
+                Map.of(
+                        KEYWORD_MESSAGE_TYPE, MessageType.LINKABLE_MESSAGE.code(),
+                        KEYWORD_LINK_TYPE, linkType.code(),
+                        KEYWORD_LINK_ADDRESS, linkAddress,
+                        KEYWORD_CONTENT, content));
+    }
+    
+    public FcmRequestDto getDefaultSnsMessage(
+            UUID receiverId, 
+            UUID actorId, 
+            String actorImage,
+            String content,
+            String objectId, // 게시물 id의 형식에 맞추어 변경 예정
+            String objectImage) {
+        return new FcmRequestDto(
+                receiverId, 
+                Map.of(
+                        KEYWORD_MESSAGE_TYPE, MessageType.DEFAULT_SNS_MESSAGE.code(),
+                        KEYWORD_ACTOR_ID, actorId.toString(),
+                        KEYWORD_ACTOR_IMAGE, actorImage,
+                        KEYWORD_CONTENT, content,
+                        KEYWORD_OBJECT_ID, objectId,
+                        KEYWORD_OBJECT_IMAGE, objectImage));
+    }
+    
+    public FcmRequestDto getFollowMessage(
+            UUID receiverId, 
+            UUID actorId, 
+            String actorImage,
+            String content,
+            boolean isFollowing) {
+        return new FcmRequestDto(
+                receiverId, 
+                Map.of(
+                        KEYWORD_MESSAGE_TYPE, MessageType.FOLLOW_MESSAGE.code(),
+                        KEYWORD_ACTOR_ID, actorId.toString(),
+                        KEYWORD_ACTOR_IMAGE, actorImage,
+                        KEYWORD_CONTENT, content,
+                        KEYWORD_FOLLOW_STATE, Boolean.toString(isFollowing)));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/domain/MessageType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/domain/MessageType.java
@@ -1,0 +1,27 @@
+package com.se.Tlog.domain.Notification.domain;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+public enum MessageType {
+    DEFAULT_STRING_MESSAGE(1),
+    LINKABLE_MESSAGE(2),
+    DEFAULT_SNS_MESSAGE(10),
+    FOLLOW_MESSAGE(11);
+    
+    private final int code;
+    MessageType(int code) { this.code = code; }
+    public String code() { return Integer.toString(code); }
+    
+    static MessageType of(String code) {
+        try {
+            int parsedCode = Integer.parseInt(code);
+            for (MessageType m : MessageType.values())
+                if (m.code == parsedCode)
+                    return m;
+        } catch (Exception e) {
+        
+        }
+        throw new CustomException(ErrorType.INVALID_TLOG_MESSAGE_TYPE);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/FcmWrapper.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/FcmWrapper.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -21,19 +20,21 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.MulticastMessage;
-import com.se.Tlog.domain.Notification.repository.dto.FcmKeyValuePairDto;
 import com.se.Tlog.domain.Notification.repository.dto.FcmMessageDto;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 
 @Component
+@RequiredArgsConstructor
 public class FcmWrapper implements InitializingBean {
-	@Autowired
-	private InvalidTokenHandler invalidTokenHandler;
+	private final InvalidTokenHandler invalidTokenHandler;
+	
+	private static final int MAX_MESSAGE_COUNT = 500;
 	
 	@Value("${firebase-env.key-path}")
 	private String SERVICE_ACCOUNT_KEY_PATH;
@@ -43,26 +44,23 @@ public class FcmWrapper implements InitializingBean {
 		initializeFirebaseApp();
 		log.info("FCM Initialize Done");
 	}
-
-	private static final int MAX_MESSAGE_COUNT = 500;
 	
 	private void initializeFirebaseApp() {
 		if (!FirebaseApp.getApps().isEmpty())
 			return;
 		
 		try {
-			FileInputStream serviceAccount = new FileInputStream(SERVICE_ACCOUNT_KEY_PATH);
 			FirebaseOptions options = FirebaseOptions.builder()
-					.setCredentials(GoogleCredentials.fromStream(serviceAccount))
+					.setCredentials(GoogleCredentials.fromStream(
+					        new FileInputStream(SERVICE_ACCOUNT_KEY_PATH)))
 					.build();
-
 			FirebaseApp.initializeApp(options);
 		} catch (Exception e) {
 			if (e.getClass() == FileNotFoundException.class)
 				throw new CustomException(ErrorType.FIREBASE_INITIALIZE_FAIL_KEY_NOT_FOUND);
 			else
 				throw new CustomException(ErrorType.FIREBASE_INITIALIZE_FAIL);
-		}		
+		}
 	}
 	
 	public boolean isValidToken(String firebaseToken) {
@@ -97,12 +95,10 @@ public class FcmWrapper implements InitializingBean {
 	}
 
 	private Message toMessage(FcmMessageDto dto) {
-		Message.Builder messageBuilder = Message.builder();
-		messageBuilder.setToken(dto.fcmToken());
-		for (FcmKeyValuePairDto payload : dto.payload())
-			messageBuilder.putData(payload.key(), payload.value());
-		
-		return messageBuilder.build();
+		return Message.builder()
+		        .setToken(dto.fcmToken())
+		        .putAllData(dto.payload())
+		        .build();
 	}
 	
 	/**
@@ -112,13 +108,12 @@ public class FcmWrapper implements InitializingBean {
 	private List<List<Message>> separatedMessages(List<FcmMessageDto> messagesDto) {
 		List<List<Message>> separatedMessages = new ArrayList<List<Message>>();
 		
-		int messageCount = 0;
-		for (int partition = 0; partition <= (messagesDto.size()-1)/MAX_MESSAGE_COUNT; partition++) {
-			List<Message> messages = new ArrayList<Message>();
-			while (messageCount < messagesDto.size() && messages.size() < MAX_MESSAGE_COUNT)
-				messages.add(toMessage(messagesDto.get(messageCount++)));
-			
-			separatedMessages.add(messages);
+		int offset = 0;
+		while (offset < messagesDto.size()) {
+		    separatedMessages.add(
+		            messagesDto.subList(offset, Math.min(offset + MAX_MESSAGE_COUNT, messagesDto.size()))
+		            .stream().map(this::toMessage).toList());
+		    offset += MAX_MESSAGE_COUNT;
 		}
 		
 		return separatedMessages;
@@ -131,17 +126,14 @@ public class FcmWrapper implements InitializingBean {
 	private List<MulticastMessage> separatedMessages(List<String> tokens, FcmMessageDto messageDto) {
 		List<MulticastMessage> separatedMessages = new ArrayList<MulticastMessage>();
 		
-		for (int partition = 0; partition <= (tokens.size()-1)/MAX_MESSAGE_COUNT; partition++) {
-			MulticastMessage.Builder messageBuilder = MulticastMessage.builder();
-			messageBuilder.addAllTokens(
-					tokens.subList(
-							partition * MAX_MESSAGE_COUNT, 
-							Math.min((partition + 1) * MAX_MESSAGE_COUNT, tokens.size())));
-			for (FcmKeyValuePairDto payload : messageDto.payload())
-				messageBuilder.putData(payload.key(), payload.value());
-			
-			separatedMessages.add(messageBuilder.build());
-		}
+		int offset = 0;
+        while (offset < tokens.size()) {
+            separatedMessages.add(
+                    MulticastMessage.builder()
+                    .addAllTokens(tokens.subList(offset, Math.min(offset + MAX_MESSAGE_COUNT, tokens.size())))
+                    .putAllData(messageDto.payload()).build());
+            offset += MAX_MESSAGE_COUNT;
+        }
 		
 		return separatedMessages;
 	}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/FcmWrapper.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/FcmWrapper.java
@@ -96,8 +96,8 @@ public class FcmWrapper implements InitializingBean {
 
 	private Message toMessage(FcmMessageDto dto) {
 		return Message.builder()
-		        .setToken(dto.fcmToken())
-		        .putAllData(dto.payload())
+		        .setToken(dto.getFcmToken())
+		        .putAllData(dto.getPayload())
 		        .build();
 	}
 	
@@ -131,7 +131,7 @@ public class FcmWrapper implements InitializingBean {
             separatedMessages.add(
                     MulticastMessage.builder()
                     .addAllTokens(tokens.subList(offset, Math.min(offset + MAX_MESSAGE_COUNT, tokens.size())))
-                    .putAllData(messageDto.payload()).build());
+                    .putAllData(messageDto.getPayload()).build());
             offset += MAX_MESSAGE_COUNT;
         }
 		

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/NotificationUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/NotificationUtil.java
@@ -35,11 +35,11 @@ public class NotificationUtil {
 	 * @param request
 	 */
 	public boolean sendNotification(FcmRequestDto request) {
-		UserFcmTokenJpaEntity dbEntity = fcmTokenRepository.findByUserId(request.userId());
+		UserFcmTokenJpaEntity dbEntity = fcmTokenRepository.findByUserId(request.getUserId());
 		if (dbEntity == null)
 			return false;
 		
-		fcmWrapper.sendFcmMessage(new FcmMessageDto(dbEntity.getFcmToken(), request.payload()));
+		fcmWrapper.sendFcmMessage(new FcmMessageDto(dbEntity.getFcmToken(), request.getPayload()));
 		return true;
 	}
 	
@@ -55,7 +55,7 @@ public class NotificationUtil {
 		int validTokens = tokens.size();
 		
 		if (validTokens > 0)
-			fcmWrapper.sendFcmMessages(tokens, new FcmMessageDto(null, request.payload()));
+			fcmWrapper.sendFcmMessages(tokens, new FcmMessageDto(null, request.getPayload()));
 		return validTokens;
 	}
 	
@@ -66,15 +66,15 @@ public class NotificationUtil {
 	 */
 	public int sendNotifications(List<FcmRequestDto> requests) {
 		// DB 접근의 최소화를 위해, user -> token 일괄 변환
-	    List<UUID> users = requests.stream().map(FcmRequestDto::userId).toList();
+	    List<UUID> users = requests.stream().map(FcmRequestDto::getUserId).toList();
 		Map<UUID, String> tokenMap = fcmTokenRepository.findAllByUserIdIn(users)
 				.stream().collect(Collectors.toMap(e -> e.getUser().getId(), e -> e.getFcmToken()));
 		if (tokenMap.size() == 0)
 			return 0;
 
 		List<FcmMessageDto> messages = requests.stream()
-		        .filter(request -> tokenMap.containsKey(request.userId()))
-		        .map(request -> new FcmMessageDto(tokenMap.get(request.userId()), request.payload()))
+		        .filter(request -> tokenMap.containsKey(request.getUserId()))
+		        .map(request -> new FcmMessageDto(tokenMap.get(request.getUserId()), request.getPayload()))
 		        .toList();
 		
 		fcmWrapper.sendFcmMessages(messages);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/NotificationUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/NotificationUtil.java
@@ -1,6 +1,5 @@
 package com.se.Tlog.domain.Notification.repository;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -67,23 +66,18 @@ public class NotificationUtil {
 	 */
 	public int sendNotifications(List<FcmRequestDto> requests) {
 		// DB 접근의 최소화를 위해, user -> token 일괄 변환
-		List<UUID> users = new ArrayList<UUID>();
-		for (FcmRequestDto m : requests)
-			users.add(m.userId());
-		if (users.size() == 0)
-			return 0;
-		
+	    List<UUID> users = requests.stream().map(FcmRequestDto::userId).toList();
 		Map<UUID, String> tokenMap = fcmTokenRepository.findAllByUserIdIn(users)
 				.stream().collect(Collectors.toMap(e -> e.getUser().getId(), e -> e.getFcmToken()));
 		if (tokenMap.size() == 0)
 			return 0;
 
-		List<FcmMessageDto> messages = new ArrayList<FcmMessageDto>();
-		for (FcmRequestDto m : requests)
-			if (tokenMap.containsKey(m.userId()))
-				messages.add(new FcmMessageDto(tokenMap.get(m.userId()), m.payload()));
-		fcmWrapper.sendFcmMessages(messages);
+		List<FcmMessageDto> messages = requests.stream()
+		        .filter(request -> tokenMap.containsKey(request.userId()))
+		        .map(request -> new FcmMessageDto(tokenMap.get(request.userId()), request.payload()))
+		        .toList();
 		
+		fcmWrapper.sendFcmMessages(messages);
 		return tokenMap.size();
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmKeyValuePairDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmKeyValuePairDto.java
@@ -1,7 +1,0 @@
-package com.se.Tlog.domain.Notification.repository.dto;
-
-public record FcmKeyValuePairDto(
-		String key,
-		String value) {
-
-}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmMessageDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmMessageDto.java
@@ -1,9 +1,9 @@
 package com.se.Tlog.domain.Notification.repository.dto;
 
-import java.util.List;
+import java.util.Map;
 
 public record FcmMessageDto(
 		String fcmToken,
-		List<FcmKeyValuePairDto> payload) {
+		Map<String, String> payload) {
 
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmMessageDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmMessageDto.java
@@ -2,8 +2,20 @@ package com.se.Tlog.domain.Notification.repository.dto;
 
 import java.util.Map;
 
-public record FcmMessageDto(
-		String fcmToken,
-		Map<String, String> payload) {
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
 
+import lombok.Getter;
+
+@Getter
+public class FcmMessageDto {
+    private String fcmToken;
+    private Map<String, String> payload;
+    
+    public FcmMessageDto(String fcmToken, Map<String, String> payload) {
+        if (fcmToken == null || payload.values().stream().anyMatch(v -> v == null))
+            throw new CustomException(ErrorType.NULL_IN_FCM_MESSAGE);
+        this.fcmToken = fcmToken;
+        this.payload = payload;
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmRequestDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmRequestDto.java
@@ -1,10 +1,10 @@
 package com.se.Tlog.domain.Notification.repository.dto;
 
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public record FcmRequestDto(
 		UUID userId,
-		List<FcmKeyValuePairDto> payload) {
+		Map<String, String> payload) {
 
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmRequestDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Notification/repository/dto/FcmRequestDto.java
@@ -3,8 +3,20 @@ package com.se.Tlog.domain.Notification.repository.dto;
 import java.util.Map;
 import java.util.UUID;
 
-public record FcmRequestDto(
-		UUID userId,
-		Map<String, String> payload) {
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
 
+import lombok.Getter;
+
+@Getter
+public class FcmRequestDto {
+    private UUID userId;
+    private Map<String, String> payload;
+    
+    public FcmRequestDto(UUID userId, Map<String, String> payload) {
+        if (userId == null || payload.values().stream().anyMatch(v -> v == null))
+            throw new CustomException(ErrorType.NULL_IN_FCM_MESSAGE);
+        this.userId = userId;
+        this.payload = payload;
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -35,6 +35,12 @@ public enum ErrorType {
     // 어드민 관련 검증
     ALREADY_APPROVED_DESTINATION(HttpStatus.BAD_REQUEST, "해당 여행지는 이미 관리자의 검수가 완료되었습니다."),
 
+    // FCM 메시지 형식 오류
+    NULL_IN_FCM_MESSAGE(HttpStatus.BAD_REQUEST, "FCM 수신자 또는 데이터에 null은 허용되지 않습니다."),
+    INVALID_TLOG_MESSAGE(HttpStatus.BAD_REQUEST, "Tlog 메시지 규격에 맞지 않습니다."),
+    INVALID_TLOG_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "Tlog 알림 타입이 없거나 잘못된 값입니다."),
+    INVALID_LINK_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "링크 알림 타입이 없거나 잘못된 값입니다."),
+
     // 인증
     // 401
     UN_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "인증이 실패되었습니다."),
@@ -82,7 +88,7 @@ public enum ErrorType {
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
     // 501 구현되지 않은 기능
     UNSUPPORTED_SSO_LOGIN(HttpStatus.NOT_IMPLEMENTED, "현재 해당 소셜 로그인 방식은 아직 지원되지 않습니다."),
-  	UNSUPPORTED_REWARD_CRITERIA(HttpStatus.NOT_IMPLEMENTED, "현재 해당 보상 기준은 아직 지원되지 않습니다."),;
+  	UNSUPPORTED_REWARD_CRITERIA(HttpStatus.NOT_IMPLEMENTED, "현재 해당 보상 기준은 아직 지원되지 않습니다.");
 
 
     private final HttpStatus status;


### PR DESCRIPTION
## 작업 동기 및 이슈
- #126 

## 추가 및 변경사항
- **알림 메시지 규격 4가지가 추가되었습니다.**
  ![메시지 규격](https://www.notion.so/TLOG-FCM-1ffc8b877abb802a999bec6232c17fa4?pvs=4#1ffc8b877abb800c943fcc136f65db04)
  - (1) 기본 메시지 알림
  - (2) 링크 가능한 메시지 알림
  - (10) 기본 sns 알림
  - (11) 팔로잉 알림

- **`NotificationService`에서 알림 유형에 따라 전송 메서드가 구성되었습니다.**
  - 각 메서드는 알림 별 요구되는 데이터에 따라 파라미터로 적절한 값을 전달해야합니다.

    <img src="https://github.com/user-attachments/assets/cb0e1256-bcfb-4f0f-99f8-a5ad2ca8005a" width="500"/>

- **테스트를 위한 메시지 전송 API가 추가되었습니다.**
  - Tlog 메시지 규격에 맞춘 메시지를 전송합니다.
 
    <img src="https://github.com/user-attachments/assets/5e824032-c900-4f2d-88fb-66ffcdaadd18" width="500"/>

- **FCM 메시지 전송에 사용되는 DTO 형식 일부 변경**
  - FcmRequestDto 및 FcmMessageDto의 payload 필드는
    이제 별도의 페이로드 DTO를 사용하지 않고 Map을 사용합니다.

- **메시지 데이터의 FCM 메시지 규정 준수**
  - FCM 메시지의 모든 데이터는 문자열로만 처리됩니다.
     - 기본 FCM 정책 상, 여러 기기 호환을 위해 데이터를 문자열로 처리합니다.
       따라서 모든 타입의 데이터는 내부적으로 문자열로 변환되어 처리됩니다.
  - FCM 메시지의 모든 데이터는 null값을 가질 수 없습니다.

- **기타 리팩토링**
  - DTO 변환 로직 개선, 가독성 증가를 위한 코드 개선, API 엔트포인트 url 통일 등
    몇가지 리팩토링이 진행되었습니다.

## 테스트 결과
- 이상 무.

## 📌 기타
