### PR TITLE
Fix: 리뷰 조회 응답형식 통일 / 평점 분포 데이터 포함 / Follow API 표시

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
@@ -3,6 +3,7 @@ package com.se.Tlog.domain.Review.application;
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Review.controller.dto.DestinationReviewDto;
 import com.se.Tlog.domain.Review.controller.dto.ReviewCreateDto;
+import com.se.Tlog.domain.Review.controller.dto.ReviewsRes;
 import com.se.Tlog.domain.Review.domain.Review;
 import com.se.Tlog.domain.Review.domain.SortType;
 import com.se.Tlog.domain.Review.repository.mongo.ReviewRepository;
@@ -28,8 +29,8 @@ public class ReviewService {
     private final DestinationDomainService destinationDomainService;
     private final UserDomainService userDomainService;
 
-    public Slice<DestinationReviewDto> getReviewsByDestinationId(String destinationId, SortType sortType, Pageable pageable) {
-        destinationDomainService.validateExists(destinationId);
+    public ReviewsRes getReviewsByDestinationId(String destinationId, SortType sortType, Pageable pageable) {
+        Map<Integer, Integer> distributionMap = destinationDomainService.getRatingDistribution(destinationId);
 
         Pageable sortedPageable = PageRequest.of(
                 pageable.getPageNumber(),
@@ -52,8 +53,10 @@ public class ReviewService {
             else
                 return DestinationReviewDto.from(review, "탈퇴한 사용자", UserProfileInfo.getNullProfile());
         }).toList();
+        
+        Slice<DestinationReviewDto> reviewDtos = new SliceImpl<>(dtoList, sortedPageable, reviews.hasNext());
 
-        return new SliceImpl<>(dtoList, sortedPageable, reviews.hasNext());
+        return new ReviewsRes(distributionMap, reviewDtos);
     }
 
     public void createReview(ReviewCreateDto reviewCreateDto) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/controller/ReviewController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/controller/ReviewController.java
@@ -1,9 +1,8 @@
 package com.se.Tlog.domain.Review.controller;
 
 import com.se.Tlog.domain.Review.application.ReviewService;
-import com.se.Tlog.domain.Review.controller.dto.DestinationReviewDto;
 import com.se.Tlog.domain.Review.controller.dto.ReviewCreateDto;
-
+import com.se.Tlog.domain.Review.controller.dto.ReviewsRes;
 import com.se.Tlog.domain.Review.domain.SortType;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
@@ -14,7 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -62,7 +60,7 @@ public class ReviewController {
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류")
             }
     )
-    public ResponseEntity<SuccessRes<Slice<DestinationReviewDto>>> getReviewsByDestinationId(
+    public ResponseEntity<SuccessRes<ReviewsRes>> getReviewsByDestinationId(
             @PathVariable String destinationId,
             @RequestParam SortType sortType,
             @PageableDefault(size = 5) Pageable pageable) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/controller/ReviewController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/controller/ReviewController.java
@@ -39,7 +39,7 @@ public class ReviewController {
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류")
             }
     )
-    public ResponseEntity<?> createReview(@RequestBody ReviewCreateDto reviewCreateDto) {
+    public ResponseEntity<SuccessRes<?>> createReview(@RequestBody ReviewCreateDto reviewCreateDto) {
         reviewService.createReview(reviewCreateDto);
         return ResponseEntity
                 .status(SuccessType.REVIEW_CREATED.getStatus())
@@ -62,11 +62,12 @@ public class ReviewController {
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류")
             }
     )
-    public ResponseEntity<Slice<DestinationReviewDto>> getReviewsByDestinationId(
+    public ResponseEntity<SuccessRes<Slice<DestinationReviewDto>>> getReviewsByDestinationId(
             @PathVariable String destinationId,
             @RequestParam SortType sortType,
             @PageableDefault(size = 5) Pageable pageable) {
-        return ResponseEntity.ok(reviewService.getReviewsByDestinationId(destinationId, sortType, pageable));
+        return ResponseEntity.ok(
+                SuccessRes.from(reviewService.getReviewsByDestinationId(destinationId, sortType, pageable)));
     }
 
     @DeleteMapping("/{reviewId}")
@@ -85,7 +86,7 @@ public class ReviewController {
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류")
             }
     )
-    public ResponseEntity<?> deleteReview(
+    public ResponseEntity<SuccessRes<?>> deleteReview(
             @PathVariable String reviewId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         String userId = userDetails.getId();

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/controller/dto/ReviewsRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/controller/dto/ReviewsRes.java
@@ -1,0 +1,15 @@
+package com.se.Tlog.domain.Review.controller.dto;
+
+import java.util.Map;
+
+import org.springframework.data.domain.Slice;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "특정 여행지의 리뷰를 조회한 데이터입니다.")
+public record ReviewsRes(
+        Map<Integer,Integer> ratingDistribution,
+        Slice<DestinationReviewDto> reviews
+        ) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/room/ChatRoomController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/room/ChatRoomController.java
@@ -1,12 +1,5 @@
 package com.se.Tlog.domain.Social.Chat.room;
 
-import com.se.Tlog.domain.User.domain.Role;
-import com.se.Tlog.domain.User.domain.User;
-import com.se.Tlog.domain.User.repository.jpa.UserRepository;
-import com.se.Tlog.global.exception.CustomException;
-import com.se.Tlog.global.response.error.ErrorType;
-import com.se.Tlog.global.response.success.SuccessRes;
-import com.se.Tlog.global.util.jwt.AccessTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -14,6 +7,8 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import com.se.Tlog.global.response.success.SuccessRes;
 
 import java.util.UUID;
 
@@ -23,8 +18,6 @@ import java.util.UUID;
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
-    private final AccessTokenProvider accessTokenProvider;
-    private final UserRepository userRepository;    // 테스트 때문에 넣어둠 나중에 지우겠습니다!
 
     @GetMapping("/room/{hostId}")
     @Operation(
@@ -43,17 +36,5 @@ public class ChatRoomController {
     )
     public ResponseEntity<?> getRoomList(@PathVariable(name = "hostId") UUID hostId) {
         return ResponseEntity.ok().body(SuccessRes.from(chatRoomService.getRoomList(hostId)));
-    }
-    // test 편의성 때문에 토큰 생성 api 작성
-    @PostMapping("/{userId}")
-    public ResponseEntity<?> createToken(@PathVariable(name = "userId") UUID userId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
-        String snsId = user.getSnsId();
-        return ResponseEntity.ok()
-                .body(accessTokenProvider.generateToken(
-                        userId.toString(),
-                        Role.USER.getValue(),
-                        snsId == null ? "" : snsId
-                ));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/room/DevChatRoomController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/room/DevChatRoomController.java
@@ -1,0 +1,53 @@
+package com.se.Tlog.domain.Social.Chat.room;
+
+import java.util.UUID;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.se.Tlog.domain.User.domain.Role;
+import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import com.se.Tlog.global.util.jwt.AccessTokenProvider;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "springdoc.swagger-ui.enabled", havingValue = "true") // 테스트 환경에서만 허용
+@RequestMapping("/api/chat")
+public class DevChatRoomController {
+    private final AccessTokenProvider accessTokenProvider;
+    private final UserRepository userRepository;    // 테스트 때문에 넣어둠 나중에 지우겠습니다!
+    
+    // test 편의성 때문에 토큰 생성 api 작성
+    @PostMapping("/{userId}")
+    @Operation(
+            summary = "테스트 편의성을 위한 토큰 발급 API",
+            description = "특정 유저에 대한 토큰을 발급합니다.",
+            tags = {"[DEV]"},
+            parameters = {@Parameter(name = "userId", description = "유저의 UUID 입니다.")},
+            responses = {
+                    @ApiResponse( responseCode = "200", description = "성공")
+            }
+    )
+    public ResponseEntity<?> createToken(@PathVariable(name = "userId") UUID userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+        String snsId = user.getSnsId();
+        return ResponseEntity.ok()
+                .body(accessTokenProvider.generateToken(
+                        userId.toString(),
+                        Role.USER.getValue(),
+                        snsId == null ? "" : snsId
+                ));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/controller/FollowController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/controller/FollowController.java
@@ -3,8 +3,16 @@ package com.se.Tlog.domain.Social.Follow.controller;
 import com.se.Tlog.domain.Social.Follow.application.FollowService;
 import com.se.Tlog.domain.Social.Follow.controller.dto.FollowDto;
 import com.se.Tlog.domain.Social.Follow.controller.dto.FollowStatusDto;
+import com.se.Tlog.domain.User.controller.dto.UserSummaryDto;
 import com.se.Tlog.global.response.success.SuccessRes;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -16,12 +24,27 @@ import java.util.UUID;
 @Controller
 @RequestMapping("/api/follow")
 @RequiredArgsConstructor
+@Tag(name = "Follow")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
 public class FollowController {
     private final FollowService followService;
 
 
     @PostMapping
-    public ResponseEntity<?> follow(@RequestBody FollowDto followDto) {
+    @Operation(
+            summary = "사용자 팔로잉 걸기/취소",
+            description = "특정 유저가 다른 유저를 팔로우합니다."
+                    + "<br> 이미 팔로우되어있다면 팔로잉을 취소합니다."
+                    + "<br> <b>갱신된 팔로우 상태가 반환됩니다.</b>",
+            responses = {
+                    @ApiResponse( responseCode = "200", description = "성공"),
+                    @ApiResponse( responseCode = "404", description = "존재하지 않는 사용자 입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    public ResponseEntity<SuccessRes<FollowStatusDto>> follow(@RequestBody FollowDto followDto) {
         FollowStatusDto followStatusDto = followService.follow(followDto);
         return ResponseEntity.ok()
                 .body(SuccessRes.from(followStatusDto));
@@ -30,18 +53,36 @@ public class FollowController {
 
     // 내가 팔로우한 사람들
     @GetMapping("/following/{userId}")
-    public ResponseEntity<?> getFollowingList(
+    @Operation(
+            summary = "내가 팔로잉한 사람들 조회",
+            description = "내가 팔로잉하고 있는 사람들을 모두 조회합니다.",
+            responses = {
+                    @ApiResponse( responseCode = "200", description = "성공"),
+                    @ApiResponse( responseCode = "404", description = "존재하지 않는 사용자 입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    public ResponseEntity<SuccessRes<Page<UserSummaryDto>>> getFollowingList(
             @PathVariable UUID userId,
             @PageableDefault(size = 10) Pageable pageable) {
-        return ResponseEntity.ok(followService.getFollowingList(userId,pageable));
+        return ResponseEntity.ok(SuccessRes.from(followService.getFollowingList(userId,pageable)));
     }
 
     // 나를 팔로우하는 사람들
     @GetMapping("/followers/{userId}")
-    public ResponseEntity<?> getFollowerList(
+    @Operation(
+            summary = "나를 팔로우하는 사람들 조회",
+            description = "나를 팔로우하고 있는 사람들을 모두 조회합니다.",
+            responses = {
+                    @ApiResponse( responseCode = "200", description = "성공"),
+                    @ApiResponse( responseCode = "404", description = "존재하지 않는 사용자 입니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    public ResponseEntity<SuccessRes<Page<UserSummaryDto>>> getFollowerList(
             @PathVariable UUID userId,
             @PageableDefault(size = 10) Pageable pageable) {
-        return ResponseEntity.ok(followService.getFollowerList(userId,pageable));
+        return ResponseEntity.ok(SuccessRes.from(followService.getFollowerList(userId,pageable)));
     }
 
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/controller/dto/FollowStatusDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/controller/dto/FollowStatusDto.java
@@ -1,7 +1,11 @@
 package com.se.Tlog.domain.Social.Follow.controller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record FollowStatusDto(
+        @Schema(example = "true")
         boolean status,
+        @Schema(example = "팔로우 되었습니다. (status는 [갱신된 팔로우 상태]를 표시합니다.)")
         String message
 ){
     public static FollowStatusDto from(boolean status) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/service/DestinationDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/domain/service/DestinationDomainService.java
@@ -8,6 +8,10 @@ import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 
 import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.TreeMap;
+
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +23,17 @@ public class DestinationDomainService {
     private final MongoTemplate mongoTemplate;
     private final DestinationRepositoryService destinationRepositoryService;
 
+    public Map<Integer, Integer> getRatingDistribution(String destinationId) {
+        int[] distribution = destinationRepository.findById(destinationId)
+                .orElseThrow(() -> new CustomException(ErrorType.DESTINATION_NOT_FOUND))
+                .getRatingCount();
+        
+        Map<Integer, Integer> resultMap = new TreeMap<>();
+        for (int i = 0; i < 5; i++)
+            resultMap.put(i+1, distribution[i]);
+        return resultMap;
+    }
+    
     public void validateExists(String destinationId) {
         if (!destinationRepository.existsById(destinationId)) {
             throw new CustomException(ErrorType.DESTINATION_NOT_FOUND);


### PR DESCRIPTION
## 작업 동기 및 이슈
- #158 
- #159 
- #160
- #161 

## 추가 및 변경사항
### 1) 리뷰 조회 API의 응답 데이터 형식이 변경되었습니다.
- SuccessRes 타입으로 래핑됨
- 평점 분포 `ratingDistribution` 추가
  <img src="https://github.com/user-attachments/assets/f8fb9da6-1c62-4fea-bc99-5a859d717392" width="500"/>

### 2) Follow 도메인이 Swagger UI에 문서화되었습니다.
  <img src="https://github.com/user-attachments/assets/fb4becb3-d267-4080-9652-3cd622ad1391" width="500"/>

### 3) ChatRoom의 토큰 발급 API 이동 + 문서화 + 개발환경에서만 표시
- 토큰 발급 API의 그룹이 `[DEV]`으로 이동되었습니다.
- Swagger UI에 문서화되었습니다.
- 개발환경에서만 사용 가능하도록 변경되었습니다.
  <img src="https://github.com/user-attachments/assets/3a4ffc0e-9a37-4e23-b1c6-086291e5a6ac" width="500"/>



## 테스트 결과
- 이상 무.
- **서버에 먼저 업데이트되었습니다!**

## 📌 기타
- **서버에 먼저 업데이트되었습니다!**