### PR TITLE
Fix: 구글 소셜로그인시 에러 발생하는 문제 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -53,12 +53,10 @@ public class SsoAuthService {
         redisUtil.save(refreshKey, refreshToken, refreshTokenProvider.getRefreshTokenDuration());
 
         String customToken = "";
-        if(!ssoUserInfo.provider().equals("google")){
-            try{
-                customToken = FirebaseAuth.getInstance().createCustomToken(user.getId().toString());
-            }catch (FirebaseAuthException e) {
-                throw new CustomException(ErrorType.FIREBASE_CUSTOM_TOKEN_ISSUE_FAIL);
-            }
+        try{
+            customToken = FirebaseAuth.getInstance().createCustomToken(user.getId().toString());
+        }catch (FirebaseAuthException e) {
+            throw new CustomException(ErrorType.FIREBASE_CUSTOM_TOKEN_ISSUE_FAIL);
         }
 
         return TokenDto.builder()

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -52,7 +52,7 @@ public class SsoAuthService {
 
         redisUtil.save(refreshKey, refreshToken, refreshTokenProvider.getRefreshTokenDuration());
 
-        String customToken = null;
+        String customToken = "";
         if(!ssoUserInfo.provider().equals("google")){
             try{
                 customToken = FirebaseAuth.getInstance().createCustomToken(user.getId().toString());


### PR DESCRIPTION
## 작업 동기 및 이슈
- #128 
- #130 

## 문제 수정

### 1) 문제 상황
- 프론트측 구글 소셜로그인 성공 후, 유효한 ID Token을 사용해
  서버측에 로그인 시도시 계속 에러가 발생함.

### 2) 원인
- 소셜로그인 동작 과정에서 Firebase 커스텀 토큰을 발행하는 과정이 있음.
  - Firebase 인증이 지원되지 않는 서비스(카카오/네이버 등등)의 경우 발급이 필요함.
- 그러나 구글의 경우, 커스텀 토큰이 불필요하여 `null` 값으로 발행하나,
  이는 자료형 변환 과정에서 에러를 일으킴.

### 3) 변경사항
- 구글 로그인을 시도할 경우에는 커스텀 토큰 값을 `null` 대신 빈 문자열 `""` 으로 발행하도록 변경

## Firebase Custom Token 발급
- 이제 구글 소셜로그인의 경우에도 Firebase Custom Token을 발급합니다.

## 테스트 결과
- 이상 무.
  구글 로그인 정상 동작.
  Firebase custom token도 정상 반환합니다.
  <img src="https://github.com/user-attachments/assets/a039cd7c-b952-44f7-b632-55d7b4dacb08" width="350"/>

## 📌 기타
