### PR TITLE
Feature [마지막PR] : 회원가입시 사용자 추가 정보를 받는 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/Tbti.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/Tbti.java
@@ -1,0 +1,57 @@
+package com.se.Tlog.domain.Tbti.domain;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+/**
+ * TBTI Value Object
+ */
+public class Tbti {
+    public static final int MIN_TBTI_CODE = 00000000;
+    public static final int MAX_TBTI_CODE = 99999999;
+    public static final int FEATURE_THRESHOLD = 50;
+
+    public static int toTbtiCode(String tbtiCode) {
+        try {
+            if (tbtiCode.length() != 8)
+                throw new CustomException(ErrorType.INVALID_TBTI_CODE);
+            return Integer.parseInt(tbtiCode);
+        } catch (Exception e) {
+            throw new CustomException(ErrorType.INVALID_TBTI_CODE);
+        }
+    }
+    
+    private int rawTbtiCode;
+    
+    public Tbti(int tbtiCode) { 
+        if (tbtiCode < MIN_TBTI_CODE || tbtiCode > MAX_TBTI_CODE)
+            throw new CustomException(ErrorType.INVALID_TBTI_CODE);
+        this.rawTbtiCode = tbtiCode;
+    }
+    
+    public Tbti(String tbtiCode) {
+        this(toTbtiCode(tbtiCode));
+    }
+    
+    public int getTbtiCode() {
+        return rawTbtiCode;
+    }
+    
+    public int getPercentage(TraitCategory category) {
+        return switch (category) {
+            case RISK_TAKING -> (rawTbtiCode / 1000000);
+            case LOCATION_PREFERENCE -> (rawTbtiCode / 10000) % 100;
+            case PLANNING_STYLE -> (rawTbtiCode / 100) % 100;
+            case ACTIVITY_LEVEL -> rawTbtiCode % 100;
+        };
+    }
+    
+    public String toString() {
+        StringBuilder tbtiStr = new StringBuilder();
+        for (TraitCategory c : TraitCategory.values())            
+            tbtiStr.append((getPercentage(c) < FEATURE_THRESHOLD
+                    ? c.getMinCategoryInitial()
+                    : c.getMaxCategoryInitial()));
+        return tbtiStr.toString();
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TraitCategory.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TraitCategory.java
@@ -16,6 +16,12 @@ public enum TraitCategory {
     public String getCategoryInitial() {
         return categoryInitial;
     }
+    public char getMinCategoryInitial() {
+        return categoryInitial.charAt(0);
+    }
+    public char getMaxCategoryInitial() {
+        return categoryInitial.charAt(2);
+    }
     
     public static TraitCategory fromString(String traitCategory) {
         try {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -32,17 +32,17 @@ public class SsoAuthService {
     private final AccessTokenProvider accessTokenProvider;
     private final RefreshTokenProvider refreshTokenProvider;
     private final RedisUtil redisUtil;
-
-    public TokenDto login(LoginRequest loginRequest){
-        SsoService ssoService = Optional.ofNullable(ssoServiceMap.get(loginRequest.type()))
+    
+    private SsoUserInfo getSsoUserInfo(SsoType type, String accessToken) {
+        SsoService ssoService = Optional.ofNullable(ssoServiceMap.get(type))
                 .orElseThrow(() -> new CustomException(ErrorType.UNSUPPORTED_SSO_LOGIN));
 
-        SsoUserInfo ssoUserInfo = ssoService.getUserInfo(loginRequest.accessToken());
+        SsoUserInfo ssoUserInfo = ssoService.getUserInfo(accessToken);
         System.out.println("ssoUserInfo = " + ssoUserInfo);
-
-        User user = userRepository.findByProviderUserInfo(ssoUserInfo.getProviderUserInfo())
-                .orElseGet(() -> userRepository.save(User.create(ssoUserInfo)));
-
+        return ssoUserInfo;
+    }
+    
+    private TokenDto loginUser(User user) {
         String accessToken = accessTokenProvider.generateToken(user.getId().toString(), user.getRole().getValue(),user.getSnsId());
         String refreshToken = refreshTokenProvider.generateToken(user.getId().toString(), user.getRole().getValue());
 
@@ -64,6 +64,27 @@ public class SsoAuthService {
                 .firebaseCustomToken(customToken)
                 .build();
     }
+    
+    private User registerNewUser(SsoUserInfo ssoUserInfo) {
+        return userRepository.save(
+                User.create(ssoUserInfo));
+    }
+    
+    public TokenDto login(LoginRequest loginRequest) {
+        SsoUserInfo ssoUserInfo = getSsoUserInfo(loginRequest.type(), loginRequest.accessToken());
+        User user = userRepository.findByProviderUserInfo(ssoUserInfo.getProviderUserInfo())
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_REGISTERED));
+        return loginUser(user);
+    }
+    
+    public TokenDto register(LoginRequest loginRequest) {
+        SsoUserInfo ssoUserInfo = getSsoUserInfo(loginRequest.type(), loginRequest.accessToken());
+        if (userRepository.findByProviderUserInfo(ssoUserInfo.getProviderUserInfo())
+                .isPresent())
+            throw new CustomException(ErrorType.ALREADY_REGISTERED);
+        return loginUser(registerNewUser(ssoUserInfo));
+    }
+    
     public void logout(String accessToken,String refreshToken) {
         Claims accessClaims = accessTokenProvider.parseToken(accessToken);
         String accessJti = accessClaims.get("jti").toString();

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -39,9 +39,8 @@ public class SsoAuthService {
 
         SsoUserInfo ssoUserInfo = ssoService.getUserInfo(loginRequest.accessToken());
         System.out.println("ssoUserInfo = " + ssoUserInfo);
-        String providerUserInfo = ssoUserInfo.provider() + " " + ssoUserInfo.providerId();
 
-        User user = userRepository.findByProviderUserInfo(providerUserInfo)
+        User user = userRepository.findByProviderUserInfo(ssoUserInfo.getProviderUserInfo())
                 .orElseGet(() -> userRepository.save(User.create(ssoUserInfo)));
 
         String accessToken = accessTokenProvider.generateToken(user.getId().toString(), user.getRole().getValue(),user.getSnsId());

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -6,10 +6,13 @@ import com.se.Tlog.domain.User.repository.api.SsoService;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.User.controller.dto.LoginRequest;
+import com.se.Tlog.domain.User.controller.dto.RegisterRequest;
+import com.se.Tlog.domain.User.controller.dto.RegisterUserProfileDto;
 import com.se.Tlog.domain.User.controller.dto.SsoUserInfo;
 import com.se.Tlog.domain.User.controller.dto.TokenDto;
 import com.se.Tlog.domain.User.domain.SsoType;
 import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.domain.User.domain.UserRegisterInfo;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import com.se.Tlog.global.util.jwt.AccessTokenProvider;
@@ -65,9 +68,9 @@ public class SsoAuthService {
                 .build();
     }
     
-    private User registerNewUser(SsoUserInfo ssoUserInfo) {
+    private User registerNewUser(SsoUserInfo ssoUserInfo, RegisterUserProfileDto userProfiles) {
         return userRepository.save(
-                User.create(ssoUserInfo));
+                User.create(new UserRegisterInfo(ssoUserInfo, userProfiles)));
     }
     
     public TokenDto login(LoginRequest loginRequest) {
@@ -77,12 +80,12 @@ public class SsoAuthService {
         return loginUser(user);
     }
     
-    public TokenDto register(LoginRequest loginRequest) {
-        SsoUserInfo ssoUserInfo = getSsoUserInfo(loginRequest.type(), loginRequest.accessToken());
+    public TokenDto register(RegisterRequest registerRequest) {
+        SsoUserInfo ssoUserInfo = getSsoUserInfo(registerRequest.type(), registerRequest.accessToken());
         if (userRepository.findByProviderUserInfo(ssoUserInfo.getProviderUserInfo())
                 .isPresent())
             throw new CustomException(ErrorType.ALREADY_REGISTERED);
-        return loginUser(registerNewUser(ssoUserInfo));
+        return loginUser(registerNewUser(ssoUserInfo, registerRequest.userProfile()));
     }
     
     public void logout(String accessToken,String refreshToken) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import com.se.Tlog.domain.User.application.AuthenticationService;
 import com.se.Tlog.domain.User.application.SsoAuthService;
 import com.se.Tlog.domain.User.controller.dto.LoginRequest;
+import com.se.Tlog.domain.User.controller.dto.RegisterRequest;
 import com.se.Tlog.domain.User.controller.dto.SsoLoginRequest;
 import com.se.Tlog.domain.User.controller.dto.TokenDto;
 import com.se.Tlog.domain.User.domain.SsoType;
@@ -82,13 +83,14 @@ public class AuthController {
             ),
             responses = {
                     @ApiResponse(responseCode = "200", description = "회원가입 성공 (액세스 토큰 및 리프레시 토큰 발급)"),
+                    @ApiResponse(responseCode = "400", description = "회원가입에 요구되는 정보가 잘못되었거나 부족합니다."),
                     @ApiResponse(responseCode = "401", description = "SSO 인증 토큰이 유효하지 않습니다."),
                     @ApiResponse(responseCode = "409", description = "이미 회원가입된 사용자입니다."),
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류"),
                     @ApiResponse(responseCode = "501", description = "현재 해당 소셜 로그인 방식은 아직 지원되지 않습니다.")
             }
     )
-    public ResponseEntity<?> register(@RequestBody LoginRequest request){
+    public ResponseEntity<?> register(@RequestBody RegisterRequest request){
 
         TokenDto tokenDto = ssoAuthService.register(request);
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
@@ -68,7 +68,39 @@ public class AuthController {
                 .body(SuccessRes.from(SuccessType.LOGIN_SSO_SUCCESS));
 	}
 
-	@PostMapping("login/user")
+    @PostMapping("/register/user")
+    @Operation(
+            summary = "SSO 회원가입 요청 (성공시 즉시 로그인합니다)",
+            description = "카카오 또는 구글 액세스 토큰을 이용하여 사용자 회원가입을 처리합니다."
+                        + "<br/>카카오는 액세스 토큰, 구글은 ID 토큰을 사용합니다."
+                        + "<br/>"
+                        + "<br/><b>로그인 성공시 즉시 로그인합니다.</b>",
+            tags = {"SSO Authentication"},
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "SSO 회원가입 요청 데이터",
+                    required = true
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "회원가입 성공 (액세스 토큰 및 리프레시 토큰 발급)"),
+                    @ApiResponse(responseCode = "401", description = "SSO 인증 토큰이 유효하지 않습니다."),
+                    @ApiResponse(responseCode = "409", description = "이미 회원가입된 사용자입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류"),
+                    @ApiResponse(responseCode = "501", description = "현재 해당 소셜 로그인 방식은 아직 지원되지 않습니다.")
+            }
+    )
+    public ResponseEntity<?> register(@RequestBody LoginRequest request){
+
+        TokenDto tokenDto = ssoAuthService.register(request);
+
+        return ResponseEntity.ok()
+                .header("Authorization",tokenDto.accessToken())
+                .header("Set-Cookie",tokenDto.refreshToken())
+                .body(SuccessRes.of(SuccessType.LOGIN_SSO_SUCCESS, Map.of(
+                        "firebaseCustomToken", tokenDto.firebaseCustomToken()
+                )));
+    }
+
+	@PostMapping("/login/user")
 	@Operation(
 			summary = "SSO 로그인 요청",
 			description = "카카오 또는 구글 액세스 토큰을 이용하여 사용자 로그인을 처리합니다."
@@ -80,6 +112,8 @@ public class AuthController {
 			),
 			responses = {
 					@ApiResponse(responseCode = "200", description = "로그인 성공 (액세스 토큰 및 리프레시 토큰 발급)"),
+					@ApiResponse(responseCode = "401", description = "SSO 인증 토큰이 유효하지 않습니다."),
+					@ApiResponse(responseCode = "404", description = "아직 회원가입하지 않은 사용자입니다."),
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류"),
 					@ApiResponse(responseCode = "501", description = "현재 해당 소셜 로그인 방식은 아직 지원되지 않습니다.")
 			}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/RegisterRequest.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/RegisterRequest.java
@@ -1,0 +1,17 @@
+package com.se.Tlog.domain.User.controller.dto;
+
+import com.se.Tlog.domain.User.domain.SsoType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "SSO 인증을 통한 회원가입 요청 DTO")
+public record RegisterRequest(
+        @Schema(description = "회원가입에 사용할 소셜 인증 타입 (KAKAO, GOOGLE)", example = "KAKAO")
+        SsoType type,
+
+        @Schema(description = "소셜 액세스 토큰")
+        String accessToken,
+        
+        @Schema(description = "회원가입시 입력해야하는 사용자 기본 정보입니다.")
+        RegisterUserProfileDto userProfile
+) {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/RegisterUserProfileDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/RegisterUserProfileDto.java
@@ -1,0 +1,9 @@
+package com.se.Tlog.domain.User.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그인시 입력해야하는 사용자 기본 정보입니다.")
+public record RegisterUserProfileDto(
+        @Schema(description = "TBTI 검사 결과. 00000000 ~ 99999999 사이의 값이어야 합니다.")
+        String tbtiValue) {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/SsoUserInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/SsoUserInfo.java
@@ -6,4 +6,7 @@ public record SsoUserInfo(
         String nickname,
         String provider
 ) {
+    public String getProviderUserInfo() {
+        return provider + " " + providerId;
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/User.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/User.java
@@ -8,9 +8,6 @@ import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
-import com.se.Tlog.domain.Tbti.domain.Tbti;
-import com.se.Tlog.domain.User.controller.dto.SsoUserInfo;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -49,12 +46,12 @@ public class User {
         this.role = Role.USER;
         this.tbti = tbti;
     }
-    public static User create(SsoUserInfo ssoUserInfo, Tbti tbti){
+    public static User create(UserRegisterInfo userRegisterInfo){
         return new User(
-                ssoUserInfo.nickname(),
-                ssoUserInfo.getProviderUserInfo(),
-                ssoUserInfo.email(),
-                tbti.getTbtiCode());
+                userRegisterInfo.getNickname(),
+                userRegisterInfo.getProviderUserInfo(), 
+                userRegisterInfo.getEmail(), 
+                userRegisterInfo.getTbti().getTbtiCode());
     }
 
     public void updateEmail(String email) {this.email = email;}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/User.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/User.java
@@ -34,19 +34,21 @@ public class User {
 
     private User(
             String name,
-            String provider,
-            String providerId,
+            String providerUserInfo,
             String email
 
     ) {
         this.name = name;
-        this.providerUserInfo = provider + " " + providerId;
+        this.providerUserInfo = providerUserInfo;
         this.email = email;
 //        this.telephoneNumber = telephoneNumber;
         this.role = Role.USER;
     }
     public static User create(SsoUserInfo ssoUserInfo){
-        return new User(ssoUserInfo.nickname(), ssoUserInfo.provider(),ssoUserInfo.providerId(), ssoUserInfo.email());
+        return new User(
+                ssoUserInfo.nickname(),
+                ssoUserInfo.getProviderUserInfo(),
+                ssoUserInfo.email());
     }
 
     public void updateEmail(String email) {this.email = email;}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/User.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/User.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
+import com.se.Tlog.domain.Tbti.domain.Tbti;
 import com.se.Tlog.domain.User.controller.dto.SsoUserInfo;
 
 @Entity
@@ -25,6 +26,8 @@ public class User {
     private String email;
 
     private String snsId;
+    
+    private int tbti;
     //private String telephoneNumber; 사용자가 동의하지 않은 경우 못받을 수 있음 nullable 하게 관리
 
     private String profileImage;
@@ -35,7 +38,8 @@ public class User {
     private User(
             String name,
             String providerUserInfo,
-            String email
+            String email,
+            int tbti
 
     ) {
         this.name = name;
@@ -43,12 +47,14 @@ public class User {
         this.email = email;
 //        this.telephoneNumber = telephoneNumber;
         this.role = Role.USER;
+        this.tbti = tbti;
     }
-    public static User create(SsoUserInfo ssoUserInfo){
+    public static User create(SsoUserInfo ssoUserInfo, Tbti tbti){
         return new User(
                 ssoUserInfo.nickname(),
                 ssoUserInfo.getProviderUserInfo(),
-                ssoUserInfo.email());
+                ssoUserInfo.email(),
+                tbti.getTbtiCode());
     }
 
     public void updateEmail(String email) {this.email = email;}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/UserRegisterInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/UserRegisterInfo.java
@@ -1,0 +1,42 @@
+package com.se.Tlog.domain.User.domain;
+
+import com.se.Tlog.domain.Tbti.domain.Tbti;
+import com.se.Tlog.domain.User.controller.dto.RegisterUserProfileDto;
+import com.se.Tlog.domain.User.controller.dto.SsoUserInfo;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.Getter;
+
+@Getter
+public class UserRegisterInfo {
+    private String nickname;
+    private String email;
+    private String providerUserInfo;
+    private String profileImage;
+    private Tbti tbti;
+    
+    public UserRegisterInfo(SsoUserInfo ssoUserInfo, RegisterUserProfileDto userProfiles) {
+        if (userProfiles == null || ssoUserInfo == null
+                || ssoUserInfo.getProviderUserInfo() == null || ssoUserInfo.getProviderUserInfo().trim().isEmpty()
+                || ssoUserInfo.nickname() == null || ssoUserInfo.nickname().trim().isEmpty())
+            throw new CustomException(ErrorType.INSUFFICIENT_INFO_FOR_REGISTER);
+        
+        this.nickname = ssoUserInfo.nickname();
+        this.email = ssoUserInfo.email();
+        this.providerUserInfo = ssoUserInfo.getProviderUserInfo();
+        this.profileImage = "";
+        this.tbti = new Tbti(userProfiles.tbtiValue());
+    }
+    
+    public void setEmail(String email) {
+        // email 형식 검증
+        this.email = email;
+    }
+    
+    public void setProfileImage(String profileImage) {
+        if (profileImage == null || profileImage.trim().isEmpty())
+            throw new CustomException(ErrorType.INVALID_IMAGE_URL);
+        this.profileImage = profileImage;
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -64,6 +64,7 @@ public enum ErrorType {
     ROLE_NOT_FOUND(HttpStatus.NOT_FOUND, "역할이 존재하지 않습니다."),
     INVALID_TBTI_CATEGORY(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리 입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 사용자 입니다."),
+    NOT_REGISTERED(HttpStatus.NOT_FOUND, "회원 등록되지 않은 사용자입니다."),
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 관리자 입니다."),
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 채팅방 입니다."),
     MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않은 메시지 입니다."),
@@ -78,6 +79,7 @@ public enum ErrorType {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 코스 리뷰(게시글)입니다."),
     REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
     //데이터 충돌
+    ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 회원가입된 사용자입니다."),
     ALREADY_EXISTS_SNSId(HttpStatus.CONFLICT, "이미 존재하는 Id 입니다."),
     ALREADY_EXISTS_TAG(HttpStatus.CONFLICT, "이미 존재하는 태그입니다."),
     ALREADY_EXISTS_DESTINATION(HttpStatus.CONFLICT, "이미 존재하는 여행지입니다."),

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -19,6 +19,7 @@ public enum ErrorType {
     SCRAP_UNSUPPORTED_TO_TEAM(HttpStatus.BAD_REQUEST, "팀에는 스크랩 기능을 지원하지 않습니다!"),
     INVITE_USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "초대하려는 유저 중 존재하지 않는 유저가 있습니다."),
     LOGOUT_FAILED(HttpStatus.BAD_REQUEST,"로그아웃에 실패하였습니다." ),
+    INSUFFICIENT_INFO_FOR_REGISTER(HttpStatus.BAD_REQUEST, "회원가입을 위한 정보가 부족합니다."),
     INVALID_REVIEW_RATING(HttpStatus.BAD_REQUEST, "리뷰 평점은 1점 이상 5점 이하여야 합니다."),
     INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "잘못된 이미지 URL 입니다." ),
     // 사용자로부터 소셜 로그인 인증 실패

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -43,6 +43,7 @@ public enum ErrorType {
     INVALID_LINK_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "링크 알림 타입이 없거나 잘못된 값입니다."),
     
     // TBTI 관련
+    INVALID_TBTI_CODE(HttpStatus.BAD_REQUEST, "TBTI 코드는 0~99999999사이여야 합니다."),
     INVALID_ANSWER_PERCENTAGE(HttpStatus.BAD_REQUEST, "TBTI 응답의 값은 0~99사이여야 합니다."),
     QUESTION_HAS_NO_ANSWER(HttpStatus.BAD_REQUEST, "TBTI 질문에는 응답이 1개 이상 존재해야 합니다."),
     INVALID_QUESTION_WEIGHT(HttpStatus.BAD_REQUEST, "TBTI 질문의 가중치는 1~5사이여야 합니다."),

--- a/tlog-was/src/test/java/com/se/Tlog/domain/Reward/Service/RewardServiceTest.java
+++ b/tlog-was/src/test/java/com/se/Tlog/domain/Reward/Service/RewardServiceTest.java
@@ -16,8 +16,10 @@ import com.se.Tlog.domain.Reward.domain.RewardCriteria;
 import com.se.Tlog.domain.Reward.domain.RewardCriteriaType;
 import com.se.Tlog.domain.Reward.domain.RewardInfo;
 import com.se.Tlog.domain.Reward.repository.jpa.RewardInfoRepository;
+import com.se.Tlog.domain.User.controller.dto.RegisterUserProfileDto;
 import com.se.Tlog.domain.User.controller.dto.SsoUserInfo;
 import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.domain.User.domain.UserRegisterInfo;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 
 import jakarta.transaction.Transactional;
@@ -35,7 +37,10 @@ class RewardServiceTest {
 	@Test
 	@DisplayName("개발자 유형의 보상 지급 테스트")
 	void testAddRewardToUser() {
-		User testUser = User.create(new SsoUserInfo("TEST_PROVIDER_ID", "TEST_EMAIL", "dev.DEVELOPER_NAME", "NULL"));
+		User testUser = User.create(
+		        new UserRegisterInfo(
+		                new SsoUserInfo("TEST_PROVIDER_ID", "TEST_EMAIL", "dev.DEVELOPER_NAME", "NULL"),
+		                new RegisterUserProfileDto("00000000")));
 		RewardInfo testReward = RewardInfo.create("보상 1", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""));
 
 		userRepository.save(testUser);
@@ -48,7 +53,10 @@ class RewardServiceTest {
 	@Test
 	@DisplayName("유저가 보유한 모든 보상 조회 테스트")
 	void testGetReward() {
-		User testUser = User.create(new SsoUserInfo("TEST_PROVIDER_ID", "TEST_EMAIL", "dev.DEVELOPER_NAME", "NULL"));
+		User testUser = User.create(
+		        new UserRegisterInfo(
+		                new SsoUserInfo("TEST_PROVIDER_ID", "TEST_EMAIL", "dev.DEVELOPER_NAME", "NULL"), 
+		                new RegisterUserProfileDto("00000000")));
 		
 		List<RewardInfo> added = new ArrayList<RewardInfo>();
 		added.add(rewardInfoRepository.save(RewardInfo.create("보상 1", RewardCriteria.create(RewardCriteriaType.TEST_NULL_CRITERIA, ""))));

--- a/tlog-was/src/test/java/com/se/Tlog/domain/Tbti/domain/TbtiTest.java
+++ b/tlog-was/src/test/java/com/se/Tlog/domain/Tbti/domain/TbtiTest.java
@@ -1,0 +1,72 @@
+package com.se.Tlog.domain.Tbti.domain;
+
+import static org.assertj.core.api.Assertions.assertThatException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class TbtiTest {
+
+    @Test
+    @DisplayName("TBTI 값 객체 생성 테스트")
+    public void testGenerate() {
+        assertThatException().isThrownBy(() -> new Tbti(-1));
+        assertThatNoException().isThrownBy(() -> new Tbti(0));
+        assertThatNoException().isThrownBy(() -> new Tbti(50000));
+        assertThatNoException().isThrownBy(() -> new Tbti(99999999));
+        assertThatException().isThrownBy(() -> new Tbti(100000000));
+
+        assertThatException().isThrownBy(() -> new Tbti(null));
+        assertThatException().isThrownBy(() -> new Tbti(""));
+        assertThatException().isThrownBy(() -> new Tbti("hello"));
+        assertThatException().isThrownBy(() -> new Tbti("1.15"));
+        assertThatException().isThrownBy(() -> new Tbti("-1"));
+        assertThatException().isThrownBy(() -> new Tbti("15123"));
+        assertThatException().isThrownBy(() -> new Tbti("001200"));
+        assertThatException().isThrownBy(() -> new Tbti("15123--1"));
+        assertThatException().isThrownBy(() -> new Tbti("1.121231"));
+        assertThatException().isThrownBy(() -> new Tbti("0ii01200"));
+        assertThatException().isThrownBy(() -> new Tbti("-1121231"));
+        
+        assertThatNoException().isThrownBy(() -> new Tbti("00000000"));
+        assertThatNoException().isThrownBy(() -> new Tbti("99999999"));
+        assertThatNoException().isThrownBy(() -> new Tbti("12345678"));
+        assertThatNoException().isThrownBy(() -> new Tbti("10000010"));
+    }
+
+    @Test
+    @DisplayName("TBTI 값 변환 테스트")
+    public void testConvert() {
+        Tbti value = new Tbti(12119931);
+        assertEquals(12, value.getPercentage(TraitCategory.RISK_TAKING));
+        assertEquals(11, value.getPercentage(TraitCategory.LOCATION_PREFERENCE));
+        assertEquals(99, value.getPercentage(TraitCategory.PLANNING_STYLE));
+        assertEquals(31, value.getPercentage(TraitCategory.ACTIVITY_LEVEL));
+        assertEquals("SENA", value.toString());
+        
+        value = new Tbti("00120134");
+        assertEquals(00, value.getPercentage(TraitCategory.RISK_TAKING));
+        assertEquals(12, value.getPercentage(TraitCategory.LOCATION_PREFERENCE));
+        assertEquals(01, value.getPercentage(TraitCategory.PLANNING_STYLE));
+        assertEquals(34, value.getPercentage(TraitCategory.ACTIVITY_LEVEL));
+        assertEquals("SELA", value.toString());
+
+        value = new Tbti("00000001");
+        assertEquals(00, value.getPercentage(TraitCategory.RISK_TAKING));
+        assertEquals(00, value.getPercentage(TraitCategory.LOCATION_PREFERENCE));
+        assertEquals(00, value.getPercentage(TraitCategory.PLANNING_STYLE));
+        assertEquals(01, value.getPercentage(TraitCategory.ACTIVITY_LEVEL));
+        assertEquals("SELA", value.toString());
+
+        value = new Tbti(99999999);
+        assertEquals(99, value.getPercentage(TraitCategory.RISK_TAKING));
+        assertEquals(99, value.getPercentage(TraitCategory.LOCATION_PREFERENCE));
+        assertEquals(99, value.getPercentage(TraitCategory.PLANNING_STYLE));
+        assertEquals(99, value.getPercentage(TraitCategory.ACTIVITY_LEVEL));
+        assertEquals("RONI", value.toString());
+    }
+}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #141 
- #155

## 추가 및 변경사항
- **이전 PR의 내용은 생략합니다 : (#154)**

### 1) User 엔티티에 TBTI 속성 추가 (54ca5117b3b59fd0dd9ede14d1efbb301b26a75e)
### 2) UserRegisterInfo 값 객체 도입 (9efd2a987e626dff6a968bf16fc3a358304fd6f7)
- User 생성시 필요한 정보를 개별로 전달하지 않으며,
  `UserRegisterInfo` 값 객체를 통해 User를 생성합니다.
- 모든 User 생성 정보의 유효성은 이 값 객체를 통해 검증됩니다.
### 3) 회원가입 API에 사용자 정보 입력 추가
- 회원가입의 경우, `LoginRequest`가 아닌 `RegisterRequest`를 사용합니다. (611b2cd363fc1c7d70e3095bf5923bf3c07351f1)
  - 둘은 거의 유사하나, 사용자 회원가입 정보인 `RegisterUserProfileDto`를 추가로 받습니다.
- `SsoAuthService` 및 `AuthController`의 회원가입 로직도 `RegisterRequest`를 사용하도록 변경되었습니다.
  (9e4e895538564a1951cd393b1d71a3f9e23d0b4c) + (64ee45f103bbaca34648d2246bee9f9ab979b7c2)

## 테스트 결과
- 이상 무.
  회원가입 정보가 부족하거나 잘못될 경우 오류코드 400을 반환합니다.
  <img src="https://github.com/user-attachments/assets/80af0d90-4c6f-419b-a2a1-32d743276fd0" width="400"/>
  
  회원가입 API는 회원가입 정보를 추가로 받습니다.
  <img src="https://github.com/user-attachments/assets/80ee90e9-9671-4a13-bdb6-39e238263a10" width="200"/>
  <img src="https://github.com/user-attachments/assets/81dc4c98-0f75-4489-8419-66220e493760" width="200"/>


## 📌 기타
