### PR TITLE
Refactor [중간PR-1] : 로그인과 회원가입 기능 분리

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -32,17 +32,17 @@ public class SsoAuthService {
     private final AccessTokenProvider accessTokenProvider;
     private final RefreshTokenProvider refreshTokenProvider;
     private final RedisUtil redisUtil;
-
-    public TokenDto login(LoginRequest loginRequest){
-        SsoService ssoService = Optional.ofNullable(ssoServiceMap.get(loginRequest.type()))
+    
+    private SsoUserInfo getSsoUserInfo(SsoType type, String accessToken) {
+        SsoService ssoService = Optional.ofNullable(ssoServiceMap.get(type))
                 .orElseThrow(() -> new CustomException(ErrorType.UNSUPPORTED_SSO_LOGIN));
 
-        SsoUserInfo ssoUserInfo = ssoService.getUserInfo(loginRequest.accessToken());
+        SsoUserInfo ssoUserInfo = ssoService.getUserInfo(accessToken);
         System.out.println("ssoUserInfo = " + ssoUserInfo);
-
-        User user = userRepository.findByProviderUserInfo(ssoUserInfo.getProviderUserInfo())
-                .orElseGet(() -> userRepository.save(User.create(ssoUserInfo)));
-
+        return ssoUserInfo;
+    }
+    
+    private TokenDto loginUser(User user) {
         String accessToken = accessTokenProvider.generateToken(user.getId().toString(), user.getRole().getValue(),user.getSnsId());
         String refreshToken = refreshTokenProvider.generateToken(user.getId().toString(), user.getRole().getValue());
 
@@ -64,6 +64,27 @@ public class SsoAuthService {
                 .firebaseCustomToken(customToken)
                 .build();
     }
+    
+    private User registerNewUser(SsoUserInfo ssoUserInfo) {
+        return userRepository.save(
+                User.create(ssoUserInfo));
+    }
+    
+    public TokenDto login(LoginRequest loginRequest) {
+        SsoUserInfo ssoUserInfo = getSsoUserInfo(loginRequest.type(), loginRequest.accessToken());
+        User user = userRepository.findByProviderUserInfo(ssoUserInfo.getProviderUserInfo())
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_REGISTERED));
+        return loginUser(user);
+    }
+    
+    public TokenDto register(LoginRequest loginRequest) {
+        SsoUserInfo ssoUserInfo = getSsoUserInfo(loginRequest.type(), loginRequest.accessToken());
+        if (userRepository.findByProviderUserInfo(ssoUserInfo.getProviderUserInfo())
+                .isPresent())
+            throw new CustomException(ErrorType.ALREADY_REGISTERED);
+        return loginUser(registerNewUser(ssoUserInfo));
+    }
+    
     public void logout(String accessToken,String refreshToken) {
         Claims accessClaims = accessTokenProvider.parseToken(accessToken);
         String accessJti = accessClaims.get("jti").toString();

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -39,9 +39,8 @@ public class SsoAuthService {
 
         SsoUserInfo ssoUserInfo = ssoService.getUserInfo(loginRequest.accessToken());
         System.out.println("ssoUserInfo = " + ssoUserInfo);
-        String providerUserInfo = ssoUserInfo.provider() + " " + ssoUserInfo.providerId();
 
-        User user = userRepository.findByProviderUserInfo(providerUserInfo)
+        User user = userRepository.findByProviderUserInfo(ssoUserInfo.getProviderUserInfo())
                 .orElseGet(() -> userRepository.save(User.create(ssoUserInfo)));
 
         String accessToken = accessTokenProvider.generateToken(user.getId().toString(), user.getRole().getValue(),user.getSnsId());

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
@@ -68,7 +68,39 @@ public class AuthController {
                 .body(SuccessRes.from(SuccessType.LOGIN_SSO_SUCCESS));
 	}
 
-	@PostMapping("login/user")
+    @PostMapping("/register/user")
+    @Operation(
+            summary = "SSO 회원가입 요청 (성공시 즉시 로그인합니다)",
+            description = "카카오 또는 구글 액세스 토큰을 이용하여 사용자 회원가입을 처리합니다."
+                        + "<br/>카카오는 액세스 토큰, 구글은 ID 토큰을 사용합니다."
+                        + "<br/>"
+                        + "<br/><b>로그인 성공시 즉시 로그인합니다.</b>",
+            tags = {"SSO Authentication"},
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "SSO 회원가입 요청 데이터",
+                    required = true
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "회원가입 성공 (액세스 토큰 및 리프레시 토큰 발급)"),
+                    @ApiResponse(responseCode = "401", description = "SSO 인증 토큰이 유효하지 않습니다."),
+                    @ApiResponse(responseCode = "409", description = "이미 회원가입된 사용자입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류"),
+                    @ApiResponse(responseCode = "501", description = "현재 해당 소셜 로그인 방식은 아직 지원되지 않습니다.")
+            }
+    )
+    public ResponseEntity<?> register(@RequestBody LoginRequest request){
+
+        TokenDto tokenDto = ssoAuthService.register(request);
+
+        return ResponseEntity.ok()
+                .header("Authorization",tokenDto.accessToken())
+                .header("Set-Cookie",tokenDto.refreshToken())
+                .body(SuccessRes.of(SuccessType.LOGIN_SSO_SUCCESS, Map.of(
+                        "firebaseCustomToken", tokenDto.firebaseCustomToken()
+                )));
+    }
+
+	@PostMapping("/login/user")
 	@Operation(
 			summary = "SSO 로그인 요청",
 			description = "카카오 또는 구글 액세스 토큰을 이용하여 사용자 로그인을 처리합니다."
@@ -80,6 +112,8 @@ public class AuthController {
 			),
 			responses = {
 					@ApiResponse(responseCode = "200", description = "로그인 성공 (액세스 토큰 및 리프레시 토큰 발급)"),
+					@ApiResponse(responseCode = "401", description = "SSO 인증 토큰이 유효하지 않습니다."),
+					@ApiResponse(responseCode = "404", description = "아직 회원가입하지 않은 사용자입니다."),
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류"),
 					@ApiResponse(responseCode = "501", description = "현재 해당 소셜 로그인 방식은 아직 지원되지 않습니다.")
 			}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/SsoUserInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/SsoUserInfo.java
@@ -6,4 +6,7 @@ public record SsoUserInfo(
         String nickname,
         String provider
 ) {
+    public String getProviderUserInfo() {
+        return provider + " " + providerId;
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/User.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/User.java
@@ -34,19 +34,21 @@ public class User {
 
     private User(
             String name,
-            String provider,
-            String providerId,
+            String providerUserInfo,
             String email
 
     ) {
         this.name = name;
-        this.providerUserInfo = provider + " " + providerId;
+        this.providerUserInfo = providerUserInfo;
         this.email = email;
 //        this.telephoneNumber = telephoneNumber;
         this.role = Role.USER;
     }
     public static User create(SsoUserInfo ssoUserInfo){
-        return new User(ssoUserInfo.nickname(), ssoUserInfo.provider(),ssoUserInfo.providerId(), ssoUserInfo.email());
+        return new User(
+                ssoUserInfo.nickname(),
+                ssoUserInfo.getProviderUserInfo(),
+                ssoUserInfo.email());
     }
 
     public void updateEmail(String email) {this.email = email;}

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -64,6 +64,7 @@ public enum ErrorType {
     ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "역할이 존재하지 않습니다."),
     INVALID_TBTI_CATEGORY(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리 입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 사용자 입니다."),
+    NOT_REGISTERED(HttpStatus.NOT_FOUND, "회원 등록되지 않은 사용자입니다."),
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 관리자 입니다."),
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 채팅방 입니다."),
     MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않은 메시지 입니다."),
@@ -78,6 +79,7 @@ public enum ErrorType {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 코스 리뷰(게시글)입니다."),
     REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
     //데이터 충돌
+    ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 회원가입된 사용자입니다."),
     ALREADY_EXISTS_SNSId(HttpStatus.CONFLICT, "이미 존재하는 Id 입니다."),
     ALREADY_EXISTS_TAG(HttpStatus.CONFLICT, "이미 존재하는 태그입니다."),
     ALREADY_EXISTS_DESTINATION(HttpStatus.CONFLICT, "이미 존재하는 여행지입니다."),


### PR DESCRIPTION
## 작업 동기 및 이슈
- #142 

- 회원가입시 사용자 정보를 추가로 받아야 할 상황이 생기면서
  로그인 성공과 실패, 회원가입 성공과 실패를 명확히 구분할 필요가 있어
  로그인과 회원가입 로직 및 API를 분리했습니다.

## 추가 및 변경사항

### 1) 로그인과 회원가입 기능 분리
- **로그인**
  로그인 기능은 이제 새 유저 등록을 담당하지 않습니다.
  - 성공 사례 :
    - 유효한 소셜로그인 정보이며, 이미 회원가입된 사용자로 로그인 시도.
      **-> 액세스 토큰 및 Firebase 토큰 등 로그인 성공 처리**
  - 실패 사례 :
    - **401** : 소셜로그인 정보가 유효하지 않음
    - **404** : 아직 회원가입하지 않은 유저임
- **회원가입**
  회원가입 기능이 별도로 추가되었습니다. (회원가입 성공시엔 로그인 결과를 반환합니다.)
  - 성공 사례 :
    - 유효한 소셜로그인 정보이며, 이미 회원가입되지 않은 사용자,
      회원가입 정보도 적절함.
      **-> 액세스 토큰 및 Firebase 토큰 등 로그인 성공 처리**
  - 실패 사례 :
    - _400 : 회원가입 정보가 부적절함_ **-> 추후 추가 예정**
    - **401** : 소셜로그인 정보가 유효하지 않음
    - **409** : 이미 회원가입 된 사용자임

### 2) SsoAuthService 로직 리팩토링
- 기존 `login()` 메소드 내에서 회원가입 처리까지 진행하였으나,
  이제 역할별로 다음과 같이 메소드가 분리되었습니다.
  - private `getSsoUserInfo()` : 소셜로그인 정보를 검증해 기본 유저 정보(provider id 등)를 얻습니다.
  - private `loginUser()` : 기존에 가입해 존재하는 User 엔티티로부터 로그인 승인 처리(토큰 발급 등)를 진행합니다.
  - private `registerNewUser()` : 소셜로그인 기본 정보 (_+ 추후 추가될 사용자 부가 정보_)를 바탕으로 새 사용자를 등록합니다.
  - **public** `login()` : 로그인 흐름만 담당합니다.
  - **public** `register()` : 회원가입 흐름만 담당합니다.

### 3) ProviderUserInfo 생성 로직 리팩토링
- 기존 ProviderUserInfo 생성 로직이 User 엔티티 및 SsoAuthService에 산재되어 있었으나,
  이제 SsoUserInfo에서 생성하도록 이동하였습니다.
  -> 소셜로그인 정보는 모두 SsoUserInfo에서 관리되도록 하여 응집도 증가

## 테스트 결과
- 이상 무.
  - API 분리 :
    <img src="https://github.com/user-attachments/assets/ed37e096-1199-4bb2-b5e8-89354e6a2b29" width="500"/>
  - 로그인/회원가입 실패 사례 열람 :
    <img src="https://github.com/user-attachments/assets/ec87f97b-b3bd-4c0b-bbdb-11091321b13b" width="500"/>
    <img src="https://github.com/user-attachments/assets/2477336a-0551-411c-b438-2aec89699970" width="500"/>
    <img src="https://github.com/user-attachments/assets/1a251353-7900-4581-b694-e916d7780a18" width="500"/>

## 📌 기타
- **중간 PR입니다. 순서대로 Merge하거나, 혹은 마지막 PR만 Merge하면 됩니다!**
  #156 