### PR TITLE
Feature: TBTI 설명 조회 및 관리 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiInfoService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiInfoService.java
@@ -1,0 +1,51 @@
+package com.se.Tlog.domain.Tbti.application;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Tbti.controller.dto.CreateTbtiInfoReq;
+import com.se.Tlog.domain.Tbti.controller.dto.TbtiInfoRes;
+import com.se.Tlog.domain.Tbti.domain.Tbti;
+import com.se.Tlog.domain.Tbti.domain.TbtiInfo;
+import com.se.Tlog.domain.Tbti.repository.jpa.TbtiInfoRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class TbtiInfoService {
+    private final TbtiInfoRepository tbtiInfoRepository;
+    
+    public void createTbtiInfo(CreateTbtiInfoReq request) {
+        if (tbtiInfoRepository.existsByTbtiString(request.tbtiString()))
+            throw new CustomException(ErrorType.ALREADY_EXISTS_TBTI_INFO);
+        
+        tbtiInfoRepository.save(
+                TbtiInfo.create(
+                        new Tbti(request.tbtiString()), 
+                        request.imageUrl(), 
+                        request.secondName(), 
+                        request.description()));
+    }
+    
+    public TbtiInfoRes getTbtiInfo(String tbtiString) {
+        Tbti tbti = new Tbti(tbtiString);
+        TbtiInfo tbtiInfo = tbtiInfoRepository.findByTbtiString(tbti.toString());
+        if (tbtiInfo == null)
+            return TbtiInfoRes.getNullDto(tbti);
+        else
+            return new TbtiInfoRes(
+                    tbti.toString(),
+                    tbtiInfo.getImageUrl(),
+                    tbtiInfo.getSecondName(),
+                    tbtiInfo.getDescription());
+    }
+    
+    public void deleteTbtiInfo(String tbtiString) {
+        Tbti tbti = new Tbti(tbtiString);
+        TbtiInfo tbtiInfo = tbtiInfoRepository.findByTbtiString(tbti.toString());
+        if (tbtiInfo == null)
+            return;
+        tbtiInfoRepository.delete(tbtiInfo);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiQuestionService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiQuestionService.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 
 @ApplicationService
 @RequiredArgsConstructor
-public class TbtiService {
+public class TbtiQuestionService {
 
     private final TbtiQuestionRepository tbtiQuestionRepository;
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiController.java
@@ -1,6 +1,6 @@
 package com.se.Tlog.domain.Tbti.controller;
 
-import com.se.Tlog.domain.Tbti.application.TbtiService;
+import com.se.Tlog.domain.Tbti.application.TbtiQuestionService;
 import com.se.Tlog.domain.Tbti.controller.dto.TbtiQuestionResponse;
 import com.se.Tlog.global.response.success.SuccessRes;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.*;
         name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
         scopes = {"scope1", "scope2"})
 public class TbtiController {
-    private final TbtiService tbtiService;
+    private final TbtiQuestionService tbtiService;
 
     @GetMapping("/user/questions")
     @Operation (

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiInfoController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiInfoController.java
@@ -1,0 +1,79 @@
+package com.se.Tlog.domain.Tbti.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.se.Tlog.domain.Tbti.application.TbtiInfoService;
+import com.se.Tlog.domain.Tbti.controller.dto.CreateTbtiInfoReq;
+import com.se.Tlog.domain.Tbti.controller.dto.TbtiInfoRes;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/tbti-info")
+@RequiredArgsConstructor
+@Tag(name = "TBTI별 설명 도메인")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
+public class TbtiInfoController {
+    private final TbtiInfoService tbtiInfoService;
+    
+    @PostMapping
+    @Operation (
+            summary = "TBTI 설명 생성하기",
+            description = "새 TBTI 설명을 생성합니다.",
+            responses = {
+                    @ApiResponse( responseCode = "200", description = "처리 성공"), 
+                    @ApiResponse(responseCode = "409", description = "이미 해당 TBTI의 설명이 존재합니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")}
+    )
+    public ResponseEntity<SuccessRes<?>> createTbtiDescription(@RequestBody CreateTbtiInfoReq request){
+        tbtiInfoService.createTbtiInfo(request);
+        return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+    }
+    
+    @GetMapping
+    @Operation (
+    		summary = "TBTI 설명 조회하기",
+    		description = "TBTI 설명을 반환합니다."
+    		            + "<br><b>설명 정보가 없을 경우, 기본 표시 정보가 반환됩니다.</b>",
+    		parameters = {
+    				@Parameter(name = "tbti", description = "설명을 조회할 TBTI 값입니다. (SELA ~ RONI)")
+    		},
+    		responses = {
+    				@ApiResponse( responseCode = "200", description = "처리 성공시 반환되는 TBTI 설명 데이터입니다."), 
+    				@ApiResponse(responseCode = "500", description = "서버 내부 오류")}
+    )
+    public ResponseEntity<SuccessRes<TbtiInfoRes>> getTbtiDescription(@RequestParam(name = "tbti", required = false) String tbti){
+        return ResponseEntity.ok().body(SuccessRes.from(
+                tbtiInfoService.getTbtiInfo(tbti)));
+    }
+
+    @DeleteMapping("/{tbti}")
+    @Operation (
+            summary = "TBTI 설명 삭제하기",
+            description = "특정 TBTI의 설명을 삭제합니다.",
+            responses = {
+                    @ApiResponse( responseCode = "200", description = "처리 성공"), 
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")}
+    )
+    public ResponseEntity<SuccessRes<?>> createTbtiDescription(@PathVariable(name = "tbti") String tbti){
+        tbtiInfoService.deleteTbtiInfo(tbti);
+        return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiManageController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiManageController.java
@@ -1,6 +1,6 @@
 package com.se.Tlog.domain.Tbti.controller;
 
-import com.se.Tlog.domain.Tbti.application.TbtiService;
+import com.se.Tlog.domain.Tbti.application.TbtiQuestionService;
 import com.se.Tlog.domain.Tbti.controller.dto.TbtiQuestionReq;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
@@ -24,7 +24,7 @@ import java.util.UUID;
         name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
         scopes = {"scope1", "scope2"})
 public class TbtiManageController {
-    private final TbtiService tbtiService;
+    private final TbtiQuestionService tbtiService;
 
     @PostMapping("/user/question")
     @Operation (

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/CreateTbtiInfoReq.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/CreateTbtiInfoReq.java
@@ -1,0 +1,20 @@
+package com.se.Tlog.domain.Tbti.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "TBTI 설명 데이터 추가시 필요한 정보입니다.")
+public record CreateTbtiInfoReq(
+        @Schema(description = "TBTI 유형입니다.", example = "RENA")
+        String tbtiString,
+        
+        @Schema(description = "TBTI 캐릭터 일러스트입니다.")
+        String imageUrl,
+        
+        @Schema(description = "TBTI 유형의 다른 이름입니다.", example = "자연 속 즉흥 사색가")
+        String secondName,
+        
+        @Schema(description = "TBTI 설명입니다.", example = "자연의 향기와 소리를 ~")
+        String description
+        ) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiInfoRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiInfoRes.java
@@ -1,0 +1,22 @@
+package com.se.Tlog.domain.Tbti.controller.dto;
+
+import com.se.Tlog.domain.Tbti.domain.Tbti;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "TBTI 특성에 관한 정보를 표시하는 데이터입니다.")
+public record TbtiInfoRes(
+        String tbtiString,
+        String imageUrl,
+        String secondName,
+        String description) {
+
+    public static TbtiInfoRes getNullDto(Tbti tbti) {
+        String tbtiStr = tbti.toString();
+        return new TbtiInfoRes(
+                tbtiStr, 
+                "", 
+                "아직 " + tbtiStr + "의 정보가 없어요...", 
+                "아직 " + tbtiStr + "가 어떤 성향인지 조사하고 있어요!");
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/Tbti.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/Tbti.java
@@ -10,16 +10,6 @@ public class Tbti {
     public static final int MIN_TBTI_CODE = 00000000;
     public static final int MAX_TBTI_CODE = 99999999;
     public static final int FEATURE_THRESHOLD = 50;
-
-    public static int toTbtiCode(String tbtiCode) {
-        try {
-            if (tbtiCode.length() != 8)
-                throw new CustomException(ErrorType.INVALID_TBTI_CODE);
-            return Integer.parseInt(tbtiCode);
-        } catch (Exception e) {
-            throw new CustomException(ErrorType.INVALID_TBTI_CODE);
-        }
-    }
     
     private int rawTbtiCode;
     
@@ -29,8 +19,17 @@ public class Tbti {
         this.rawTbtiCode = tbtiCode;
     }
     
-    public Tbti(String tbtiCode) {
-        this(toTbtiCode(tbtiCode));
+    public Tbti(String tbtiString) {
+        TraitCategory[] categories = TraitCategory.values();
+        if (tbtiString == null || tbtiString.length() != categories.length)
+            throw new CustomException(ErrorType.INVALID_TBTI_STRING);
+        
+        tbtiString = tbtiString.toUpperCase();
+        rawTbtiCode = 0;
+        for (int i = 0; i < categories.length; i++) {
+            rawTbtiCode *= 100;
+            rawTbtiCode += categories[i].getPercentage(tbtiString.charAt(i));
+        }
     }
     
     public int getTbtiCode() {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiInfo.java
@@ -1,0 +1,50 @@
+package com.se.Tlog.domain.Tbti.domain;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * TBTI 관련 각종 정보(일러스트, 설명, 한줄설명 등)를 관리하는 엔티티입니다.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class TbtiInfo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    private String tbtiString;
+    
+    private String imageUrl;
+    
+    private String secondName;
+    
+    private String description;
+    
+    private TbtiInfo(String tbtiString, String imageUrl, String secondName, String description) {
+        this.tbtiString = tbtiString;
+        this.imageUrl = imageUrl;
+        this.secondName = secondName;
+        this.description = description;
+    }
+    
+    public static TbtiInfo create(Tbti tbti, String imageUrl, String secondName, String description) {
+        if (tbti == null
+                || imageUrl == null
+                || secondName == null
+                || description == null)
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        
+        return new TbtiInfo(tbti.toString(), imageUrl, secondName, description);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TraitCategory.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TraitCategory.java
@@ -22,6 +22,14 @@ public enum TraitCategory {
     public char getMaxCategoryInitial() {
         return categoryInitial.charAt(2);
     }
+    public int getPercentage(char initial) {
+        if (initial == categoryInitial.charAt(0))
+            return 0;
+        else if (initial == categoryInitial.charAt(2))
+            return 99;
+        else
+            throw new CustomException(ErrorType.INVALID_TBTI_STRING);
+    }
     
     public static TraitCategory fromString(String traitCategory) {
         try {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/repository/jpa/TbtiInfoRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/repository/jpa/TbtiInfoRepository.java
@@ -1,0 +1,12 @@
+package com.se.Tlog.domain.Tbti.repository.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.se.Tlog.domain.Tbti.domain.TbtiInfo;
+
+@Repository
+public interface TbtiInfoRepository extends JpaRepository<TbtiInfo, Long> {
+    TbtiInfo findByTbtiString(String tbtiString);
+    boolean existsByTbtiString(String tbtiString);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/RegisterUserProfileDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/RegisterUserProfileDto.java
@@ -4,6 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "로그인시 입력해야하는 사용자 기본 정보입니다.")
 public record RegisterUserProfileDto(
-        @Schema(description = "TBTI 검사 결과. 00000000 ~ 99999999 사이의 값이어야 합니다.")
+        @Schema(description = "TBTI 검사 결과. 00000000 ~ 99999999 사이의 값이어야 합니다.", example = "00137501")
         String tbtiValue) {
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/UserRegisterInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/UserRegisterInfo.java
@@ -26,7 +26,11 @@ public class UserRegisterInfo {
         this.email = ssoUserInfo.email();
         this.providerUserInfo = ssoUserInfo.getProviderUserInfo();
         this.profileImage = "";
-        this.tbti = new Tbti(Integer.parseInt(userProfiles.tbtiValue()));
+        try {
+            this.tbti = new Tbti(Integer.parseInt(userProfiles.tbtiValue()));
+        } catch (Exception e) {
+            throw new CustomException(ErrorType.INVALID_TBTI_CODE);
+        }
     }
     
     public void setEmail(String email) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/UserRegisterInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/UserRegisterInfo.java
@@ -26,7 +26,7 @@ public class UserRegisterInfo {
         this.email = ssoUserInfo.email();
         this.providerUserInfo = ssoUserInfo.getProviderUserInfo();
         this.profileImage = "";
-        this.tbti = new Tbti(userProfiles.tbtiValue());
+        this.tbti = new Tbti(Integer.parseInt(userProfiles.tbtiValue()));
     }
     
     public void setEmail(String email) {

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -44,6 +44,7 @@ public enum ErrorType {
     INVALID_LINK_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "링크 알림 타입이 없거나 잘못된 값입니다."),
     
     // TBTI 관련
+    INVALID_TBTI_STRING(HttpStatus.BAD_REQUEST, "올바른 TBTI 알파벳이 아닙니다."),
     INVALID_TBTI_CODE(HttpStatus.BAD_REQUEST, "TBTI 코드는 0~99999999사이여야 합니다."),
     INVALID_ANSWER_PERCENTAGE(HttpStatus.BAD_REQUEST, "TBTI 응답의 값은 0~99사이여야 합니다."),
     QUESTION_HAS_NO_ANSWER(HttpStatus.BAD_REQUEST, "TBTI 질문에는 응답이 1개 이상 존재해야 합니다."),
@@ -84,6 +85,7 @@ public enum ErrorType {
     ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 회원가입된 사용자입니다."),
     ALREADY_EXISTS_SNSId(HttpStatus.CONFLICT, "이미 존재하는 Id 입니다."),
     ALREADY_EXISTS_TAG(HttpStatus.CONFLICT, "이미 존재하는 태그입니다."),
+    ALREADY_EXISTS_TBTI_INFO(HttpStatus.CONFLICT, "이미 존재하는 TBTI 설명입니다."),
     ALREADY_EXISTS_DESTINATION(HttpStatus.CONFLICT, "이미 존재하는 여행지입니다."),
     ALREADY_OWN_REWARD(HttpStatus.CONFLICT, "이미 보유하고 있는 보상입니다."),
     ALREADY_EXIST_IN_TEAM(HttpStatus.CONFLICT, "이미 팀에 속해있는 유저입니다."),

--- a/tlog-was/src/test/java/com/se/Tlog/domain/Tbti/domain/TbtiTest.java
+++ b/tlog-was/src/test/java/com/se/Tlog/domain/Tbti/domain/TbtiTest.java
@@ -19,50 +19,73 @@ public class TbtiTest {
         assertThatNoException().isThrownBy(() -> new Tbti(50000));
         assertThatNoException().isThrownBy(() -> new Tbti(99999999));
         assertThatException().isThrownBy(() -> new Tbti(100000000));
-
-        assertThatException().isThrownBy(() -> new Tbti(null));
-        assertThatException().isThrownBy(() -> new Tbti(""));
-        assertThatException().isThrownBy(() -> new Tbti("hello"));
-        assertThatException().isThrownBy(() -> new Tbti("1.15"));
-        assertThatException().isThrownBy(() -> new Tbti("-1"));
-        assertThatException().isThrownBy(() -> new Tbti("15123"));
-        assertThatException().isThrownBy(() -> new Tbti("001200"));
-        assertThatException().isThrownBy(() -> new Tbti("15123--1"));
-        assertThatException().isThrownBy(() -> new Tbti("1.121231"));
-        assertThatException().isThrownBy(() -> new Tbti("0ii01200"));
-        assertThatException().isThrownBy(() -> new Tbti("-1121231"));
-        
-        assertThatNoException().isThrownBy(() -> new Tbti("00000000"));
-        assertThatNoException().isThrownBy(() -> new Tbti("99999999"));
-        assertThatNoException().isThrownBy(() -> new Tbti("12345678"));
-        assertThatNoException().isThrownBy(() -> new Tbti("10000010"));
     }
 
     @Test
-    @DisplayName("TBTI 값 변환 테스트")
-    public void testConvert() {
+    @DisplayName("TBTI 값 변환 테스트1")
+    public void testConvert1() {
         Tbti value = new Tbti(12119931);
+        assertEquals(12119931, value.getTbtiCode());
         assertEquals(12, value.getPercentage(TraitCategory.RISK_TAKING));
         assertEquals(11, value.getPercentage(TraitCategory.LOCATION_PREFERENCE));
         assertEquals(99, value.getPercentage(TraitCategory.PLANNING_STYLE));
         assertEquals(31, value.getPercentage(TraitCategory.ACTIVITY_LEVEL));
         assertEquals("SENA", value.toString());
         
-        value = new Tbti("00120134");
-        assertEquals(00, value.getPercentage(TraitCategory.RISK_TAKING));
+        value = new Tbti(120134);
+        assertEquals(120134, value.getTbtiCode());
+        assertEquals(0, value.getPercentage(TraitCategory.RISK_TAKING));
         assertEquals(12, value.getPercentage(TraitCategory.LOCATION_PREFERENCE));
-        assertEquals(01, value.getPercentage(TraitCategory.PLANNING_STYLE));
+        assertEquals(1, value.getPercentage(TraitCategory.PLANNING_STYLE));
         assertEquals(34, value.getPercentage(TraitCategory.ACTIVITY_LEVEL));
         assertEquals("SELA", value.toString());
 
-        value = new Tbti("00000001");
-        assertEquals(00, value.getPercentage(TraitCategory.RISK_TAKING));
-        assertEquals(00, value.getPercentage(TraitCategory.LOCATION_PREFERENCE));
-        assertEquals(00, value.getPercentage(TraitCategory.PLANNING_STYLE));
-        assertEquals(01, value.getPercentage(TraitCategory.ACTIVITY_LEVEL));
+        value = new Tbti(1);
+        assertEquals(1, value.getTbtiCode());
+        assertEquals(0, value.getPercentage(TraitCategory.RISK_TAKING));
+        assertEquals(0, value.getPercentage(TraitCategory.LOCATION_PREFERENCE));
+        assertEquals(0, value.getPercentage(TraitCategory.PLANNING_STYLE));
+        assertEquals(1, value.getPercentage(TraitCategory.ACTIVITY_LEVEL));
         assertEquals("SELA", value.toString());
 
         value = new Tbti(99999999);
+        assertEquals(99999999, value.getTbtiCode());
+        assertEquals(99, value.getPercentage(TraitCategory.RISK_TAKING));
+        assertEquals(99, value.getPercentage(TraitCategory.LOCATION_PREFERENCE));
+        assertEquals(99, value.getPercentage(TraitCategory.PLANNING_STYLE));
+        assertEquals(99, value.getPercentage(TraitCategory.ACTIVITY_LEVEL));
+        assertEquals("RONI", value.toString());
+    }
+
+    @Test
+    @DisplayName("TBTI 값 변환 테스트2")
+    public void testConvert2() {
+        Tbti value = new Tbti("SENA");
+        assertEquals(9900, value.getTbtiCode());
+        assertEquals(00, value.getPercentage(TraitCategory.RISK_TAKING));
+        assertEquals(00, value.getPercentage(TraitCategory.LOCATION_PREFERENCE));
+        assertEquals(99, value.getPercentage(TraitCategory.PLANNING_STYLE));
+        assertEquals(00, value.getPercentage(TraitCategory.ACTIVITY_LEVEL));
+        assertEquals("SENA", value.toString());
+        
+        value = new Tbti("SELI");
+        assertEquals(99, value.getTbtiCode());
+        assertEquals(0, value.getPercentage(TraitCategory.RISK_TAKING));
+        assertEquals(0, value.getPercentage(TraitCategory.LOCATION_PREFERENCE));
+        assertEquals(0, value.getPercentage(TraitCategory.PLANNING_STYLE));
+        assertEquals(99, value.getPercentage(TraitCategory.ACTIVITY_LEVEL));
+        assertEquals("SELI", value.toString());
+
+        value = new Tbti("SOLI");
+        assertEquals(990099, value.getTbtiCode());
+        assertEquals(00, value.getPercentage(TraitCategory.RISK_TAKING));
+        assertEquals(99, value.getPercentage(TraitCategory.LOCATION_PREFERENCE));
+        assertEquals(00, value.getPercentage(TraitCategory.PLANNING_STYLE));
+        assertEquals(99, value.getPercentage(TraitCategory.ACTIVITY_LEVEL));
+        assertEquals("SOLI", value.toString());
+
+        value = new Tbti("RONI");
+        assertEquals(99999999, value.getTbtiCode());
         assertEquals(99, value.getPercentage(TraitCategory.RISK_TAKING));
         assertEquals(99, value.getPercentage(TraitCategory.LOCATION_PREFERENCE));
         assertEquals(99, value.getPercentage(TraitCategory.PLANNING_STYLE));


### PR DESCRIPTION
## 작업 동기 및 이슈
- #163 

## 추가 및 변경사항
### 1) 문자열로 TBTI 값 객체 생성하는 로직 변경
- 기존에는 문자열을 숫자 코드값으로 받고 있었음. ("21003756" 등)
- 이제 **문자열은 TBTI 알파벳으로 구성**되어야 합니다! ("SELI" 등)
### 2) 각 TBTI별 설명을 담는 TbtiInfo 엔티티 추가
- `TbtiInfo` 엔티티 추가
  - 이와 관련된 Repository 추가
### 3) TBTI 설명의 조회 및 관리 기능 추가
- 설명 추가, 조회, 삭제 기능이 추가되었습니다.
  - 조회시 정보가 없으면 **기본 표시 정보**로 반환합니다! (하단 사진 참고)
- `TbtiInfoService` 및 `TbtiInfoController`에서 지원됩니다.

## 테스트 결과
- 이상 무.
  <img src="https://github.com/user-attachments/assets/de620c95-3e29-456b-914d-8a0939afbfb9" width="350"/>
  - 잘못된 TBTI 문자열 (sollla 등) 입력시 :
    <img src="https://github.com/user-attachments/assets/3e49128d-84dd-486e-96a1-c2e3febe075a" width="500"/>
  - 설명 조회
    <img src="https://github.com/user-attachments/assets/27e06da5-23b8-42c1-a5ef-d4a34a697d98" width="500"/>
  - **없는 설명 조회시**
    <img src="https://github.com/user-attachments/assets/b98f5df2-3f3a-4783-b3df-c83cf21c84fc" width="500"/>




## 📌 기타
