### PR TITLE
Feature: SNS 댓글 추가 및 조회 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/repository/dto/CourseDistrictsDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/repository/dto/CourseDistrictsDto.java
@@ -1,0 +1,12 @@
+package com.se.Tlog.domain.Course.repository.dto;
+
+import java.util.List;
+
+/**
+ * 코스가 거쳐가는 모든 지역구를 반환하는 데이터 형식입니다.
+ */
+public record CourseDistrictsDto(
+        String courseId,
+        List<String> districts) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/repository/mongo/CourseRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/repository/mongo/CourseRepository.java
@@ -3,13 +3,76 @@ package com.se.Tlog.domain.Course.repository.mongo;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 import com.se.Tlog.domain.Course.domain.Course;
 import com.se.Tlog.domain.Course.domain.OwnerType;
+import com.se.Tlog.domain.Course.repository.dto.CourseDistrictsDto;
 
 @Repository
 public interface CourseRepository extends MongoRepository<Course, String> {
     List<Course> findAllByOwnerIdAndOwnerType(UUID ownerId, OwnerType ownerType);
+    
+    @Aggregation(pipeline = {
+            // Course 조회
+            """
+            { $match: { _id: ObjectId(?0) } }
+            """,
+            // Course 내 모든 여행지의 id 추출
+            """
+            { 
+                $project: { 
+                    _id: 1,
+                    destIds: { 
+                        $reduce: {
+                            input: '$dates.destinations',
+                            initialValue: [],
+                            in: { 
+                                $concatArrays : [ 
+                                    "$$value",
+                                    { 
+                                        $map : {
+                                            input : "$$this",
+                                            as : "item",
+                                            in : { $convert: { input : "$$item", to : "objectId" } }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+            """,
+            // 여행지 컬렉션과 join
+            """
+            { 
+                $lookup: {
+                    from: 'destinations',
+                    localField: 'destIds',
+                    foreignField: '_id',
+                    pipeline: [ { $project: { _id:0, district:1 }} ],
+                    as: 'districts'
+                }
+            }
+            """,
+            // DTO에 매핑
+            """
+            {
+                $project: {
+                    courseId: "$_id", 
+                    districts: {
+                        $reduce: {
+                            input: "$districts.district",
+                            initialValue: [],
+                            in: { $concatArrays: ["$$value", ["$$this"]] }
+                        }
+                    }
+                } 
+            }
+            """
+    })
+    CourseDistrictsDto findAllDestinationNameInCourse(String courseId);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/application/PostService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/application/PostService.java
@@ -1,5 +1,6 @@
 package com.se.Tlog.domain.Social.Post.application;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -12,6 +13,7 @@ import com.se.Tlog.domain.Course.repository.mongo.CourseRepository;
 import com.se.Tlog.domain.Social.Post.controller.dto.CreatePostReq;
 import com.se.Tlog.domain.Social.Post.controller.dto.PostDetailRes;
 import com.se.Tlog.domain.Social.Post.controller.dto.PostPreviewRes;
+import com.se.Tlog.domain.Social.Post.controller.dto.ReplyRes;
 import com.se.Tlog.domain.Social.Post.domain.Post;
 import com.se.Tlog.domain.Social.Post.repository.mongo.PostRepository;
 import com.se.Tlog.domain.User.domain.User;
@@ -30,6 +32,10 @@ public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final CourseRepository courseRepository;
+    private final ReplyService replyService;
+    
+    // 게시물 첫 조회시 기본으로 전송할 댓글 수 입니다.
+    private static final int DEFAULT_REPLY_COUNT = 10;
     
     public String createPost(CreatePostReq request) {
         if (!userRepository.existsById(request.author()))
@@ -71,6 +77,7 @@ public class PostService {
                     return new CustomException(ErrorType.POST_NOT_FOUND);
                 });
         CourseDistrictsDto courseDestinations = courseRepository.findAllDestinationNameInCourse(course.getId());
+        List<ReplyRes> replies = replyService.getReplyResOfPost(DEFAULT_REPLY_COUNT, null, postId);
         
         return new PostDetailRes(
                 post.getId(), 
@@ -82,6 +89,7 @@ public class PostService {
                 author.getName(),
                 author.getProfileImage(),
                 post.getImageUrls(),
-                post.getContent());
+                post.getContent(),
+                replies);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/application/PostService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/application/PostService.java
@@ -1,0 +1,87 @@
+package com.se.Tlog.domain.Social.Post.application;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Course.domain.Course;
+import com.se.Tlog.domain.Course.repository.dto.CourseDistrictsDto;
+import com.se.Tlog.domain.Course.repository.mongo.CourseRepository;
+import com.se.Tlog.domain.Social.Post.controller.dto.CreatePostReq;
+import com.se.Tlog.domain.Social.Post.controller.dto.PostDetailRes;
+import com.se.Tlog.domain.Social.Post.controller.dto.PostPreviewRes;
+import com.se.Tlog.domain.Social.Post.domain.Post;
+import com.se.Tlog.domain.Social.Post.repository.mongo.PostRepository;
+import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
+@ApplicationService
+@RequiredArgsConstructor
+public class PostService {
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final CourseRepository courseRepository;
+    
+    public String createPost(CreatePostReq request) {
+        if (!userRepository.existsById(request.author()))
+            throw new CustomException(ErrorType.USER_NOT_FOUND);
+        if (!courseRepository.existsById(request.courseId()))
+            throw new CustomException(ErrorType.COURSE_NOT_FOUND);
+        if (request.content() == null)
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        
+        return postRepository.save(
+                Post.create(request.author(), request.courseId(), request.content(), request.imageUrls())
+                ).getId();
+    }
+    
+    public Page<PostPreviewRes> getPreviewUserPosts(UUID userId, Pageable pageable) {
+        if (!userRepository.existsById(userId))
+            throw new CustomException(ErrorType.USER_NOT_FOUND);
+        
+        return postRepository.findAllPreviewByAuthor(userId, pageable)
+                .map(post -> {
+                    if (0 < post.getImageUrls().size())
+                        return new PostPreviewRes(post.getId(), post.getImageUrls().get(0));
+                    else
+                        return new PostPreviewRes(post.getId(), "");
+                });
+    }
+    
+    public PostDetailRes getPostDetail(String postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorType.POST_NOT_FOUND));
+        User author = userRepository.findById(post.getAuthor())
+                .orElseThrow(() -> {
+                    log.error("SNS 게시글 조회 오류 : 탈퇴한 작성자의 게시글을 조회하려 하였습니다. (post id : " + post.getId() + ")");
+                    return new CustomException(ErrorType.POST_NOT_FOUND);
+                });
+        Course course = courseRepository.findById(post.getCourseId())
+                .orElseThrow(() -> {
+                    log.error("SNS 게시글 조회 오류 : 삭제된 코스가 참조된 게시글을 조회하려 하였습니다. (post id : " + post.getId() + ")");
+                    return new CustomException(ErrorType.POST_NOT_FOUND);
+                });
+        CourseDistrictsDto courseDestinations = courseRepository.findAllDestinationNameInCourse(course.getId());
+        
+        return new PostDetailRes(
+                post.getId(), 
+                post.getLikeCount(),
+                postId,
+                course.getId(), 
+                courseDestinations.districts(), 
+                author.getId(),
+                author.getName(),
+                author.getProfileImage(),
+                post.getImageUrls(),
+                post.getContent());
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/application/ReplyService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/application/ReplyService.java
@@ -1,0 +1,133 @@
+package com.se.Tlog.domain.Social.Post.application;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.bson.types.ObjectId;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Social.Post.controller.dto.ReplyRes;
+import com.se.Tlog.domain.Social.Post.domain.Reply;
+import com.se.Tlog.domain.Social.Post.repository.mongo.PostRepository;
+import com.se.Tlog.domain.Social.Post.repository.mongo.ReplyRepository;
+import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+
+@ApplicationService
+@RequiredArgsConstructor
+public class ReplyService {
+    private final ReplyRepository replyRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    
+    public String attachReplyToPost(String postId, UUID authorId, String content) {
+        if (!userRepository.existsById(authorId))
+            throw new CustomException(ErrorType.USER_NOT_FOUND);
+        if (!postRepository.existsById(postId))
+            throw new CustomException(ErrorType.POST_NOT_FOUND);
+        if (content == null)
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        
+        return replyRepository.save(Reply.create(postId, null, authorId, content))
+                .getId();
+    }
+    
+    public String attachReplyToReply(String replyId, UUID authorId, String content) {
+        if (!userRepository.existsById(authorId))
+            throw new CustomException(ErrorType.USER_NOT_FOUND);
+        Reply parentReply = replyRepository.findById(replyId)
+                .orElseThrow(() -> new CustomException(ErrorType.REPLY_NOT_FOUND));
+        if (content == null)
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        
+        parentReply.addNestedReply();
+        replyRepository.save(parentReply);
+        return replyRepository.save(Reply.create(parentReply.getPostId(), replyId, authorId, content))
+                .getId();
+    }
+    
+    public ReplyRes getReply(String replyId) {
+        Reply reply = replyRepository.findById(replyId)
+                .orElseThrow(() -> new CustomException(ErrorType.REPLY_NOT_FOUND));
+        User author = userRepository.findById(reply.getAuthorId())
+                .orElseThrow(() -> {
+                    log.error("댓글 조회 오류 : 탈퇴한 작성자의 댓글을 조회하려 시도했습니다. (reply id : " + replyId + ")");
+                    return new CustomException(ErrorType.REPLY_NOT_FOUND); 
+                });
+        
+        return new ReplyRes(
+                reply.getId(),
+                reply.getContent(),
+                reply.getNestedReplyCount(),
+                author.getId(),
+                author.getName(),
+                author.getProfileImage());
+    }
+
+    public List<ReplyRes> getReplyResOfPost(int size, String lastReplyId, String postId) {
+        if (!postRepository.existsById(postId))
+            throw new CustomException(ErrorType.POST_NOT_FOUND);
+        if (size <= 0 || (null != lastReplyId && !ObjectId.isValid(lastReplyId)))
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        
+        List<Reply> replyList = replyRepository.findAllOfPost(size, lastReplyId, postId);
+        Map<UUID, User> users = userRepository.findAllById(
+                replyList.stream().map(r -> r.getAuthorId()).collect(Collectors.toSet()))
+                .stream().collect(Collectors.toMap(
+                        u -> u.getId(),
+                        u -> u));
+        if (users.size() != replyList.size())
+            log.error("댓글 조회 오류 : 게시글 내 댓글 중 탈퇴한 작성자의 댓글이 남아있습니다. (post id : " + postId + ")");
+        
+        return replyList.stream()
+            .filter(reply -> users.containsKey(reply.getAuthorId()))
+            .map(reply -> {
+                User author = users.get(reply.getAuthorId());
+                return new ReplyRes(
+                        reply.getId(),
+                        reply.getContent(),
+                        reply.getNestedReplyCount(),
+                        author.getId(),
+                        author.getName(),
+                        author.getProfileImage());
+            }).toList();
+    }
+    
+    public List<ReplyRes> getReplyResOfReply(int size, String lastReplyId, String replyId) {
+        if (!replyRepository.existsById(replyId))
+            throw new CustomException(ErrorType.REPLY_NOT_FOUND);
+        if (size <= 0 || (null != lastReplyId && !ObjectId.isValid(lastReplyId)))
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        
+        List<Reply> replyList = replyRepository.findAllOfReply(size, lastReplyId, replyId);
+        Map<UUID, User> users = userRepository.findAllById(
+                replyList.stream().map(r -> r.getAuthorId()).collect(Collectors.toSet()))
+                .stream().collect(Collectors.toMap(
+                        u -> u.getId(),
+                        u -> u));
+        if (users.size() != replyList.size())
+            log.error("댓글 조회 오류 : 대댓글 중 탈퇴한 작성자의 댓글이 남아있습니다. (reply id : " + replyId + ")");
+        
+        return replyList.stream()
+            .filter(reply -> users.containsKey(reply.getAuthorId()))
+            .map(reply -> {
+                User author = users.get(reply.getAuthorId());
+                return new ReplyRes(
+                        reply.getId(),
+                        reply.getContent(),
+                        reply.getNestedReplyCount(),
+                        author.getId(),
+                        author.getName(),
+                        author.getProfileImage());
+            }).toList();
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/PostController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/PostController.java
@@ -1,0 +1,82 @@
+package com.se.Tlog.domain.Social.Post.controller;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.se.Tlog.domain.Social.Post.application.PostService;
+import com.se.Tlog.domain.Social.Post.controller.dto.CreatePostReq;
+import com.se.Tlog.domain.Social.Post.controller.dto.PostDetailRes;
+import com.se.Tlog.domain.Social.Post.controller.dto.PostPreviewRes;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.success.SuccessRes;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "SNS - 코스 리뷰(게시물)")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
+public class PostController {
+    private final PostService postService;
+    
+    @PostMapping("/post")
+    @Operation (
+            summary = "코스 리뷰(게시물) 작성",
+            description = "특정 사용자가 코스 리뷰(게시물)를 작성합니다.<br>등록에 성공한 코스 리뷰(게시글)의 상세 데이터를 반환합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<PostDetailRes>> createPostOfUser(@RequestBody CreatePostReq request) {
+        String newPostId = postService.createPost(request);
+        return ResponseEntity.ok(SuccessRes.from(
+                postService.getPostDetail(newPostId)));
+    }
+    
+    @GetMapping("/user/{userId}/posts/preview")
+    @Operation (
+            summary = "사용자의 코스 리뷰(게시물) 미리보기 정보",
+            description = "특정 사용자의 코스 리뷰(게시물)들을 미리보기 형태로 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<Page<PostPreviewRes>>> getPreviewPostOfUser(@PathVariable(name = "userId") UUID userId, Pageable pageable) {
+        return ResponseEntity.ok(SuccessRes.from(
+                postService.getPreviewUserPosts(userId, pageable)));
+    }
+    
+    @GetMapping("/post/{postId}")
+    @Operation (
+            summary = "코스 리뷰(게시물) 상세보기 정보",
+            description = "특정 코스 리뷰(게시물)의 상세보기 데이터를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<PostDetailRes>> getDetailPost(@PathVariable(name = "postId") String postId) {
+        return ResponseEntity.ok(SuccessRes.from(
+                postService.getPostDetail(postId)));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/ReplyController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/ReplyController.java
@@ -1,0 +1,113 @@
+package com.se.Tlog.domain.Social.Post.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.se.Tlog.domain.Social.Post.application.ReplyService;
+import com.se.Tlog.domain.Social.Post.controller.dto.CreateReplyReq;
+import com.se.Tlog.domain.Social.Post.controller.dto.ReplyRes;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.success.SuccessRes;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "SNS - 댓글")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
+public class ReplyController {
+    private final ReplyService replyService;
+
+    @PostMapping("/post/{postId}/reply")
+    @Operation (
+            summary = "게시물에 댓글 작성",
+            description = "특정 게시물에 댓글을 작성합니다.<br>등록에 성공한 댓글 데이터를 반환합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<ReplyRes>> createReplyToPost(@PathVariable(name = "postId") String postId, @RequestBody CreateReplyReq request) {
+        String newReplyId = replyService.attachReplyToPost(postId, request.author(), request.content());
+        
+        return ResponseEntity.ok(SuccessRes.from(
+                replyService.getReply(newReplyId)));
+    }
+
+    @PostMapping("/reply/{replyId}/reply")
+    @Operation (
+            summary = "댓글에 대댓글 작성",
+            description = "특정 댓글에 대댓글을 작성합니다.<br>등록에 성공한 댓글 데이터를 반환합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<ReplyRes>> createReplyToReply(@PathVariable(name = "replyId") String replyId, @RequestBody CreateReplyReq request) {
+        String newReplyId = replyService.attachReplyToReply(replyId, request.author(), request.content());
+        
+        return ResponseEntity.ok(SuccessRes.from(
+                replyService.getReply(newReplyId)));
+    }
+
+    @GetMapping("/post/{postId}/replys")
+    @Operation (
+            summary = "코스 리뷰(게시글)의 댓글 조회",
+            description = "특정 코스 리뷰(게시글)의 댓글을 조회합니다."
+                        + "<br>Paging 대신 <b>lastReplyId</b> 및 <b>size</b>를 사용하여 해당 댓글 이후부터 조회합니다."
+                        + "<br><b>lastReplyId</b>가 <code>null</code>(기입X)이면 가장 첫 댓글부터 조회합니다."
+                        + "<br>"
+                        + "<br>- <b>lastReplyId</b>는 ReplyId 형식에 맞아야 합니다."
+                        + "<br>- <b>size</b>는 1 이상이어야 합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<List<ReplyRes>>> getReplyOfPost(
+            @PathVariable(name = "postId") String postId,
+            @RequestParam(required = false) String lastReplyId,
+            @RequestParam int size) {
+        return ResponseEntity.ok(SuccessRes.from(
+                replyService.getReplyResOfPost(size, lastReplyId, postId)));
+    }
+
+    @GetMapping("/reply/{replyId}/replys")
+    @Operation (
+            summary = "댓글의 대댓글 조회",
+            description = "특정 댓글의 대댓글을 조회합니다."
+                        + "<br>Paging 대신 <b>lastReplyId</b> 및 <b>size</b>를 사용하여 해당 댓글 이후부터 조회합니다."
+                        + "<br><b>lastReplyId</b>가 <code>null</code>(기입X)이면 가장 첫 댓글부터 조회합니다."
+                        + "<br>"
+                        + "<br>- <b>lastReplyId</b>는 ReplyId 형식에 맞아야 합니다."
+                        + "<br>- <b>size</b>는 1 이상이어야 합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<List<ReplyRes>>> getReplyOfReply(
+            @PathVariable(name = "replyId") String replyId,
+            @RequestParam(required = false) String lastReplyId,
+            @RequestParam int size) {
+        return ResponseEntity.ok(SuccessRes.from(
+                replyService.getReplyResOfReply(size, lastReplyId, replyId)));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/dto/CreatePostReq.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/dto/CreatePostReq.java
@@ -1,0 +1,22 @@
+package com.se.Tlog.domain.Social.Post.controller.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "코스 리뷰(게시글) 생성 데이터 형식입니다.")
+public record CreatePostReq(
+        @Schema(description = "작성자 id")
+        UUID author,
+        
+        @Schema(description = "참조된 코스 id")
+        String courseId, 
+        
+        @Schema(description = "본문 내용")
+        String content, 
+        
+        @Schema(description = "이미지")
+        List<String> imageUrls) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/dto/CreateReplyReq.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/dto/CreateReplyReq.java
@@ -1,0 +1,15 @@
+package com.se.Tlog.domain.Social.Post.controller.dto;
+
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "댓글 생성 데이터 형식입니다.")
+public record CreateReplyReq(
+        @Schema(description = "작성자 id")
+        UUID author,
+        
+        @Schema(description = "댓글 내용")
+        String content) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/dto/PostDetailRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/dto/PostDetailRes.java
@@ -24,6 +24,9 @@ public record PostDetailRes(
         
         // 내용 정보
         List<String> contentImageUrls,
-        String content) {
+        String content,
+        
+        // 댓글 정보
+        List<ReplyRes> replies) {
 
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/dto/PostDetailRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/dto/PostDetailRes.java
@@ -1,0 +1,29 @@
+package com.se.Tlog.domain.Social.Post.controller.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "코스 리뷰(게시물)의 전체 데이터 형식입니다.")
+public record PostDetailRes(
+        // 코스 리뷰(게시물) 정보
+        String postId,
+        int postLikeCount,
+        @Schema(description = "코스 리뷰(게시물)의 공유 코드 (현재는 게시물 고유 id로 반환함) (url 구성 방법은 추후 논의)")
+        String postLinkCode,
+        
+        // 코스 정보
+        String courseId,
+        List<String> courseDistrics,
+        
+        // 작성자 정보
+        UUID authorId,
+        String authorName,
+        String authorProfileImageUrl,
+        
+        // 내용 정보
+        List<String> contentImageUrls,
+        String content) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/dto/PostPreviewRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/dto/PostPreviewRes.java
@@ -1,0 +1,13 @@
+package com.se.Tlog.domain.Social.Post.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "코스 리뷰(게시물)의 미리보기 데이터 형식입니다.")
+public record PostPreviewRes(
+        @Schema(description = "코스 리뷰(게시물) id")
+        String postId,
+        
+        @Schema(description = "간략히 보기 대표사진")
+        String previewImageUrl) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/dto/ReplyRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/dto/ReplyRes.java
@@ -1,0 +1,19 @@
+package com.se.Tlog.domain.Social.Post.controller.dto;
+
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "SNS 내 코스 리뷰(게시글)에 작성되는 댓글 조회 데이터형식입니다.")
+public record ReplyRes(
+        // 댓글 정보
+        String replyId,
+        String content,
+        int nestedReplyCount,
+        
+        // 작성자 정보
+        UUID authorId,
+        String authorName,
+        String authorProfileImageUrl) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/domain/Post.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/domain/Post.java
@@ -1,0 +1,50 @@
+package com.se.Tlog.domain.Social.Post.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.Getter;
+
+@Document(collection = "sns_post")
+@Getter
+public class Post {
+    @Id
+    private String id;
+    
+    private UUID author;
+    
+    private String courseId;
+    
+    private String content;
+    
+    private List<String> imageUrls;
+    
+    private int likeCount;
+    
+    public void updateLikeCount(int likeCount) {
+        this.likeCount = likeCount;
+    }
+
+    private Post(UUID author, String courseId, String content, List<String> imageUrls) {
+        this.author = author;
+        this.courseId = courseId;
+        this.content = content;
+        this.imageUrls = new ArrayList<String>(imageUrls);
+        this.likeCount = 0;
+    }
+    
+    public static Post create(UUID author, String courseId, String content, List<String> imageUrls) {
+        if (courseId == null || content == null)
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        if (imageUrls == null)
+            imageUrls = new ArrayList<String>();
+        return new Post(author, courseId, content, imageUrls);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/domain/Reply.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/domain/Reply.java
@@ -1,0 +1,51 @@
+package com.se.Tlog.domain.Social.Post.domain;
+
+import java.util.UUID;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.Getter;
+
+@Document(collection = "sns_reply")
+@Getter
+public class Reply {
+    private static final String NULL_PARENT_ID = "000000000000000000000000";
+    
+    @Id
+    private String id;
+    private String postId;
+    private String parentId;
+    
+    private UUID authorId;
+    private String content;
+    private int nestedReplyCount;
+    
+    public void addNestedReply() {
+        nestedReplyCount++;
+    }
+    
+    public void removeNestedReply() {
+        if (nestedReplyCount > 0)
+            nestedReplyCount--;
+    }
+    
+    private Reply(String postId, String parentId, UUID authorId, String content) {
+        this.postId = postId;
+        this.parentId = parentId;
+        this.authorId = authorId;
+        this.content = content;
+        this.nestedReplyCount = 0;
+    }
+    
+    public static Reply create(String postId, String parentId, UUID authorId, String content) {
+        if (postId == null || authorId == null || content == null)
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        if (parentId == null)
+            parentId = NULL_PARENT_ID;
+        return new Reply(postId, parentId, authorId, content);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/repository/mongo/PostRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/repository/mongo/PostRepository.java
@@ -1,0 +1,23 @@
+package com.se.Tlog.domain.Social.Post.repository.mongo;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.se.Tlog.domain.Social.Post.domain.Post;
+
+@Repository
+public interface PostRepository extends MongoRepository<Post, String> {
+    /**
+     * 대표 이미지 조회를 위해 이미지 필드만 조회합니다.
+     * @param author
+     * @param pageable
+     * @return
+     */
+    @Query(value = "{ 'author' : ?0 }", fields = "{ '_id' : 1, 'imageUrls' : 1 }")
+    Page<Post> findAllPreviewByAuthor(UUID author, Pageable pageable);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/repository/mongo/ReplyRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/repository/mongo/ReplyRepository.java
@@ -1,0 +1,71 @@
+package com.se.Tlog.domain.Social.Post.repository.mongo;
+
+import java.util.List;
+
+import org.springframework.data.mongodb.repository.Aggregation;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import com.se.Tlog.domain.Social.Post.domain.Reply;
+
+@Repository
+public interface ReplyRepository extends MongoRepository<Reply, String> {
+    static final String NULL_LAST_REPLY_ID = "000000000000000000000000";
+    static final String NULL_PARENT_ID = "000000000000000000000000";
+    
+    @Aggregation(pipeline = {
+            // id 기반 페이징 (-> 성능상 좀 더 우수)
+            """
+            { $sort: { _id: 1 } }
+            """,
+            // 결과 쿼리
+            """
+            {
+                $match: {
+                    _id: { $gt: ObjectId(?1) },
+                    postId: ?2
+                    parentId: "000000000000000000000000"
+                }
+            }
+            """,
+            """
+            { $limit: ?0 }
+            """
+    })
+    List<Reply> findAllByPostId(int limit, String lastReplyId, String postId);
+    
+    @Aggregation(pipeline = {
+            // id 기반 페이징 (-> 성능상 좀 더 우수)
+            """
+            { $sort: { _id: 1 } }
+            """,
+            // 결과 쿼리
+            """
+            {
+                $match: {
+                    _id: { $gt: ObjectId(?1) },
+                    parentId: ?2
+                }
+            }
+            """,
+            """
+            { $limit: ?0 }
+            """,
+            
+    })
+    List<Reply> findAllByParentId(int limit, String lastReplyId, String parentId);
+
+    default List<Reply> findAllOfPost(int size, String lastRelyId, String postId) {
+        return findAllByPostId(
+                size,
+                (null == lastRelyId ? NULL_LAST_REPLY_ID : lastRelyId),
+                postId);
+    }
+    
+    default List<Reply> findAllOfReply(int size, String lastRelyId, String parentReplyId) {
+        return findAllByParentId(
+                size,
+                (null == lastRelyId ? NULL_LAST_REPLY_ID : lastRelyId),
+                parentReplyId);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorType {
 
     // 400 잘못된 요청
+    ILLEGAL_ARGUMENT(HttpStatus.BAD_REQUEST, "null값 또는 잘못된 값이 입력되었습니다."),
     CONTENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "Content 내용이 비어있습니다."),
     TEAM_NAME_NOT_FOUND(HttpStatus.BAD_REQUEST, "팀 이름이 비어있습니다."),
     TEAM_CANNOT_BE_ORPHAN(HttpStatus.BAD_REQUEST, "팀에 최소 1명 이상의 팀원이 필요합니다."),
@@ -68,6 +69,8 @@ public enum ErrorType {
     SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 여행지가 스크랩 목록에 없습니다."),
     SHOPCART_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 여행지가 장바구니에 없습니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 리뷰를 찾을 수 없습니다."),
+    COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 여행 코스입니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 코스 리뷰(게시글)입니다."),
     //데이터 충돌
     ALREADY_EXISTS_SNSId(HttpStatus.CONFLICT, "이미 존재하는 Id 입니다."),
     ALREADY_EXISTS_TAG(HttpStatus.CONFLICT, "이미 존재하는 태그입니다."),

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -71,6 +71,7 @@ public enum ErrorType {
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 리뷰를 찾을 수 없습니다."),
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 여행 코스입니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 코스 리뷰(게시글)입니다."),
+    REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
     //데이터 충돌
     ALREADY_EXISTS_SNSId(HttpStatus.CONFLICT, "이미 존재하는 Id 입니다."),
     ALREADY_EXISTS_TAG(HttpStatus.CONFLICT, "이미 존재하는 태그입니다."),


### PR DESCRIPTION
## 작업 동기 및 이슈
- #133 

## 추가 및 변경사항
- **SNS 내 댓글 기능이 추가되었습니다.**
### 1) 자료구조 관련 명세
  - Reply 엔티티 추가
  - 댓글 조회시 표시되는 데이터
    - 댓글 내용
    - 작성자 정보
### 2) 기능 명세
- 1: 댓글 작성 기능
   - 게시글에 댓글 작성
   - 댓글에 대댓글 작성
- 2: 댓글 조회 기능
  - 게시글의 댓글 조회 - **슬라이싱과 유사한 조회 방식을 사용합니다.**
  - 댓글의 대댓글 조회 - **슬라이싱과 유사한 조회 방식을 사용합니다.**
- 3: 게시글 조회시 기본적으로 10개 댓글 함께 조회

## 테스트 결과
- 이상 무.
  기능별 테스트 결과 이상 무.
  - 게시글에 댓글이 함께 조회되는 예시 :
    <img src="https://github.com/user-attachments/assets/9e75651a-7058-410a-996b-955d7f096d24" width="350"/>
  - 댓글 및 대댓글 조회 예시 :
    <img src="https://github.com/user-attachments/assets/9041dfcc-f1c0-4ae6-a785-0bd6a4e04c80" width="350"/>


## 📌 기타
- 좋아요 기능도 작업중에 있습니다!