### PR TITLE
Feature : 상세 조회시 비슷한 여행지 조회하는 기능 작성 

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -3,11 +3,9 @@ package com.se.Tlog.domain.Travel.application;
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Review.controller.dto.DestinationReviewDto;
 import com.se.Tlog.domain.Review.domain.service.ReviewDomainService;
-import com.se.Tlog.domain.Travel.controller.dto.AddFixedTagDto;
-import com.se.Tlog.domain.Travel.controller.dto.DestinationDetailsRes;
-import com.se.Tlog.domain.Travel.controller.dto.DestinationDto;
-import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+import com.se.Tlog.domain.Travel.controller.dto.*;
 import com.se.Tlog.domain.Travel.domain.*;
+import com.se.Tlog.domain.Travel.domain.repository.CustomTagRepositoryService;
 import com.se.Tlog.domain.Travel.domain.repository.DestinationRepositoryService;
 import com.se.Tlog.domain.Travel.domain.repository.TagRepositoryService;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
@@ -16,7 +14,6 @@ import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
-import org.springframework.data.mongodb.core.MongoTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +28,7 @@ public class DestinationService {
     private final UnapprovedDestinationRepository unapprovedDestinationRepository;
     private final CustomTagService customTagService;
     private final ReviewDomainService reviewDomainService;
-    private final MongoTemplate mongoTemplate;
+    private final CustomTagRepositoryService customTagRepositoryService;
 
     public void generateNewDestination(DestinationDto destinationDto) {
         Destination destinationData = Destination.create(
@@ -109,6 +106,7 @@ public class DestinationService {
         List<TagCount> topTags = customTagService.getTopTags(destination.getId(), 3);
         List<DestinationReviewDto> top2Reviews = reviewDomainService.getTop2Reviews(destination.getId());
 
-        return DestinationDetailsRes.from(destination, topTags, top2Reviews);
+        List<DestinationSimilarDto> relatedDestinations = customTagRepositoryService.findRelatedDestinations(destination.getId(), topTags);
+        return DestinationDetailsRes.from(destination, topTags, top2Reviews, relatedDestinations);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationDetailsRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationDetailsRes.java
@@ -25,9 +25,11 @@ public record DestinationDetailsRes(
         String imageUrl,
         List<TagCount> topTags,
         Map<Integer,Integer> ratingDistribution,
-        List<DestinationReviewDto> top2Reviews
+        List<DestinationReviewDto> top2Reviews,
+        List<DestinationSimilarDto> relatedDestinations
 ) {
-    public static DestinationDetailsRes from(Destination destination, List<TagCount> topTags, List<DestinationReviewDto> top2Reviews) {
+    public static DestinationDetailsRes from(Destination destination, List<TagCount> topTags, List<DestinationReviewDto> top2Reviews,
+                                             List<DestinationSimilarDto> relatedDestinations) {
         Map<Integer, Integer> distribution = new TreeMap<>();
         int[] ratingCount = destination.getRatingCount();
         for (int i = 0; i < 5; i++) {
@@ -50,7 +52,8 @@ public record DestinationDetailsRes(
                 destination.getImageUrl(),
                 topTags,
                 distribution,
-                top2Reviews
+                top2Reviews,
+                relatedDestinations
         );
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationSimilarDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationSimilarDto.java
@@ -1,0 +1,14 @@
+package com.se.Tlog.domain.Travel.controller.dto;
+
+import com.se.Tlog.domain.Travel.domain.TagCount;
+
+import java.util.List;
+
+public record DestinationSimilarDto(
+        String destinationId,
+        String name,
+        String imageUrl,
+        String description,
+        List<TagCount> customTags
+) {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/repository/CustomTagRepositoryService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/repository/CustomTagRepositoryService.java
@@ -1,7 +1,11 @@
 package com.se.Tlog.domain.Travel.domain.repository;
 
+import com.se.Tlog.domain.Travel.controller.dto.DestinationSimilarDto;
+import com.se.Tlog.domain.Travel.domain.TagCount;
+
 import java.util.List;
 
 public interface CustomTagRepositoryService {
     void addCustomTag(String destinationId, List<String> tagNameList);
+    List<DestinationSimilarDto> findRelatedDestinations(String destinationId, List<TagCount> topTags);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/CustomTagRepositoryServiceImplement.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/CustomTagRepositoryServiceImplement.java
@@ -1,17 +1,23 @@
 package com.se.Tlog.domain.Travel.repository;
 
 import com.mongodb.DuplicateKeyException;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationSimilarDto;
 import com.se.Tlog.domain.Travel.domain.CustomTagDocument;
+import com.se.Tlog.domain.Travel.domain.TagCount;
 import com.se.Tlog.domain.Travel.domain.repository.CustomTagRepositoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.*;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -40,5 +46,77 @@ public class CustomTagRepositoryServiceImplement implements CustomTagRepositoryS
                     CustomTagDocument.class
             );
         }
+    }
+    @Override
+    public List<DestinationSimilarDto> findRelatedDestinations(String destinationId, List<TagCount> topTags) {
+        // ne : 자기자신 제외 not equal
+        MatchOperation match = Aggregation.match(Criteria.where("destinationId").ne(destinationId));
+
+        // 태그 있으면 tag value 반환 , 없으면 0 -> List 형태로
+        List<Object> addOperands = topTags.stream()
+                .map(tagCount -> {
+                    String tag = "$customTags." + tagCount.getTagName();
+                    return new Document("$ifNull", List.of(tag, 0));
+                })
+                .collect(Collectors.toList());
+
+        // 위 List 결과 전체 합산 및 score 필드 생성  (db 반영 x)
+        AddFieldsOperation addScore = Aggregation.addFields()
+                .addField("score").withValue(new Document("$add", addOperands))
+                .build();
+        // customtags 의 destinationId 타입 변환
+        AggregationOperation convertDestinationId = context -> new Document(
+                "$addFields",
+                new Document("destinationIdObjectId", new Document("$toObjectId", "$destinationId"))
+        );
+
+        // lookup 설정 destinations 대상
+        LookupOperation lookup = LookupOperation.newLookup()
+                .from("destinations")
+                .localField("destinationIdObjectId")
+                .foreignField("_id")
+                .as("destination");
+
+        UnwindOperation unwind = Aggregation.unwind("destination");
+
+        SortOperation sort = Aggregation.sort(Sort.by(Sort.Direction.DESC, "score"));
+        LimitOperation limit = Aggregation.limit(5);
+
+        // id 타입 변환 및 tag 구조 변환
+        AggregationExpression customTagsExpression = context ->
+                new Document("$map", new Document()
+                        .append("input", new Document(
+                                "$slice",
+                                List.of(new Document("$objectToArray", "$customTags"),3)
+                        ))
+                        .append("as","tag")
+                        .append("in", new Document()
+                                .append("tagName", "$$tag.k")
+                                .append("count", "$$tag.v")
+                        ));
+
+        ProjectionOperation project = Aggregation.project()
+                .andInclude("destinationId")
+                .and("destination.name").as("name")
+                .and("destination.imageUrl").as("imageUrl")
+                .and("destination.description").as("description")
+                .and(customTagsExpression).as("customTags");
+
+        Aggregation aggregation = Aggregation.newAggregation(
+                match,
+                addScore,
+                convertDestinationId,
+                lookup,
+                unwind,
+                sort,
+                limit,
+                project
+        );
+
+        return mongoTemplate.aggregate(
+                aggregation,
+                "customtags",
+                DestinationSimilarDto.class
+        ).getMappedResults();
     }
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #151 

## 추가 및 변경사항
- 상세 조회시 커스텀 태그 기반으로 비슷한 여행지 조회하는 기능 작성 
- 상세조회 DTO에 비슷한 여행지 List 반영 (limit = 5)

## 테스트 결과
### 메인 여행지
<img width="1320" alt="스크린샷 2025-06-03 오후 9 16 52" src="https://github.com/user-attachments/assets/6faa9b94-eb60-45ee-99fb-24eb5b16da60" />

### 비슷한 여행지
- 비슷한 여행지들의 tagCount 를 보면 내림차순 정렬 된걸 볼 수 있고 관련 여행지인 것을 확인할 수 있습니다.

<img width="979" alt="스크린샷 2025-06-03 오후 9 17 03" src="https://github.com/user-attachments/assets/d1e905cd-59c6-4ae0-85e2-6de32c7849c8" />

<img width="848" alt="스크린샷 2025-06-03 오후 9 17 11" src="https://github.com/user-attachments/assets/8262d4aa-7282-4a8d-8076-f79f331ee890" />


## 📌 기타
- 응답 포맷에 customTag의 name만 있어도 될 것 같은데 구조 통일상 포함하였습니다.
- List에 최대 5개 반영되게 하였습니다!
