### PR TITLE
Feature: 질문 데이터 구조 변경 (응답 데이터 구성 / 가중치 추가 등)

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiService.java
@@ -1,8 +1,10 @@
 package com.se.Tlog.domain.Tbti.application;
 
 import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Tbti.controller.dto.TbtiAnswerDto;
 import com.se.Tlog.domain.Tbti.controller.dto.TbtiQuestionReq;
 import com.se.Tlog.domain.Tbti.controller.dto.TbtiQuestionRes;
+import com.se.Tlog.domain.Tbti.domain.TbtiAnswer;
 import com.se.Tlog.domain.Tbti.domain.TbtiQuestion;
 import com.se.Tlog.domain.Tbti.domain.TraitCategory;
 import com.se.Tlog.domain.Tbti.repository.jpa.TbtiQuestionRepository;
@@ -10,36 +12,60 @@ import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.UUID;
 
 @ApplicationService
 @RequiredArgsConstructor
 public class TbtiService {
 
-    final TbtiQuestionRepository tbtiQuestionRepository;
+    private final TbtiQuestionRepository tbtiQuestionRepository;
 
     @Transactional
     public void createTbtiQuestion(TbtiQuestionReq tbtiQuestionReq) {
+        if (tbtiQuestionReq.answers() == null || tbtiQuestionReq.answers().size() == 0)
+            throw new CustomException(ErrorType.QUESTION_HAS_NO_ANSWER);
+
+        List<TbtiAnswer> tbtiAnswers = tbtiQuestionReq.answers().stream()
+                .map(dto -> TbtiAnswer.createAnswer(dto.content(), dto.percentage()))
+                .toList();
         TbtiQuestion tbtiQuestion = TbtiQuestion.create(
-                tbtiQuestionReq.getContent(),
-                tbtiQuestionReq.getTraitCategory()
-        );
+                tbtiQuestionReq.content(),
+                TraitCategory.fromString(tbtiQuestionReq.traitCategory()),
+                tbtiAnswers,
+                tbtiQuestionReq.weight());
 
         tbtiQuestionRepository.save(tbtiQuestion);
     }
 
