### PR TITLE
Fix: 여행지 평균 평점이 Infinity가 되는 문제 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/service/DestinationDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/service/DestinationDomainService.java
@@ -30,7 +30,7 @@ public class DestinationDomainService {
         if (destination == null) {
             throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);
         }
-        float approximateAverage = (float) (destination.getRatingSum() + rating) / (destination.getReviewCount());
+        float approximateAverage = (float) (destination.getRatingSum() + rating) / (destination.getReviewCount() + 1);
 
         destinationRepositoryService.increaseReviewCountAndRating(destinationId, rating, approximateAverage);
     }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #145 

## 원인
- 평균 평점 연산 과정에서 `총 리뷰 수`를 업데이트 전 값으로 계산함.
  -> 현재 리뷰가 하나도 없는 여행지에 새 리뷰를 추가할 경우,
    `총 리뷰 수`를 1이 아닌 0으로 계산하게 되면서 `Infinity` 값으로 계산됨.

## 변경사항
- 계산 로직에서 `총 리뷰 수`를 `이전 값 + 1` 으로 변경했습니다!

## 테스트 결과
- 이상 무.

- **서버에는 먼저 반영해두었습니다!**

## 📌 기타
- **서버에는 먼저 반영해두었습니다!**
