### PR TITLE
Feature: 여행지 정렬 기능 (REVIEW, POPULAR) 및 동시성 이슈 해결

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
@@ -57,6 +57,8 @@ public class ReviewService {
         Review review = Review.create(reviewCreateDto);
         reviewRepository.save(review);
 
+        destinationDomainService.increaseReviewCountAndRating(reviewCreateDto.destinationId(), reviewCreateDto.rating());
+
         customTagService.addCustomTag(reviewCreateDto.destinationId(), reviewCreateDto.customTagNames());
     }
 
@@ -67,6 +69,7 @@ public class ReviewService {
         if (!review.getUserId().equals(userId)) {
             throw new CustomException(ErrorType.UN_AUTHORIZATION);
         }
+        destinationDomainService.decreaseReviewCount(review.getDestinationId());
         reviewRepository.delete(review);
     }
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
@@ -69,7 +69,7 @@ public class ReviewService {
         if (!review.getUserId().equals(userId)) {
             throw new CustomException(ErrorType.UN_AUTHORIZATION);
         }
-        destinationDomainService.decreaseReviewCount(review.getDestinationId());
+        destinationDomainService.decreaseReviewCountAndRating(review.getDestinationId(), review);
         reviewRepository.delete(review);
     }
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/entity/TeamUserJpaEntity.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/repository/jpa/entity/TeamUserJpaEntity.java
@@ -17,7 +17,7 @@ import static jakarta.persistence.FetchType.LAZY;
 @Entity
 @Table(
         name = "teamUsers",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"team", "user"})
+        uniqueConstraints = @UniqueConstraint(columnNames = {"team_id", "user_id"})
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/CustomTagService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/CustomTagService.java
@@ -1,15 +1,11 @@
 package com.se.Tlog.domain.Travel.application;
 
-import com.mongodb.DuplicateKeyException;
 import com.se.Tlog.domain.Travel.domain.CustomTagDocument;
 import com.se.Tlog.domain.Travel.domain.TagCount;
+import com.se.Tlog.domain.Travel.domain.repository.CustomTagRepositoryService;
 import com.se.Tlog.domain.Travel.repository.mongo.CustomTagDocumentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
