### PR TITLE
Fix: 팀 초대 코드가 정수로 표시되는 문제 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Social.Chat.room.ChatRoomService;
 import com.se.Tlog.domain.Team.controller.dto.*;
+import com.se.Tlog.domain.Team.domain.InviteCodeUtil;
 import com.se.Tlog.domain.Team.domain.Team;
 import com.se.Tlog.domain.Team.domain.TeamDomainService;
 import com.se.Tlog.domain.Team.domain.repository.TeamRepositoryService;
@@ -110,7 +111,7 @@ public class TeamService {
 	}*/
 	@Transactional
 	public void joinTeamByInviteCode(TeamUserRequestDto request) {
-		Team team = teamRepository.findByInviteCode(request.inviteCode())
+		Team team = teamRepository.findByInviteCode(InviteCodeUtil.strToLong(request.inviteCode()))
 				.orElseThrow(() -> new CustomException(ErrorType.TEAM_NOT_FOUND));
 		User user = userRepository.findById(request.userId())
 				.orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
@@ -1,5 +1,6 @@
 package com.se.Tlog.domain.Team.controller.dto;
 
+import com.se.Tlog.domain.Team.domain.InviteCodeUtil;
 import com.se.Tlog.domain.Team.domain.Team;
 import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
 
@@ -11,7 +12,7 @@ public record TeamDetailDto(
         UUID teamId,
         String teamName,
         //String teamTBTI,
-        long inviteCode,
+        String inviteCode,
         LocalDate startDate,
         LocalDate endDate,
         List<TeamMemberDto> members,
@@ -21,7 +22,7 @@ public record TeamDetailDto(
         return new TeamDetailDto(
                 team.getId(),
                 team.getName(),
-                team.getInviteCode(),
+                InviteCodeUtil.longToStr(team.getInviteCode()),
                 team.getCreatedAt().toLocalDate(),
                 LocalDate.now(),
                 members,

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamUserRequestDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamUserRequestDto.java
@@ -6,8 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "기본적인 팀원 관리 요청에 사용되는 DTO. 팀 초대, 팀원으로 추가, 팀 방출에 사용됩니다.")
 public record TeamUserRequestDto(
-		@Schema(description = "처리할 팀의 code")
-		long inviteCode,
+		@Schema(description = "처리할 팀의 초대 코드")
+		String inviteCode,
 		
 		@Schema(description = "처리할 유저의 id")
 		UUID userId

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/InviteCodeUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/InviteCodeUtil.java
@@ -27,7 +27,7 @@ public class InviteCodeUtil {
 	
 	public static long strToLong(String inviteCode) {
 		if (null == inviteCode || inviteCode.length() != INVITE_CODE_LEN)
-			throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
+			throw new CustomException(ErrorType.INTERNAL_ERROR_BY_INVITE_CODE);
 		
 		long codeValue = 0;
 		long multiply = 1;
@@ -40,7 +40,7 @@ public class InviteCodeUtil {
 				codeValue += multiply * (26 + (code - 'A'));
 			}
 			else {
-				throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
+				throw new CustomException(ErrorType.INTERNAL_ERROR_BY_INVITE_CODE);
 			}
 			multiply *= 52;
 		}
@@ -50,7 +50,7 @@ public class InviteCodeUtil {
 	
 	public static String longToStr(long inviteCode) {
 		if (!isValidCode(inviteCode))
-			throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
+			throw new CustomException(ErrorType.INTERNAL_ERROR_BY_INVITE_CODE);
 		
 		char[] codes = new char[INVITE_CODE_LEN];
 		for (int i = INVITE_CODE_LEN - 1; i >= 0; i--) {


### PR DESCRIPTION
## 작업 동기 및 이슈
- #137 

## 추가 및 변경사항
- DTO에서 팀 초대 코드를 6자리 코드로 받도록 수정
- DTO 생성/파싱 로직에서 변환 로직을 사용하도록 수정

## 테스트 결과
- 이상 무.
  팀 초대 및 팀 정보보기 API에서 6자리 초대코드 활용이 올바르게 동작합니다.
  - 초대코드 사용 예시 : 
    <img src="https://github.com/user-attachments/assets/956f2afd-26d3-4c13-a2ad-df0cf7c6cc42" width="350"/>


## 📌 기타
