### PR TITLE
Fix: 여행지 조회 관련 문제 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
@@ -47,7 +47,7 @@ public class ReviewService {
         List<DestinationReviewDto> dtoList = reviews.getContent().stream().map(review -> {
             UUID userId = UUID.fromString(review.getUserId());
             UserProfileInfo userProfileInfo = userProfiles.get(userId);
-            return DestinationReviewDto.from(review, userProfileInfo);
+            return DestinationReviewDto.from(review, review.getUsername(), userProfileInfo);
         }).toList();
 
         return new SliceImpl<>(dtoList, sortedPageable, reviews.hasNext());

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
@@ -42,12 +42,15 @@ public class ReviewService {
                 .map(UUID::fromString)
                 .collect(Collectors.toSet());
 
-        Map<UUID,UserProfileInfo> userProfiles = userDomainService.getUserProfile(uniqueUserIds);
+        Map<UUID,UserProfileInfo> userProfiles = userDomainService.getUserProfileOnlyExist(uniqueUserIds);
 
         List<DestinationReviewDto> dtoList = reviews.getContent().stream().map(review -> {
             UUID userId = UUID.fromString(review.getUserId());
             UserProfileInfo userProfileInfo = userProfiles.get(userId);
-            return DestinationReviewDto.from(review, review.getUsername(), userProfileInfo);
+            if (userProfileInfo != null)
+                return DestinationReviewDto.from(review, review.getUsername(), userProfileInfo);
+            else
+                return DestinationReviewDto.from(review, "탈퇴한 사용자", UserProfileInfo.getNullProfile());
         }).toList();
 
         return new SliceImpl<>(dtoList, sortedPageable, reviews.hasNext());

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/controller/dto/DestinationReviewDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/controller/dto/DestinationReviewDto.java
@@ -16,11 +16,15 @@ public record DestinationReviewDto(
         List<String> reviewImageUrl,
         LocalDateTime createdAt
 ) {
-    public static DestinationReviewDto from(Review review, UserProfileInfo userProfileInfo) {
+    public static DestinationReviewDto from(
+            Review review, 
+            // 추후 username과 UserProfileInfo를 합쳐 사용자 데이터로 묶는게 좋겠습니다!
+            String username, 
+            UserProfileInfo userProfileInfo) {
         return new DestinationReviewDto(
                 review.getId(),
                 review.getUserId(),
-                review.getUsername(),
+                username,
                 userProfileInfo.imageUrl(),
                 review.getRating(),
                 review.getContent(),

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/domain/Review.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/domain/Review.java
@@ -27,6 +27,7 @@ public class Review {
 	private String userId;
 	private String destinationId;
 
+	// 추후 리팩토링 소요 : 사용자 정보를 리뷰에서 가지고 있음
 	private String username;
 
 	private int rating;
@@ -41,6 +42,7 @@ public class Review {
 		return new Review(
 				dto.userId(),
 				dto.destinationId(),
+				// 추후 리팩토링 소요 : 사용자 정보를 리뷰에서 가지고 있음
 				dto.username(),
 				dto.rating(),
 				dto.content(),
@@ -51,6 +53,7 @@ public class Review {
 	private Review(
 			String userId,
 			String destinationId,
+			// 추후 리팩토링 소요 : 사용자 정보를 리뷰에서 가지고 있음
 			String username,
 			int rating,
 			String content,
@@ -58,6 +61,7 @@ public class Review {
 	){
 		this.userId = userId;
 		this.destinationId = destinationId;
+		// 추후 리팩토링 소요 : 사용자 정보를 리뷰에서 가지고 있음
 		this.username = username;
 		this.rating = rating;
 		this.content = content;

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/domain/service/ReviewDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/domain/service/ReviewDomainService.java
@@ -28,12 +28,15 @@ public class ReviewDomainService {
                 .map(Review::getUserId)
                 .map(UUID::fromString)
                 .collect(Collectors.toSet());
-        Map<UUID,UserProfileInfo> userProfiles = userDomainService.getUserProfile(uniqueUserIds);
+        Map<UUID,UserProfileInfo> userProfiles = userDomainService.getUserProfileOnlyExist(uniqueUserIds);
 
         return reviews.stream().map(review -> {
             UUID userId = UUID.fromString(review.getUserId());
             UserProfileInfo userProfileInfo = userProfiles.get(userId);
-            return DestinationReviewDto.from(review, review.getUsername(), userProfileInfo);
+            if (userProfileInfo != null)
+                return DestinationReviewDto.from(review, review.getUsername(), userProfileInfo);
+            else
+                return DestinationReviewDto.from(review, "탈퇴한 사용자", UserProfileInfo.getNullProfile());
         }).toList();
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/domain/service/ReviewDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/domain/service/ReviewDomainService.java
@@ -33,7 +33,7 @@ public class ReviewDomainService {
         return reviews.stream().map(review -> {
             UUID userId = UUID.fromString(review.getUserId());
             UserProfileInfo userProfileInfo = userProfiles.get(userId);
-            return DestinationReviewDto.from(review, userProfileInfo);
+            return DestinationReviewDto.from(review, review.getUsername(), userProfileInfo);
         }).toList();
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationDetailsRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationDetailsRes.java
@@ -12,6 +12,7 @@ import java.util.TreeMap;
 public record DestinationDetailsRes(
         String id,
         String name,
+        String description,
         String address,
         Location location,
         String city,
@@ -36,6 +37,7 @@ public record DestinationDetailsRes(
         return new DestinationDetailsRes(
                 destination.getId(),
                 destination.getName(),
+                destination.getDescription(),
                 destination.getAddress(),
                 destination.getLocation(),
                 destination.getCity(),

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Destination.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/Destination.java
@@ -39,7 +39,7 @@ public class Destination {
 	private int reviewCount;
 	private float averageRating;
 
-	private final int[] ratingCount = new int[5];
+	private int[] ratingCount = new int[5];
 
 	private String description;
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/UserProfileInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/UserProfileInfo.java
@@ -10,4 +10,8 @@ public record UserProfileInfo(
                 user.getProfileImage()
         );
     }
+    
+    public static UserProfileInfo getNullProfile() {
+        return new UserProfileInfo("" /*, "탈퇴한 사용자"*/);
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/service/UserDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/service/UserDomainService.java
@@ -30,11 +30,19 @@ public class UserDomainService {
                 .map(UserSummaryDto::from)
                 .toList();
     }
+    
     public Map<UUID,UserProfileInfo> getUserProfile(Set<UUID> userIds) {
         List<User> users = userRepository.findByIdIn(userIds);
         if(users.size() != userIds.size()){
             throw new CustomException(ErrorType.USER_NOT_FOUND);
         }
+
+        return users.stream()
+                .collect(Collectors.toMap(User::getId, UserProfileInfo::of));
+    }
+    
+    public Map<UUID,UserProfileInfo> getUserProfileOnlyExist(Set<UUID> userIds) {
+        List<User> users = userRepository.findByIdIn(userIds);
 
         return users.stream()
                 .collect(Collectors.toMap(User::getId, UserProfileInfo::of));


### PR DESCRIPTION
## 작업 동기 및 이슈
- #147 
- #148 
- #150 

## 원인
- 여행지 조회시 `사용자가 없습니다` 조회 실패 :
  - 리뷰 조회 중, 작성자 UUID가 없는 사용자를 가리킬 때 발생.
  - 로그인/회원가입 등 작업 과정에서 User 데이터를 변경하며 자주 발생.
  - 작성자를 찾지 못하면 별도의 처리 없이 에러를 반환하고 있어, 조회는 즉시 실패함.
- 여행지 상세 조회시, 각 평점별 갯수가 항상 0으로 표시됨 :
  - Destination 엔티티 내 필드가 수정 불가(`final`)로 구성되어있어
    DB에서 읽어들인 데이터를 매핑하지 못하는 것으로 파악.

## 추가 및 변경사항
- 리뷰 조회 중 작성자가 없는 사용자일 경우,
  - 기존에는 바로 에러를 반환하였으나,
  - **탈퇴된 사용자 처리하여 조회합니다.**
    - 에러를 반환하지 않고 그대로 조회하는 `UserDomainService.getUserProfileOnlyExist()` 확장 메서드 도입
- Destination.ratingCount 필드에서 `final` 키워드를 제거하였습니다.
- DestinationDetailsRes에 `decription` 필드가 추가되었습니다.

## 테스트 결과
- **서버에 먼저 반영되었습니다!**
- 이상 무.
  설명이 함께 표시됨
  평점별 갯수 올바르게 조회됨
  찾을 수 없는 리뷰 작성자는 탈퇴한 사용자로 처리되어 조회됨
  <img src="https://github.com/user-attachments/assets/35154419-e10f-4638-843c-871465e22a53" width="450"/>
  <img src="https://github.com/user-attachments/assets/8c645668-fc9c-4532-97c0-b407af4a6860" width="500"/>

## 📌 기타
- **서버에 먼저 반영되었습니다!**