@@ -22,30 +18,10 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CustomTagService {
     private final CustomTagDocumentRepository customTagDocumentRepository;
-    private final MongoTemplate mongoTemplate;
+    private final CustomTagRepositoryService customTagRepositoryService;
 
     public void addCustomTag(String destinationId, List<String> tagNameList) {
-
-        try {
-            mongoTemplate.upsert(
-                    Query.query(Criteria.where("destinationId").is(destinationId)),
-                    new Update().setOnInsert("destinationId", destinationId),
-                    CustomTagDocument.class
-            );
-        } catch (DuplicateKeyException e) {
-            log.info(" CustomTagDocument가 이미 존재합니다 destinationId : {}", destinationId);
-        }
-
-        for (String tagName : tagNameList) {
-            String normalizedTagName = tagName.trim().toLowerCase();
-
-            mongoTemplate.updateFirst(
-                    Query.query(Criteria.where("destinationId").is(destinationId)),
-                    new Update().inc("customTags." + normalizedTagName, 1),
-                    CustomTagDocument.class
-            );
-        }
-
+        customTagRepositoryService.addCustomTag(destinationId, tagNameList);
     }
 
     public List<TagCount> getTopTags(String destinationId, int limit) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/CustomTagService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/CustomTagService.java
@@ -1,9 +1,15 @@
 package com.se.Tlog.domain.Travel.application;
 
+import com.mongodb.DuplicateKeyException;
 import com.se.Tlog.domain.Travel.domain.CustomTagDocument;
 import com.se.Tlog.domain.Travel.domain.TagCount;
 import com.se.Tlog.domain.Travel.repository.mongo.CustomTagDocumentRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
@@ -11,22 +17,41 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomTagService {
     private final CustomTagDocumentRepository customTagDocumentRepository;
+    private final MongoTemplate mongoTemplate;
 
     public void addCustomTag(String destinationId, List<String> tagNameList) {
-        CustomTagDocument customTag = customTagDocumentRepository.findByDestinationId(destinationId)
-                .orElseGet(() -> CustomTagDocument.create(destinationId));
 
-        customTag.addOrIncrement(tagNameList);
-        customTagDocumentRepository.save(customTag);
+        try {
+            mongoTemplate.upsert(
+                    Query.query(Criteria.where("destinationId").is(destinationId)),
+                    new Update().setOnInsert("destinationId", destinationId),
+                    CustomTagDocument.class
+            );
+        } catch (DuplicateKeyException e) {
+            log.info(" CustomTagDocument가 이미 존재합니다 destinationId : {}", destinationId);
+        }
+
+        for (String tagName : tagNameList) {
+            String normalizedTagName = tagName.trim().toLowerCase();
+
+            mongoTemplate.updateFirst(
+                    Query.query(Criteria.where("destinationId").is(destinationId)),
+                    new Update().inc("customTags." + normalizedTagName, 1),
+                    CustomTagDocument.class
+            );
+        }
+
     }
 
     public List<TagCount> getTopTags(String destinationId, int limit) {
         return customTagDocumentRepository.findByDestinationId(destinationId)
-                .map(doc -> doc.getCustomTags().stream()
+                .map(doc -> doc.getCustomTags().entrySet().stream()
+                        .map(entry -> new TagCount(entry.getKey(), entry.getValue()))
                         .sorted(Comparator.comparing(TagCount::getCount).reversed())
                         .limit(limit)
                         .toList()
@@ -39,7 +64,8 @@ public class CustomTagService {
                 .stream()
                 .collect(Collectors.toMap(
                         CustomTagDocument::getDestinationId,
-                        doc -> doc.getCustomTags().stream()
+                        doc -> doc.getCustomTags().entrySet().stream()
+                                .map(entry -> new TagCount(entry.getKey(),entry.getValue()))
                             .sorted(Comparator.comparing(TagCount::getCount).reversed())
                             .limit(limit)
                             .toList()));

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -7,10 +7,7 @@ import com.se.Tlog.domain.Travel.controller.dto.AddFixedTagDto;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationDetailsRes;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationDto;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
-import com.se.Tlog.domain.Travel.domain.Destination;
-import com.se.Tlog.domain.Travel.domain.TagCount;
-import com.se.Tlog.domain.Travel.domain.TagInfo;
-import com.se.Tlog.domain.Travel.domain.UnapprovedDestination;
+import com.se.Tlog.domain.Travel.domain.*;
 import com.se.Tlog.domain.Travel.domain.repository.DestinationRepositoryService;
 import com.se.Tlog.domain.Travel.domain.repository.TagRepositoryService;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
@@ -18,9 +15,10 @@ import com.se.Tlog.domain.Travel.repository.mongo.UnapprovedDestinationRepositor
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.*;
+import org.springframework.data.mongodb.core.query.Criteria;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +33,7 @@ public class DestinationService {
     private final UnapprovedDestinationRepository unapprovedDestinationRepository;
     private final CustomTagService customTagService;
     private final ReviewDomainService reviewDomainService;
+    private final MongoTemplate mongoTemplate;
 
     public void generateNewDestination(DestinationDto destinationDto) {
         Destination destinationData = Destination.create(
@@ -68,8 +67,41 @@ public class DestinationService {
                 TagInfo.createAll(fixedTags, tagRepositoryService));
     }
 
-    public Page<DestinationSummaryRes> getAllDestinations(Pageable pageable) {
-        return convertToDto(destinationRepository.findAllWithActiveTags(pageable));
+    public Slice<DestinationSummaryRes> getAllDestinations(Pageable pageable, String city,
+                                                          DestinationSortType sortType, String tbti) {
+        MatchOperation matchStage = Aggregation.match(Criteria.where("city").is(city));
+
+        SortOperation sortStage = null;
+        switch (sortType){
+            case REVIEW -> { //평점 높은 순
+                sortStage = Aggregation.sort(Sort.by(Sort.Order.desc("averageRating")));
+            }
+            case POPULAR -> { // 리뷰 갯수
+                sortStage = Aggregation.sort(Sort.by(Sort.Order.desc("reviewCount")));
+            }
+        }
+
+        SkipOperation skipStage = Aggregation.skip((long) pageable.getPageNumber() * pageable.getPageSize());
+        LimitOperation limitStage = Aggregation.limit(pageable.getPageSize() + 1);  // 다음 페이지 존재 여부 확인 위해 +1
+
+        Aggregation aggregation = Aggregation.newAggregation(
+                matchStage,
+                sortStage,
+                skipStage,
+                limitStage
+        );
+
+        List<Destination> destinations = new ArrayList<>(mongoTemplate.aggregate(aggregation, "destinations", Destination.class)
+                .getMappedResults());
+
+        boolean hasNext = destinations.size() > pageable.getPageSize();
+
+        if (hasNext) {
+            destinations.remove(destinations.size() - 1);
+        }
+
+        List<DestinationSummaryRes> destinationSummaryRes = convertToDto(destinations);
+        return new SliceImpl<>(new ArrayList<>(destinationSummaryRes), pageable, hasNext);
     }
     
     public Page<DestinationSummaryRes> getDestinationByIds(List<String> ids, Pageable pageable) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -17,8 +17,6 @@ import com.se.Tlog.global.response.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.aggregation.*;
-import org.springframework.data.mongodb.core.query.Criteria;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -69,31 +67,7 @@ public class DestinationService {
 
     public Slice<DestinationSummaryRes> getAllDestinations(Pageable pageable, String city,
                                                           DestinationSortType sortType, String tbti) {
-        MatchOperation matchStage = Aggregation.match(Criteria.where("city").is(city));
-
-        SortOperation sortStage = null;
-        switch (sortType){
-            case REVIEW -> { //평점 높은 순
-                sortStage = Aggregation.sort(Sort.by(Sort.Order.desc("averageRating")));
-            }
-            case POPULAR -> { // 리뷰 갯수
-                sortStage = Aggregation.sort(Sort.by(Sort.Order.desc("reviewCount")));
-            }
-        }
-
-        SkipOperation skipStage = Aggregation.skip((long) pageable.getPageNumber() * pageable.getPageSize());
-        LimitOperation limitStage = Aggregation.limit(pageable.getPageSize() + 1);  // 다음 페이지 존재 여부 확인 위해 +1
-
-        Aggregation aggregation = Aggregation.newAggregation(
-                matchStage,
-                sortStage,
-                skipStage,
-                limitStage
-        );
-
-        List<Destination> destinations = new ArrayList<>(mongoTemplate.aggregate(aggregation, "destinations", Destination.class)
-                .getMappedResults());
-
+        List<Destination> destinations = destinationRepoService.getDestinations(pageable, city, sortType);
         boolean hasNext = destinations.size() > pageable.getPageSize();
 
         if (hasNext) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
@@ -4,6 +4,7 @@ import com.se.Tlog.domain.Travel.application.DestinationService;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationDetailsRes;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationDto;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+import com.se.Tlog.domain.Travel.domain.DestinationSortType;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,8 +12,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -56,8 +57,12 @@ public class DestinationController {
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류")
             }
     )
-    public ResponseEntity<Page<DestinationSummaryRes>> getAllDestinations(@PageableDefault(size = 10) Pageable pageable) {
-        return ResponseEntity.ok(destinationService.getAllDestinations(pageable));
+    public ResponseEntity<Slice<DestinationSummaryRes>> getAllDestinations(
+            @PageableDefault(size = 10) Pageable pageable,
+            @RequestParam String city,
+            @RequestParam(defaultValue = "RECOMMAND") DestinationSortType sortType,
+            @RequestParam(required = false) String tbti) {
+        return ResponseEntity.ok(destinationService.getAllDestinations(pageable,city,sortType,tbti));
     }
 
     @GetMapping("/{id}")

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationSummaryRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationSummaryRes.java
@@ -24,7 +24,7 @@ public record DestinationSummaryRes(
                 destination.getCity(),
                 destination.getLocation(),
                 destination.getReviewCount(),
-                destination.getAverageRating(),
+                Math.round(destination.getAverageRating() * 10) / 10.0f,
                 destination.getImageUrl(),
                 topTags
         );

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/CustomTagDocument.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/CustomTagDocument.java
@@ -6,8 +6,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 @Document(collection = "customtags")
 @Getter
@@ -17,24 +17,7 @@ public class CustomTagDocument {
     private String id;
 
     private String destinationId;
-    private List<TagCount> customTags = new ArrayList<>();
-
-    public void addOrIncrement(List<String> tagNames) {
-        for (String tagName : tagNames) {
-            String normalizedTagName = tagName.trim().toLowerCase();
-
-            TagCount existing = customTags.stream()
-                    .filter(t -> t.getTagName().equals(normalizedTagName))
-                    .findFirst()
-                    .orElse(null);
-
-            if (existing != null) {
-                existing.increment();
-            }else{
-                customTags.add(TagCount.create(normalizedTagName));
-            }
-        }
-    }
+    private Map<String, Integer> customTags = new HashMap<>();
 
     public static CustomTagDocument create(String destinationId) {
         return new CustomTagDocument(destinationId);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/DestinationSortType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/DestinationSortType.java
@@ -1,0 +1,7 @@
+package com.se.Tlog.domain.Travel.domain;
+
+public enum DestinationSortType {
+    RECOMMEND,
+    POPULAR,
+    REVIEW
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/TagCount.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/TagCount.java
@@ -1,13 +1,12 @@
 package com.se.Tlog.domain.Travel.domain;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class TagCount {
     private String tagName;
     private int count;

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/repository/CustomTagRepositoryService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/repository/CustomTagRepositoryService.java
@@ -1,0 +1,7 @@
+package com.se.Tlog.domain.Travel.domain.repository;
+
+import java.util.List;
+
+public interface CustomTagRepositoryService {
+    void addCustomTag(String destinationId, List<String> tagNameList);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/repository/DestinationRepositoryService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/repository/DestinationRepositoryService.java
@@ -1,10 +1,17 @@
 package com.se.Tlog.domain.Travel.domain.repository;
 
+import com.se.Tlog.domain.Review.domain.Review;
+import com.se.Tlog.domain.Travel.domain.Destination;
+import com.se.Tlog.domain.Travel.domain.DestinationSortType;
 import com.se.Tlog.domain.Travel.domain.TagInfo;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface DestinationRepositoryService {
 	boolean exist(String name);
 	void addFixedTags(String id, List<TagInfo> fixedTags);
+	void increaseReviewCountAndRating(String destinationId, int rating, float approximateAverage);
+	void decreaseReviewCountAndRating(String destinationId, Review review);
+	List<Destination> getDestinations(Pageable pageable, String city, DestinationSortType sortType);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/service/DestinationDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/service/DestinationDomainService.java
@@ -1,17 +1,24 @@
 package com.se.Tlog.domain.Travel.domain.service;
 
+import com.mongodb.client.result.UpdateResult;
+import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
+
 
 @Service
 @RequiredArgsConstructor
 public class DestinationDomainService {
     private final DestinationRepository destinationRepository;
-
+    private final MongoTemplate mongoTemplate;
 
     public void validateExists(String destinationId) {
         if (!destinationRepository.existsById(destinationId)) {
@@ -19,6 +26,38 @@ public class DestinationDomainService {
         }
     }
 
+    public void increaseReviewCountAndRating(String destinationId, int rating) {
+        Destination destination = mongoTemplate.findById(destinationId, Destination.class);
+        if (destination == null) {
+            throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);
+        }
+        float approximateAverage = (float) (destination.getRatingSum() + rating) / (destination.getReviewCount());
+
+        Update update = new Update()
+                .inc("reviewCount", 1)
+                .inc("ratingSum", rating)
+                .inc("ratingCount." + (rating - 1), 1)
+                .set("averageRating", approximateAverage);
+
+        UpdateResult updateResult = mongoTemplate.updateFirst(
+                Query.query(Criteria.where("_id").is(destinationId)),
+                update,
+                Destination.class
+        );
+
+        if (updateResult.getMatchedCount() == 0) {
+            throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);
+        }
+
+    }
+
+    public void decreaseReviewCount(String destinationId) {
+        mongoTemplate.updateFirst(
+                Query.query(Criteria.where("_id").is(destinationId)),
+                new Update().inc("reviewCount", -1),
+                Destination.class
+        );
+    }
     public boolean isApproved(String destinationId) {
         return destinationRepository.existsById(destinationId);
     }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/service/DestinationDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/service/DestinationDomainService.java
@@ -1,16 +1,14 @@
 package com.se.Tlog.domain.Travel.domain.service;
 
-import com.mongodb.client.result.UpdateResult;
+import com.se.Tlog.domain.Review.domain.Review;
 import com.se.Tlog.domain.Travel.domain.Destination;
+import com.se.Tlog.domain.Travel.domain.repository.DestinationRepositoryService;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 
 
@@ -19,6 +17,7 @@ import org.springframework.stereotype.Service;
 public class DestinationDomainService {
     private final DestinationRepository destinationRepository;
     private final MongoTemplate mongoTemplate;
+    private final DestinationRepositoryService destinationRepositoryService;
 
     public void validateExists(String destinationId) {
         if (!destinationRepository.existsById(destinationId)) {
@@ -33,30 +32,11 @@ public class DestinationDomainService {
         }
         float approximateAverage = (float) (destination.getRatingSum() + rating) / (destination.getReviewCount());
 
-        Update update = new Update()
-                .inc("reviewCount", 1)
-                .inc("ratingSum", rating)
-                .inc("ratingCount." + (rating - 1), 1)
-                .set("averageRating", approximateAverage);
-
-        UpdateResult updateResult = mongoTemplate.updateFirst(
-                Query.query(Criteria.where("_id").is(destinationId)),
-                update,
-                Destination.class
-        );
-
-        if (updateResult.getMatchedCount() == 0) {
-            throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);
-        }
-
+        destinationRepositoryService.increaseReviewCountAndRating(destinationId, rating, approximateAverage);
     }
 
-    public void decreaseReviewCount(String destinationId) {
-        mongoTemplate.updateFirst(
-                Query.query(Criteria.where("_id").is(destinationId)),
-                new Update().inc("reviewCount", -1),
-                Destination.class
-        );
+    public void decreaseReviewCountAndRating(String destinationId, Review review) {
+        destinationRepositoryService.decreaseReviewCountAndRating(destinationId, review);
     }
     public boolean isApproved(String destinationId) {
         return destinationRepository.existsById(destinationId);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/CustomTagRepositoryServiceImplement.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/CustomTagRepositoryServiceImplement.java
@@ -1,0 +1,44 @@
+package com.se.Tlog.domain.Travel.repository;
+
+import com.mongodb.DuplicateKeyException;
+import com.se.Tlog.domain.Travel.domain.CustomTagDocument;
+import com.se.Tlog.domain.Travel.domain.repository.CustomTagRepositoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomTagRepositoryServiceImplement implements CustomTagRepositoryService {
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public void addCustomTag(String destinationId, List<String> tagNameList) {
+        try {
+            mongoTemplate.upsert(
+                    Query.query(Criteria.where("destinationId").is(destinationId)),
+                    new Update().setOnInsert("destinationId", destinationId),
+                    CustomTagDocument.class
+            );
+        } catch (DuplicateKeyException e) {
+            log.info(" CustomTagDocument가 이미 존재합니다 destinationId : {}", destinationId);
+        }
+
+        for (String tagName : tagNameList) {
+            String normalizedTagName = tagName.trim().toLowerCase();
+
+            mongoTemplate.updateFirst(
+                    Query.query(Criteria.where("destinationId").is(destinationId)),
+                    new Update().inc("customTags." + normalizedTagName, 1),
+                    CustomTagDocument.class
+            );
+        }
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/DestinationRepositoryServiceImplement.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/DestinationRepositoryServiceImplement.java
@@ -1,9 +1,19 @@
 package com.se.Tlog.domain.Travel.repository;
 
+import com.mongodb.client.result.UpdateResult;
+import com.se.Tlog.domain.Review.domain.Review;
 import com.se.Tlog.domain.Travel.domain.Destination;
+import com.se.Tlog.domain.Travel.domain.DestinationSortType;
 import com.se.Tlog.domain.Travel.domain.TagInfo;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.*;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Component;
 
 import com.se.Tlog.domain.Travel.domain.repository.DestinationRepositoryService;
@@ -11,12 +21,14 @@ import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class DestinationRepositoryServiceImplement implements DestinationRepositoryService {
     private final DestinationRepository destinationRepository;
+    private final MongoTemplate mongoTemplate;
 
     @Override
     public boolean exist(String name) {
@@ -30,5 +42,82 @@ public class DestinationRepositoryServiceImplement implements DestinationReposit
 
         destination.addFixedTags(fixedTags);
 		destinationRepository.save(destination);
+    }
+
+    @Override
+    public void increaseReviewCountAndRating(String destinationId, int rating, float approximateAverage) {
+        Update update = new Update()
+                .inc("reviewCount", 1)
+                .inc("ratingSum", rating)
+                .inc("ratingCount." + (rating - 1), 1)
+                .set("averageRating", approximateAverage);
+
+        UpdateResult updateResult = mongoTemplate.updateFirst(
+                Query.query(Criteria.where("_id").is(destinationId)),
+                update,
+                Destination.class
+        );
+
+        if (updateResult.getMatchedCount() == 0) {
+            throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);
+        }
+    }
+
+    @Override
+    public void decreaseReviewCountAndRating(String destinationId, Review review) {
+        Destination destination = mongoTemplate.findById(destinationId, Destination.class);
+        if (destination == null) {
+            throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);
+        }
+
+        int updatedReviewCount = destination.getReviewCount() - 1;
+        float approximateAverage;
+        if (updatedReviewCount <= 0) {  // 음수 방지
+            approximateAverage = 0f;
+        } else {
+            approximateAverage = (float) (destination.getRatingSum() - review.getRating()) / updatedReviewCount;
+        }
+
+        UpdateResult updateResult = mongoTemplate.updateFirst(
+                Query.query(Criteria.where("_id").is(destinationId)),
+                new Update().inc("reviewCount", -1)
+                        .inc("ratingSum", -review.getRating())
+                        .inc("ratingCount." + (review.getRating() - 1), -1)
+                        .set("averageRating", approximateAverage)
+                ,
+                Destination.class
+        );
+
+        if (updateResult.getMatchedCount() == 0) {
+            throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);
+        }
+    }
+
+    @Override
+    public List<Destination> getDestinations(Pageable pageable, String city, DestinationSortType sortType) {
+        MatchOperation matchStage = Aggregation.match(Criteria.where("city").is(city));
+
+        SortOperation sortStage = null;
+        switch (sortType){
+            case REVIEW -> { //평점 높은 순
+                sortStage = Aggregation.sort(Sort.by(Sort.Order.desc("averageRating")));
+            }
+            case POPULAR -> { // 리뷰 갯수
+                sortStage = Aggregation.sort(Sort.by(Sort.Order.desc("reviewCount")));
+            }
+        }
+
+        SkipOperation skipStage = Aggregation.skip((long) pageable.getPageNumber() * pageable.getPageSize());
+        LimitOperation limitStage = Aggregation.limit(pageable.getPageSize() + 1);  // 다음 페이지 존재 여부 확인 위해 +1
+
+        Aggregation aggregation = Aggregation.newAggregation(
+                matchStage,
+                sortStage,
+                skipStage,
+                limitStage
+        );
+
+        return new ArrayList<>(mongoTemplate.aggregate(aggregation, "destinations", Destination.class)
+                .getMappedResults());
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/exception/GlobalExceptionHandler.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/exception/GlobalExceptionHandler.java
@@ -37,6 +37,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<?> handleException(Exception e) {
         ErrorRes error = ErrorRes.of(INTERNAL_SERVER_ERROR.getStatusCode(), INTERNAL_SERVER_ERROR.getMessage());
         log.error("Error occurred : [errorCode={}, message={}]",e.getClass(), e.getMessage());
+        log.error("Exception occurred", e);  // stacktrace 출력!
         return ResponseEntity.status(error.status()).body(error);
     }
 }

--- a/tlog-was/src/test/java/com/se/Tlog/domain/review/ReviewServiceTest.java
+++ b/tlog-was/src/test/java/com/se/Tlog/domain/review/ReviewServiceTest.java
@@ -1,0 +1,74 @@
+package com.se.Tlog.domain.review;
+
+import com.se.Tlog.domain.Review.application.ReviewService;
+import com.se.Tlog.domain.Review.controller.dto.ReviewCreateDto;
+import com.se.Tlog.domain.Travel.domain.Destination;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest(properties = "spring.profiles.active=dev")
+@AutoConfigureMockMvc
+public class ReviewServiceTest {
+    @Autowired
+    private ReviewService reviewService; // 실제 서비스
+
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    private final String TEST_DESTINATION_ID = "680f7ac05bf45e4afa8e59b5";
+
+    @Test
+    @DisplayName("동시성 테스트")
+    void testConcurrentReviewCreation() throws InterruptedException {
+        // 사전 검증: Destination이 실제로 존재하는지 체크
+        Destination existingDestination = mongoTemplate.findById(TEST_DESTINATION_ID, Destination.class);
+        assertThat(existingDestination).as("테스트할 Destination이 DB에 존재해야 합니다.").isNotNull();
+
+        int numberOfThreads = 20; // 동시에 요청할 쓰레드 수
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        Random random = new Random();
+        for (int i = 0; i < numberOfThreads; i++) {
+            int threadNumber = i;
+            executorService.submit(() -> {
+                try {
+                    int randomRating = random.nextInt(5) + 1;
+                    ReviewCreateDto reviewDto = new ReviewCreateDto(
+                            "54aa01c5-b5ff-4153-a766-3ddc3af2fa58",           // userId
+                            TEST_DESTINATION_ID,             // destinationId
+                            "테스트 사용자 " + threadNumber,    // username
+                            randomRating,                               // rating
+                            "테스트 리뷰 내용 " + threadNumber,  // content
+                            List.of(),                       // imageUrlList (empty)
+                            List.of("하하", "히히", "쿄쿄")                        // customTagNames (empty)
+                    );
+                    reviewService.createReview(reviewDto);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(); // 모든 스레드가 끝날 때까지 대기
+        Thread.sleep(1000);
+        // 최종적으로 Destination의 reviewCount가 예상값과 일치하는지 확인
+        Destination updatedDestination = mongoTemplate.findById(TEST_DESTINATION_ID, Destination.class);
+
+        assertThat(updatedDestination.getReviewCount()).isGreaterThanOrEqualTo(numberOfThreads);
+    }
+
+}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #131 

## 추가 및 변경사항

### 1) 여행지 조회 정렬 타입 기능 작성 (REVIEW, POPULAR)
- Destination Controller 파라미터로 정렬타입 및 tbti , city 가 추가되었습니다. (figma 반영, tbti 관련 기능 미반영)

- 정렬 기준을 평점 , 리뷰 갯수로 정함에 따라 리뷰가 추가될때마다 Destination의 필드를 업데이트가 중요해졌습니다. 기존의 구조에는 동시성 이슈가 해결되지 않은 상태여서 race condition문제로 인해서 데이터정합성에 문제가 있었습니다. 
   - $inc 연산을 사용하면 원자성을 보장해주는 mongoDB의 특성으로 해결했고 평점 계산에 대해서는 100% 정확하진 않지만 사용자에게 제공할때 100% 일치할 필요는 없을 것 같아서 현재 구조로 처리했고 추후에 리뷰 데이터가 많이 쌓인다면 배치 처리 시스템으로 데이터 정확도를 높이는 방향으로 하면 될 것 같습니다.
 
- customtags Document 내의 List<TagCount> 도 마찬가지로 동시성 이슈로 인해 Map<String, Integer> 구조로 수정했습니다.
   - 기존의 구조대로 한다면 특정 태그가 있는지 확인하고 증가하는 과정에서 트랜잭션처럼 묶여 있지 않아서 동시 요청시 race condition이 발생합니다. 그래서 기존 구조를 Map 으로 수정하여 $inc 연산자로 특정 태그 확인과 값 증가를 원자적으로 처리할 수 있는 방향으로 수정했습니다.
   - 데이터 반환할 때도 문제없게 수정했고 기존의 TagCount는 dto로 사용하는 방향으로 처리했습니다. (코드가 매끄럽지 않은 부분이 있을수도 있습니다!)

- 기존의 여행지 전체 조회 메서드는 Page 로 반환 했었는데 figma 화면 구조상 무한 스크롤인 것 같아 Slice 타입으로 수정하였고 프론트에서 다음 페이지 존재 여부를 확인 하여 처리할 수 있게 수정하였습니다. 응답 구조에서 "last" : false 이면 "마지막 페이지가 아니다" 인 것으로 인지하고 다음 페이지를 요청하게끔 작성하면 될 것 같습니다.  

- Test 클래스가 하나 있는데 해당 클래스에서 리뷰가 없는 destinationId로 테스트 하여 다중 요청시 데이터 누락이 없는지 확인해 볼 수 있습니다.
 
## 테스트 결과

### Test 파일 실행후 데이터 확인
**스레드 20개 테스트**
동시 요청해도 리뷰 정상적으로 업데이트 되었고 customtag 카운트도 잘 된걸 확인할 수 있습니다.

<img width="869" alt="스크린샷 2025-05-30 오후 9 10 57" src="https://github.com/user-attachments/assets/aeb46678-6fba-4546-b035-7a1b08ab9907" />

**destination Document 데이터 반영 확인**
db에는 평점을 아래 사진처럼 저장해두고 반환할 때 소수 첫째자리로 반환하게끔 작성했습니다.

<img width="873" alt="스크린샷 2025-06-01 오후 8 06 01" src="https://github.com/user-attachments/assets/46ce4124-60f9-4851-b2ca-fcd240836b1e" />


## 📌 기타
- 코드가 길어 추천순 정렬은 추후 작성하겠습니다!