-    public Page<TbtiQuestionRes> getAllTbtiQuestion(Pageable pageable) {
-        return tbtiQuestionRepository.findAll(pageable).map(TbtiQuestionRes::from);
+    public List<TbtiQuestionRes> getAllTbtiQuestion() {
+        List<TbtiQuestion> questions = tbtiQuestionRepository.findAllFetch();
+        return questions.stream().map(question -> new TbtiQuestionRes(
+                question.getId(),
+                question.getContent(),
+                question.getAnswerWeight(),
+                question.getTraitCategory(),
+                question.getTraitCategory().getCategoryInitial(),
+                question.getTbtiAnswers().stream()
+                        .map(answer -> new TbtiAnswerDto(answer.getContent(), answer.getPercentage()))
+                        .toList())
+                ).toList();
     }
 
-    public Page<TbtiQuestionRes> getAllTbtiQuestionByTraitCategory(String traitCategory, Pageable pageable) {
-
+    public List<TbtiQuestionRes> getAllTbtiQuestionByTraitCategory(String traitCategory) {
         TraitCategory traitCategoryEnum = TraitCategory.fromString(traitCategory);
-        return tbtiQuestionRepository.findByTraitCategory(traitCategoryEnum, pageable)
-                .map(TbtiQuestionRes::from);
+        List<TbtiQuestion> questions = tbtiQuestionRepository.findByTraitCategoryFetch(traitCategoryEnum);
+        return questions.stream().map(question -> new TbtiQuestionRes(
+                question.getId(),
+                question.getContent(),
+                question.getAnswerWeight(),
+                question.getTraitCategory(),
+                question.getTraitCategory().getCategoryInitial(),
+                question.getTbtiAnswers().stream()
+                        .map(answer -> new TbtiAnswerDto(answer.getContent(), answer.getPercentage()))
+                        .toList())
+                ).toList();
     }
 
     @Transactional

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiController.java
@@ -30,7 +30,7 @@ public class TbtiController {
     		summary = "사용자용 TBTI 질문 전체 가져오기",
     		description = "모든 사용자용 TBTI 질문을 반환합니다.",
 			parameters = {
-					@Parameter(name = "categories", description = "TBTI 특성 카테고리입니다.")
+					@Parameter(name = "categories", description = "TBTI 특성 카테고리입니다. (RISK_TAKING, LOCATION_PREFERENCE, PLANNING_STYLE,  ACTIVITY_LEVEL)")
     		},
 			responses = {
 					@ApiResponse( responseCode = "200", description = "처리 성공시 반환되는 TBTI 질문 Page입니다.",

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiController.java
@@ -1,43 +1,36 @@
 package com.se.Tlog.domain.Tbti.controller;
 
 import com.se.Tlog.domain.Tbti.application.TbtiService;
-import com.se.Tlog.domain.Tbti.controller.dto.TbtiQuestionReq;
 import com.se.Tlog.domain.Tbti.controller.dto.TbtiQuestionResponse;
 import com.se.Tlog.global.response.success.SuccessRes;
-import com.se.Tlog.global.response.success.SuccessType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.UUID;
 
 
 @RestController
 @RequestMapping("/api/tbti")
 @RequiredArgsConstructor
+@Tag(name = "TBTI 도메인")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
 public class TbtiController {
+    private final TbtiService tbtiService;
 
-    final TbtiService tbtiService;
-
-    @GetMapping
+    @GetMapping("/user/questions")
     @Operation (
-    		summary = "전체 TBTI 질문 가져오기",
-    		description = "모든 TBTI 질문을 반환합니다.",
-			tags = {"TBTI 도메인"},
-			security = @SecurityRequirement(
-					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
-					scopes = {"scope1", "scope2"}),
+    		summary = "사용자용 TBTI 질문 전체 가져오기",
+    		description = "모든 사용자용 TBTI 질문을 반환합니다.",
 			parameters = {
-					@Parameter(name = "categories", description = "TBTI 특성 카테고리입니다."),
-					@Parameter(name = "pageable", description = "Page 정보")
+					@Parameter(name = "categories", description = "TBTI 특성 카테고리입니다.")
     		},
 			responses = {
 					@ApiResponse( responseCode = "200", description = "처리 성공시 반환되는 TBTI 질문 Page입니다.",
@@ -48,52 +41,9 @@ public class TbtiController {
 					@ApiResponse(responseCode = "505", description = "서버 내부 오류")}
 	)
     public ResponseEntity<?> getAllTbtiQuestion(
-            @RequestParam(name = "categories", required = false) String traitCategory,
-            @PageableDefault(size = 10) Pageable pageable
-    ){
+            @RequestParam(name = "categories", required = false) String traitCategory){
         if (traitCategory == null || traitCategory.isEmpty())
-            return ResponseEntity.ok().body(SuccessRes.from(tbtiService.getAllTbtiQuestion(pageable)));
-        return ResponseEntity.ok().body(SuccessRes.from(tbtiService.getAllTbtiQuestionByTraitCategory(traitCategory, pageable)));
+            return ResponseEntity.ok().body(SuccessRes.from(tbtiService.getAllTbtiQuestion()));
+        return ResponseEntity.ok().body(SuccessRes.from(tbtiService.getAllTbtiQuestionByTraitCategory(traitCategory)));
     }
-
-    @PostMapping
-    @Operation (
-    		summary = "새 TBTI 질문 등록하기",
-    		description = "새 TBTI 질문을 등록합니다.",
-			tags = {"TBTI 도메인"},
-			security = @SecurityRequirement(
-					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
-					scopes = {"scope1", "scope2"}),
-			responses = {
-					@ApiResponse( responseCode = "200", description = "성공"), 
-					@ApiResponse(responseCode = "505", description = "서버 내부 오류")}
-	)
-    public ResponseEntity<?> createTbtiQuestion(@RequestBody TbtiQuestionReq tbtiQuestionReq){
-        tbtiService.createTbtiQuestion(tbtiQuestionReq);
-
-        return ResponseEntity.ok()
-                .body(SuccessRes.from(SuccessType.OK));
-    }
-    
-    @DeleteMapping("/{tbtiQuestionId}")
-    @Operation (
-    		summary = "TBTI 질문 삭제하기",
-    		description = "TBTI 질문을 삭제합니다.",
-			tags = {"TBTI 도메인"},
-			security = @SecurityRequirement(
-					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
-					scopes = {"scope1", "scope2"}),
-			parameters = {@Parameter(name = "tbtiQuestionId", description = "삭제할 TBTI 질문의 UUID입니다.")},
-			responses = {
-					@ApiResponse( responseCode = "200", description = "성공"), 
-					@ApiResponse(responseCode = "505", description = "서버 내부 오류")}
-	)
-    public ResponseEntity<?> deleteTbtiQuestion(@PathVariable(name = "tbtiQuestionId") UUID tbtiQuestionId) {
-        tbtiService.deleteTbtiQuestion(tbtiQuestionId);
-        return ResponseEntity.ok()
-                .body(SuccessRes.from(SuccessType.OK));
-    }
-
-
-
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiManageController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiManageController.java
@@ -29,7 +29,9 @@ public class TbtiManageController {
     @PostMapping("/user/question")
     @Operation (
     		summary = "새 TBTI 질문 등록하기",
-    		description = "새 TBTI 질문을 등록합니다.",
+    		description = "새 TBTI 질문을 등록합니다."
+    		            + "<br> 가중치는 1~5 사이의 값을 갖습니다."
+    		            + "<br> TBTI 카테고리는 [RISK_TAKING, LOCATION_PREFERENCE, PLANNING_STYLE,  ACTIVITY_LEVEL] 의 값을 갖습니다.",
 			responses = {
 					@ApiResponse( responseCode = "200", description = "성공"), 
 					@ApiResponse(responseCode = "505", description = "서버 내부 오류")}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiManageController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiManageController.java
@@ -1,0 +1,58 @@
+package com.se.Tlog.domain.Tbti.controller;
+
+import com.se.Tlog.domain.Tbti.application.TbtiService;
+import com.se.Tlog.domain.Tbti.controller.dto.TbtiQuestionReq;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+
+@RestController
+@RequestMapping("/api/tbti")
+@RequiredArgsConstructor
+@Tag(name = "TBTI 관리 도메인")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
+public class TbtiManageController {
+    private final TbtiService tbtiService;
+
+    @PostMapping("/user/question")
+    @Operation (
+    		summary = "새 TBTI 질문 등록하기",
+    		description = "새 TBTI 질문을 등록합니다.",
+			responses = {
+					@ApiResponse( responseCode = "200", description = "성공"), 
+					@ApiResponse(responseCode = "505", description = "서버 내부 오류")}
+	)
+    public ResponseEntity<?> createTbtiQuestion(@RequestBody TbtiQuestionReq tbtiQuestionReq){
+        tbtiService.createTbtiQuestion(tbtiQuestionReq);
+
+        return ResponseEntity.ok()
+                .body(SuccessRes.from(SuccessType.OK));
+    }
+    
+    @DeleteMapping("/user/question/{tbtiQuestionId}")
+    @Operation (
+    		summary = "TBTI 질문 삭제하기",
+    		description = "TBTI 질문을 삭제합니다.",
+			parameters = {@Parameter(name = "tbtiQuestionId", description = "삭제할 TBTI 질문의 UUID입니다.")},
+			responses = {
+					@ApiResponse( responseCode = "200", description = "성공"), 
+					@ApiResponse(responseCode = "505", description = "서버 내부 오류")}
+	)
+    public ResponseEntity<?> deleteTbtiQuestion(@PathVariable(name = "tbtiQuestionId") UUID tbtiQuestionId) {
+        tbtiService.deleteTbtiQuestion(tbtiQuestionId);
+        return ResponseEntity.ok()
+                .body(SuccessRes.from(SuccessType.OK));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiAnswerDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiAnswerDto.java
@@ -1,0 +1,13 @@
+package com.se.Tlog.domain.Tbti.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "TBTI 질문의 응답 형식 DTO")
+public record TbtiAnswerDto(
+        @Schema(description = "응답 문구")
+        String content,
+        
+        @Schema(description = "해당하는 TBTI 성향의 % 값 (0~99)")
+        int percentage) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiQuestionReq.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiQuestionReq.java
@@ -1,20 +1,22 @@
 package com.se.Tlog.domain.Tbti.controller.dto;
 
-import com.se.Tlog.domain.Tbti.domain.TraitCategory;
+import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
 @Schema(description = "TBTI 질문 요청 DTO")
-public class TbtiQuestionReq {
+public record TbtiQuestionReq(
 
 	@Schema(description = "질문의 내용입니다.")
-    String content;
+    String content,
+    
+    @Schema(description = "질문의 가중치입니다. (1~5)")
+    int weight,
 	
 	@Schema(description = "TBTI 유형입니다.")
-    TraitCategory traitCategory;
+    String traitCategory,
+    
+    @Schema(description = "응답 형식")
+    List<TbtiAnswerDto> answers) {
 	
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiQuestionReq.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiQuestionReq.java
@@ -13,7 +13,7 @@ public record TbtiQuestionReq(
     @Schema(description = "질문의 가중치입니다. (1~5)")
     int weight,
 	
-	@Schema(description = "TBTI 유형입니다.")
+	@Schema(description = "TBTI 유형입니다. (RISK_TAKING, LOCATION_PREFERENCE, PLANNING_STYLE,  ACTIVITY_LEVEL)")
     String traitCategory,
     
     @Schema(description = "응답 형식")

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiQuestionRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiQuestionRes.java
@@ -2,9 +2,9 @@ package com.se.Tlog.domain.Tbti.controller.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
 import java.util.UUID;
 
-import com.se.Tlog.domain.Tbti.domain.TbtiQuestion;
 import com.se.Tlog.domain.Tbti.domain.TraitCategory;
 
 @Schema(description = "TBTI 질문 응답 DTO")
@@ -16,14 +16,16 @@ public record TbtiQuestionRes(
         @Schema(description = "TBTI 질문의 표시 내용")
         String content,
         
+        @Schema(description = "TBTI 질문의 가중치")
+        int weight,
+        
         @Schema(description = "질문지의 TBTI 영역")
-        TraitCategory traitCategory
-) {
-    public static TbtiQuestionRes from(TbtiQuestion tbtiQuestion) {
-        return new TbtiQuestionRes(
-                tbtiQuestion.getId(),
-                tbtiQuestion.getContent(),
-                tbtiQuestion.getTraitCategory()
-        );
-    }
+        TraitCategory traitCategory,
+        
+        @Schema(description = "질문지의 TBTI 영역 알파벳")
+	    String categoryIntial,
+	    
+	    @Schema(description = "응답 형식")
+	    List<TbtiAnswerDto> answers) {
+    
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiAnswer.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiAnswer.java
@@ -7,7 +7,8 @@ import lombok.NoArgsConstructor;
 
 import static lombok.AccessLevel.*;
 
-import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
 
 @Entity
 @Getter
@@ -16,30 +17,35 @@ public class TbtiAnswer {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
-
+    
     @ManyToOne
     @JoinColumn(name = "tbtiQuestion_id")
     private TbtiQuestion tbtiQuestion;
+    
+    private String content;
 
-    private int score;
+    private int percentage;
+    
+    public void setQuestion(TbtiQuestion question) {
+        this.tbtiQuestion = question;
+    }
 
     @Builder
-    private TbtiAnswer(User user, TbtiQuestion tbtiQuestion, int score) {
-        this.user = user;
-        this.tbtiQuestion = tbtiQuestion;
-        this.score = score;
+    private TbtiAnswer(String content, int percentage) {
+        this.content = content;
+        this.percentage = percentage;
     }
 
     //응답 생성 메서드
-    public static TbtiAnswer createAnswer(User user, TbtiQuestion tbtiQuestion, int score) {
+    public static TbtiAnswer createAnswer(String content, int percentage) {
+        if (content == null)
+            throw new CustomException(ErrorType.CONTENT_NOT_FOUND);
+        if (percentage < 0 || percentage > 99)
+            throw new CustomException(ErrorType.INVALID_ANSWER_PERCENTAGE);
+        
         return TbtiAnswer.builder()
-                .user(user)
-                .tbtiQuestion(tbtiQuestion)
-                .score(score)
+                .content(content)
+                .percentage(percentage)
                 .build();
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiQuestion.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiQuestion.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import static lombok.AccessLevel.*;
@@ -23,19 +25,33 @@ public class TbtiQuestion {
     @Enumerated(EnumType.STRING)
     private TraitCategory traitCategory;
 
-    private TbtiQuestion(String content, TraitCategory traitCategory) {
-        validateContent(content);
+    @OneToMany(mappedBy = "tbtiQuestion",
+            cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TbtiAnswer> tbtiAnswers;
+    
+    private int answerWeight;
+
+    private TbtiQuestion(String content, TraitCategory traitCategory, List<TbtiAnswer> tbtiAnswers, int answerWeight) {
         this.content = content;
         this.traitCategory = traitCategory;
+        this.tbtiAnswers = new ArrayList<TbtiAnswer>(tbtiAnswers);
+        this.tbtiAnswers.forEach(answer -> answer.setQuestion(this));
+        this.answerWeight = answerWeight;
     }
 
     // 질문 생성 메서드
-    public static TbtiQuestion create(String content, TraitCategory traitCategory) {
-        return new TbtiQuestion(content, traitCategory);
+    public static TbtiQuestion create(String content, TraitCategory traitCategory, List<TbtiAnswer> tbtiAnswers, int answerWeight) {
+        validateContent(content);
+        if (tbtiAnswers == null || tbtiAnswers.size() == 0)
+            throw new CustomException(ErrorType.QUESTION_HAS_NO_ANSWER);
+        if (answerWeight < 1 || answerWeight > 5)
+            throw new CustomException(ErrorType.INVALID_QUESTION_WEIGHT);
+        
+        return new TbtiQuestion(content, traitCategory, tbtiAnswers, answerWeight);
     }
 
     // 유효성 검사 메서드
-    private void validateContent(String content){
+    private static void validateContent(String content){
         if(content == null || content.isBlank()){
             throw new CustomException(ErrorType.CONTENT_NOT_FOUND);
         }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TraitCategory.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TraitCategory.java
@@ -4,11 +4,19 @@ import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 
 public enum TraitCategory {
-    ACTIVITY_LEVEL, // 활동적 ↔ 여유로움
-    LOCATION_PREFERENCE, // 자연 ↔ 도시
-    PLANNING_STYLE, // 계획적 ↔ 즉흥적
-    RISK_TAKING; // 개척적 ↔ 안정적
+    RISK_TAKING("S-R"), // 교류형(S) ↔ 사색형(R) 0 ~ 99
+    LOCATION_PREFERENCE("E-O"), // 자연친화(E) ↔ 도시친화(O) 0 ~ 99
+    PLANNING_STYLE("L-N"), // 계획적(L) ↔ 즉흥적(N) 0 ~ 99
+    ACTIVITY_LEVEL("A-I"); // 활동형(A) ↔ 여유형(I) 0 ~ 99
 
+    private String categoryInitial;
+    private TraitCategory(String categoryInitial) {
+        this.categoryInitial = categoryInitial;
+    }
+    public String getCategoryInitial() {
+        return categoryInitial;
+    }
+    
     public static TraitCategory fromString(String traitCategory) {
         try {
             return TraitCategory.valueOf(traitCategory.toUpperCase());

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/repository/jpa/TbtiQuestionRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/repository/jpa/TbtiQuestionRepository.java
@@ -1,16 +1,21 @@
 package com.se.Tlog.domain.Tbti.repository.jpa;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.se.Tlog.domain.Tbti.domain.TbtiQuestion;
 import com.se.Tlog.domain.Tbti.domain.TraitCategory;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface TbtiQuestionRepository extends JpaRepository<TbtiQuestion, UUID> {
-    Page<TbtiQuestion> findByTraitCategory(TraitCategory traitCategory, Pageable pageable);
+    
+    @Query(value = "SELECT q FROM TbtiQuestion q JOIN FETCH q.tbtiAnswers")
+    List<TbtiQuestion> findAllFetch();
+    
+    @Query(value = "SELECT q FROM TbtiQuestion q JOIN FETCH q.tbtiAnswers WHERE q.traitCategory = :traitCategory")
+    List<TbtiQuestion> findByTraitCategoryFetch(TraitCategory traitCategory);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -41,6 +41,11 @@ public enum ErrorType {
     INVALID_TLOG_MESSAGE(HttpStatus.BAD_REQUEST, "Tlog 메시지 규격에 맞지 않습니다."),
     INVALID_TLOG_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "Tlog 알림 타입이 없거나 잘못된 값입니다."),
     INVALID_LINK_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "링크 알림 타입이 없거나 잘못된 값입니다."),
+    
+    // TBTI 관련
+    INVALID_ANSWER_PERCENTAGE(HttpStatus.BAD_REQUEST, "TBTI 응답의 값은 0~99사이여야 합니다."),
+    QUESTION_HAS_NO_ANSWER(HttpStatus.BAD_REQUEST, "TBTI 질문에는 응답이 1개 이상 존재해야 합니다."),
+    INVALID_QUESTION_WEIGHT(HttpStatus.BAD_REQUEST, "TBTI 질문의 가중치는 1~5사이여야 합니다."),
 
     // 인증
     // 401

--- a/tlog-was/src/test/java/com/se/Tlog/domain/tlog/TbtiQuestionTest.java
+++ b/tlog-was/src/test/java/com/se/Tlog/domain/tlog/TbtiQuestionTest.java
@@ -3,8 +3,6 @@ package com.se.Tlog.domain.tlog;
 import com.se.Tlog.domain.Tbti.domain.TbtiAnswer;
 import com.se.Tlog.domain.Tbti.domain.TbtiQuestion;
 import com.se.Tlog.domain.Tbti.domain.TraitCategory;
-import com.se.Tlog.domain.User.controller.dto.SsoUserInfo;
-import com.se.Tlog.domain.User.domain.User;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -14,6 +12,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
+
 
 @SpringBootTest
 @Slf4j
@@ -21,7 +21,7 @@ public class TbtiQuestionTest {
 
     String content = "너는 여행을 계획할 때 활동적인게 좋아?";
     TraitCategory traitCategory = TraitCategory.ACTIVITY_LEVEL;
-    TbtiQuestion tbtiQuestion = TbtiQuestion.create(content, traitCategory);
+    TbtiQuestion tbtiQuestion = TbtiQuestion.create(content, traitCategory, List.of(TbtiAnswer.createAnswer("응답 1", 50)), 1);
 
 
     @Test
@@ -34,6 +34,10 @@ public class TbtiQuestionTest {
         assertThat(tbtiQuestion.getTraitCategory()).isEqualTo(traitCategory);
     }
 
+    /*
+     * 25.05.31
+     * TbtiAnswer 엔티티의 용도가 변경됨에 따라 테스트 로직이 수정되었습니다.
+     * 
     @Test
     @DisplayName("질문 응답 테스트")
     void tbtiAnswerTest() {
@@ -56,5 +60,5 @@ public class TbtiQuestionTest {
         assertThat(tbtiAnswer.getScore()).isEqualTo(score);
         assertThat(tbtiAnswer.getUser()).isEqualTo(user);
 
-    }
+    }*/
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #139 

## ⚠️주의사항⚠️
- **DB 스키마가 변경되었습니다.**
  - 이번 수정으로 TbtiAnswer 내 `score` 컬럼이 불필요하게 되었으나, nullable: false로 설정되어 있어
    **해당 컬럼을 삭제**해야 질문 추가가 올바르게 동작합니다!

## 추가 및 변경사항
### 1) TbtiAnswer 엔티티의 역할 변경
- TbtiAnswer 엔티티는 사용자의 응답 결과를 기록하는데에 사용되었습니다.
- 그러나 추후 응답 결과는 TBTI 8자리 코드로 다루게 될 것이며, 이에 따라 응답을 기록할 필요는 없겠습니다.
- 따라서 해당 엔티티는 **질문 하단에 표시할 응답항목**을 다루는 역할로 변경하였습니다.
  - `percentage` : 응답시 적용할 점수값(0~99 사이 %값)이 추가되었습니다. ![이 값은 결과 계산에 반영됩니다.](https://www.notion.so/TBTI-204c8b877abb80b2a622da8b5d217190?source=copy_link#205c8b877abb806b9f45cdfd78072b7a)
### 2) TBTI 질문에 가중치 정보 추가
- TBTI 질문은 가중치(1~5)를 가집니다.
  ![이 값은 결과 계산에 반영됩니다.](https://www.notion.so/TBTI-204c8b877abb80b2a622da8b5d217190?source=copy_link#205c8b877abb806b9f45cdfd78072b7a)
### 3) TBTI 질문 DTO 변경
- TBTI 질문 데이터는 이제 응답항목 데이터도 포함합니다.
  <img src="https://github.com/user-attachments/assets/760e1d33-dcc9-426c-978d-1d49b426bc84" width="350"/>
### 4) 변경된 TBTI 카테고리 반영
- TBTI 카테고리별 알파벳이 변경됨에 따라, 내부 코드(TraitCatergory enum 등)에 반영하였습니다.
### 5) TBTI 관련 API를 관리와 사용으로 분리
- TBTI 질문 편집 등의 기능이 늘어날 것 같아 관리와 사용 용도로 API를 분리했습니다만,
  계속 보고 있으니 굳이 안해도 되는 작업이었겠다 싶은 생각도 듭니다...!
  <img src="https://github.com/user-attachments/assets/c349eaff-3e6d-45fd-8634-3a7a56c338b1" width="500"/>
  <img src="https://github.com/user-attachments/assets/a6a52de2-67fb-489f-9f1c-eb30fc1a0786" width="500"/>

## 테스트 결과
- **1차:** TbtiAnswer 내 `score` 컬럼을 유지하면 질문 생성이 불가능.
- **2차:** TbtiAnswer.`score` 컬럼 삭제 후
  이상 무.
  질문 생성, 조회, 삭제가 올바르게 동작합니다.

## 📌 기타
