### PR TITLE
Fix: 여행지 조회 API의 반환 타입 통일

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
@@ -57,12 +57,14 @@ public class DestinationController {
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류")
             }
     )
-    public ResponseEntity<Slice<DestinationSummaryRes>> getAllDestinations(
+    public ResponseEntity<SuccessRes<Slice<DestinationSummaryRes>>> getAllDestinations(
             @PageableDefault(size = 10) Pageable pageable,
             @RequestParam String city,
             @RequestParam(defaultValue = "RECOMMAND") DestinationSortType sortType,
             @RequestParam(required = false) String tbti) {
-        return ResponseEntity.ok(destinationService.getAllDestinations(pageable,city,sortType,tbti));
+        return ResponseEntity
+                .status(SuccessType.DESTINATION_GET_SUCCESS.getStatus())
+                .body(SuccessRes.from(destinationService.getAllDestinations(pageable,city,sortType,tbti)));
     }
 
     @GetMapping("/{id}")
@@ -80,8 +82,10 @@ public class DestinationController {
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류")
             }
     )
-    public ResponseEntity<DestinationDetailsRes> getDestinationById(
+    public ResponseEntity<SuccessRes<DestinationDetailsRes>> getDestinationById(
             @Parameter(description = "특정 destination의 UUID 입니다.") @PathVariable String id) {
-        return ResponseEntity.ok(destinationService.getDestinationById(id));
+        return ResponseEntity
+                .status(SuccessType.DESTINATION_GET_SUCCESS.getStatus())
+                .body(SuccessRes.from(destinationService.getDestinationById(id)));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/success/SuccessType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/success/SuccessType.java
@@ -17,6 +17,7 @@ public enum SuccessType {
     AVAILABLE_ID(HttpStatus.OK, "사용가능한 아이디입니다."),
     TAG_UPDATE(HttpStatus.OK, "태그 상태 업데이트에 성공하였습니다." ),
     MESSAGE_READ_SUCCESS(HttpStatus.OK, "메시지 읽음 처리에 성공하였습니다."),
+    DESTINATION_GET_SUCCESS(HttpStatus.OK, "여행지 조회에 성공하였습니다."),
     // 201
     CREATED(HttpStatus.CREATED, "등록을 성공하였습니다."),
     CHATROOM_CREATE(HttpStatus.CREATED, "채팅방 생성을 성공하였습니다."),


### PR DESCRIPTION
## 작업 동기 및 이슈
- #143 

## 추가 및 변경사항
- 여행지 조회 API에서 SuccessRes가 빠진 부분에
  해당 데이터를 포함하도록 변경

## 테스트 결과
- 이상 무.

- **서버에는 먼저 반영해두었습니다!**

## 📌 기타
- **서버에는 먼저 반영해두었습니다!**

- 다른 도메인의 API 중에도 반환 타입의 형태가 다른 경우가 발견되었습니다.
  그러나 현재 프론트도 이미 작업이 진행되어있는 만큼,
  다른 API의 반환 타입은 프론트와 상의 후에 변경하는 것이 맞겠다 판단하고 있습니다!