### PR TITLE
Feature: 보상 관련 정보 추가

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Reward/application/RewardInfoService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Reward/application/RewardInfoService.java
@@ -25,7 +25,9 @@ public class RewardInfoService {
 	public RewardInfo addNewRewardInfo(CreateRewardInfoRequest request) {
 		RewardInfo newRewardInfo = 
 				RewardInfo.create(
+				        request.iconImageUrl(),
 						request.name(),
+						request.description(),
 						RewardCriteria.create(request.criteriaType(), request.criteriaParameter()));
 		return rewardInfoRepository.save(newRewardInfo);
 	}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Reward/application/RewardInfoService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Reward/application/RewardInfoService.java
@@ -3,8 +3,8 @@ package com.se.Tlog.domain.Reward.application;
 import java.util.List;
 
 import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Reward.controller.dto.CreateRewardInfoRequest;
 import com.se.Tlog.domain.Reward.domain.RewardCriteria;
-import com.se.Tlog.domain.Reward.domain.RewardCriteriaType;
 import com.se.Tlog.domain.Reward.domain.RewardInfo;
 import com.se.Tlog.domain.Reward.repository.jpa.RewardInfoRepository;
 
@@ -22,11 +22,11 @@ public class RewardInfoService {
 	 * @param parameter
 	 * @return
 	 */
-	public RewardInfo addNewRewardInfo(String name, RewardCriteriaType type, String parameter) {
+	public RewardInfo addNewRewardInfo(CreateRewardInfoRequest request) {
 		RewardInfo newRewardInfo = 
 				RewardInfo.create(
-						name,
-						RewardCriteria.create(type, parameter));
+						request.name(),
+						RewardCriteria.create(request.criteriaType(), request.criteriaParameter()));
 		return rewardInfoRepository.save(newRewardInfo);
 	}
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Reward/application/RewardService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Reward/application/RewardService.java
@@ -26,7 +26,6 @@ public class RewardService {
 	
 	/**
 	 * 특정 유저에게 보상을 설정합니다.
-	 * <br/> 보상 조건이 맞지 않으면 보상 설정에 실패하며, <code>false</code>를 반환합니다.
 	 * @param userId
 	 * @param rewardInfoId
 	 * @return
@@ -44,6 +43,29 @@ public class RewardService {
 	}
 	
 	/**
+	 * 특정 유저가 기본으로 표시할 보상을 설정합니다.
+	 * @param userId
+	 * @param rewardInfoId
+	 */
+	public void setDefaultReward(UUID userId, Long rewardInfoId) {
+	    if (!userRepository.existsById(userId))
+	        throw new CustomException(ErrorType.USER_NOT_FOUND);
+	    
+	    List<Reward> userRewards = rewardRepository.findAllByUser_Id(userId);
+	    Reward selection = null;
+	    for (Reward r : userRewards)
+	        if (r.getRewardInfo().getId() == rewardInfoId)
+	            selection = r;
+        if (selection == null)
+            throw new CustomException(ErrorType.REWARD_NOT_RECEIVED);
+	    
+	    userRewards.forEach(reward -> reward.setDefault(false));
+        selection.setDefault(true);
+	    
+	    rewardRepository.saveAll(userRewards);
+	}
+	
+	/**
 	 * 특정 유저가 보유하고 있는 모든 보상을 조회합니다.
 	 * @param userId
 	 * @return
@@ -52,9 +74,10 @@ public class RewardService {
 		return rewardRepository.findAllByUser_Id(userId)
 				.stream().map(reward -> new UserRewardDto(
 				        reward.getRewardInfo().getId(),
-				        reward.getRewardInfo().getName(), 
+				        reward.getRewardInfo().getName(),
 				        reward.getRewardInfo().getDescription(),
-				        reward.getRewardInfo().getIconImageUrl()))
+				        reward.getRewardInfo().getIconImageUrl(),
+				        reward.isDefault()))
 				.toList();
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Reward/application/RewardService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Reward/application/RewardService.java
@@ -14,6 +14,7 @@ import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @ApplicationService
@@ -47,22 +48,15 @@ public class RewardService {
 	 * @param userId
 	 * @param rewardInfoId
 	 */
+	@Transactional
 	public void setDefaultReward(UUID userId, Long rewardInfoId) {
 	    if (!userRepository.existsById(userId))
 	        throw new CustomException(ErrorType.USER_NOT_FOUND);
 	    
-	    List<Reward> userRewards = rewardRepository.findAllByUser_Id(userId);
-	    Reward selection = null;
-	    for (Reward r : userRewards)
-	        if (r.getRewardInfo().getId() == rewardInfoId)
-	            selection = r;
-        if (selection == null)
+        if (!rewardRepository.existsByRewardInfo_IdAndUser_Id(rewardInfoId, userId))
             throw new CustomException(ErrorType.REWARD_NOT_RECEIVED);
 	    
-	    userRewards.forEach(reward -> reward.setDefault(false));
-        selection.setDefault(true);
-	    
-	    rewardRepository.saveAll(userRewards);
+        rewardRepository.updateDefaultReward(rewardInfoId, userId);
 	}
 	
 	/**

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Reward/application/RewardService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Reward/application/RewardService.java
@@ -5,8 +5,8 @@ import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Reward.controller.dto.UserRewardDto;
 import com.se.Tlog.domain.Reward.domain.Reward;
-import com.se.Tlog.domain.Reward.domain.RewardInfo;
 import com.se.Tlog.domain.Reward.domain.repository.RewardRepositoryService;
 import com.se.Tlog.domain.Reward.repository.jpa.RewardInfoRepository;
 import com.se.Tlog.domain.Reward.repository.jpa.RewardRepository;
@@ -48,9 +48,13 @@ public class RewardService {
 	 * @param userId
 	 * @return
 	 */
-	public List<RewardInfo> getAllRewardOfUser(UUID userId) {
+	public List<UserRewardDto> getAllRewardOfUser(UUID userId) {
 		return rewardRepository.findAllByUser_Id(userId)
-				.stream().map(Reward::getRewardInfo)
+				.stream().map(reward -> new UserRewardDto(
+				        reward.getRewardInfo().getId(),
+				        reward.getRewardInfo().getName(), 
+				        reward.getRewardInfo().getDescription(),
+				        reward.getRewardInfo().getIconImageUrl()))
 				.toList();
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Reward/controller/RewardController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Reward/controller/RewardController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import com.se.Tlog.domain.Reward.application.RewardService;
 import com.se.Tlog.domain.Reward.controller.dto.AddRewardToUserRequest;
-import com.se.Tlog.domain.Reward.controller.dto.RewardInfoDto;
+import com.se.Tlog.domain.Reward.controller.dto.UserRewardDto;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorRes;
 import com.se.Tlog.global.response.error.ErrorType;
@@ -71,11 +71,9 @@ public class RewardController {
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류. 조회에 실패했습니다.",
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
-	public ResponseEntity<SuccessRes<List<RewardInfoDto>>> getRewardsByUser(@RequestParam UUID userId) {
+	public ResponseEntity<SuccessRes<List<UserRewardDto>>> getRewardsByUser(@RequestParam UUID userId) {
 		return ResponseEntity.ok(
 				SuccessRes.from(
-						rewardService.getAllRewardOfUser(userId)
-						.stream().map(RewardInfoDto::fromEntity)
-						.toList()));
+						rewardService.getAllRewardOfUser(userId)));
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Reward/controller/RewardController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Reward/controller/RewardController.java
@@ -18,17 +18,23 @@ import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorRes;
 import com.se.Tlog.global.response.error.ErrorType;
 import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @Controller
 @RequestMapping("/api/reward")
 @RequiredArgsConstructor
+@Tag(name = "사용자 보상 관리")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
 public class RewardController {
 	private final RewardService rewardService;
 	
@@ -36,10 +42,6 @@ public class RewardController {
 	@Operation (
 			summary = "사용자에게 보상 지급",
     		description = "사용자에게 보상 지급을 요청합니다.",
-			tags = {"사용자 보상 관리"},
-			security = @SecurityRequirement(
-					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
-					scopes = {"scope1", "scope2"}),
 			responses = {
 					@ApiResponse(responseCode = "200", description = "처리 성공, 사용자의 보상 지급 결과를 반환합니다."),
 					@ApiResponse(responseCode = "404", description = "요청한 사용자나 보상 형식이 존재하지 않습니다.",
@@ -58,14 +60,28 @@ public class RewardController {
 		}
 	}
 	
+	@PostMapping("/{rewardId}/user/{userId}")
+    @Operation (
+            summary = "사용자의 기본 표시 보상 설정",
+            description = "사용자의 기본 표시 보상을 설정합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공"),
+                    @ApiResponse(responseCode = "404", description = "사용자가 해당 보상을 보유하고 있지 않습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<?>> setDefaultReward(
+            @RequestParam(name = "rewardId") Long rewardInfoId,
+            @RequestParam(name = "userId") UUID userId) {
+	    rewardService.setDefaultReward(userId, rewardInfoId);
+        return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+    }
+	
 	@GetMapping
 	@Operation (
 			summary = "사용자가 보유한 보상 조회",
     		description = "특정 사용자가 보유한 보상들을 조회합니다.",
-			tags = {"사용자 보상 관리"},
-			security = @SecurityRequirement(
-					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
-					scopes = {"scope1", "scope2"}),
 			responses = {
 					@ApiResponse(responseCode = "200", description = "처리 성공, 주어진 사용자가 보유한 보상 리스트를 반환합니다."),
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류. 조회에 실패했습니다.",

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Reward/controller/RewardInfoController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Reward/controller/RewardInfoController.java
@@ -70,10 +70,7 @@ public class RewardInfoController {
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
 	public ResponseEntity<SuccessRes<?>> createRewardInfo(@RequestBody CreateRewardInfoRequest requestData) {
-		rewardInfoService.addNewRewardInfo(
-				requestData.name(),
-				requestData.criteriaType(),
-				requestData.criteriaParameter());
+		rewardInfoService.addNewRewardInfo(requestData);
 		return ResponseEntity.ok().body(SuccessRes.from(SuccessType.CREATED)); 
 	}
 	

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Reward/controller/dto/CreateRewardInfoRequest.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Reward/controller/dto/CreateRewardInfoRequest.java
@@ -6,8 +6,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "새 보상 형식의 생성 요청을 위한 정보입니다.")
 public record CreateRewardInfoRequest(
+        @Schema(description = "보상 형식의 아이콘 이미지")
+        String iconImageUrl,
+        
 		@Schema(description = "보상의 이름")
 		String name,
+		
+        @Schema(description = "보상 설명 문구")
+        String description,
 		
 		@Schema(description = "보상 달성 조건의 유형")
 		RewardCriteriaType criteriaType,

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Reward/controller/dto/UserRewardDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Reward/controller/dto/UserRewardDto.java
@@ -1,0 +1,12 @@
+package com.se.Tlog.domain.Reward.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자의 보상 데이터를 표시하는 형식입니다.")
+public record UserRewardDto(
+        Long rewardId, // 서비스의 고유 보상 id인 RewardInfo의 id입니다!
+        String name,
+        String description,
+        String iconImageUrl) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Reward/controller/dto/UserRewardDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Reward/controller/dto/UserRewardDto.java
@@ -7,6 +7,7 @@ public record UserRewardDto(
         Long rewardId, // 서비스의 고유 보상 id인 RewardInfo의 id입니다!
         String name,
         String description,
-        String iconImageUrl) {
+        String iconImageUrl,
+        boolean isDefaultReward) {
 
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Reward/domain/Reward.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Reward/domain/Reward.java
@@ -34,6 +34,12 @@ public class Reward {
 	@JoinColumn(name = "reward_info")
 	private RewardInfo rewardInfo;
 	
+	private boolean isDefault;
+	
+	public void setDefault(boolean isDefault) {
+	    this.isDefault = isDefault;
+	}
+	
 	private Reward(User user, RewardInfo rewardInfo) {
 		this.user = user;
 		this.rewardInfo = rewardInfo;

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Reward/domain/RewardInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Reward/domain/RewardInfo.java
@@ -1,5 +1,8 @@
 package com.se.Tlog.domain.Reward.domain;
 
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -19,22 +22,30 @@ public class RewardInfo {
 	@Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+    
+    private String iconImageUrl;
 	
 	private String name;
+    
+    private String description;
 	
 	@Embedded
 	private RewardCriteria rewardCriteria;
 	
-	// private media icon // 보상 뱃지 아이콘 등 부가 정보
-	
-	// private String description = "팔로워 수를 100명 돌파했어요!!"
-	
-	private RewardInfo(String name, RewardCriteria rewardCriteria) {
+	private RewardInfo(String iconImageUrl, String name, String description, RewardCriteria rewardCriteria) {
+	    this.iconImageUrl = iconImageUrl;
 		this.name = name;
+		this.description = description;
 		this.rewardCriteria = rewardCriteria;
 	}
 	
-	public static RewardInfo create(String name, RewardCriteria rewardCriteria) {
-		return new RewardInfo(name, rewardCriteria);
+	public static RewardInfo create(String iconImageUrl, String name, String description, RewardCriteria rewardCriteria) {
+	    if (iconImageUrl == null
+	            || name == null || name.trim().isEmpty()
+	            || description == null || description.trim().isEmpty()
+	            || rewardCriteria == null)
+	        throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+	    
+		return new RewardInfo(iconImageUrl, name, description, rewardCriteria);
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Reward/repository/jpa/RewardRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Reward/repository/jpa/RewardRepository.java
@@ -4,12 +4,28 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.se.Tlog.domain.Reward.domain.Reward;
 
 @Repository
 public interface RewardRepository extends JpaRepository<Reward, Long> {
-	List<Reward> findAllByUser_Id(UUID id);
+    @Modifying
+    @Query("""
+            UPDATE Reward r 
+            SET r.isDefault =
+                CASE
+                    WHEN (r.rewardInfo.id = :rewardInfoId) THEN true
+                    ELSE false
+                END
+            WHERE r.user.id = :userId
+            """)
+    void updateDefaultReward(Long rewardInfoId, UUID userId);
+    
+    @Query("SELECT r FROM Reward r JOIN FETCH r.user JOIN FETCH r.rewardInfo WHERE r.user.id = :userId")
+	List<Reward> findAllByUser_Id(UUID userId);
+    
 	boolean existsByRewardInfo_IdAndUser_Id(Long rewardInfoId, UUID userId);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -71,6 +71,7 @@ public enum ErrorType {
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 관리자 입니다."),
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 채팅방 입니다."),
     MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않은 메시지 입니다."),
+    REWARD_NOT_RECEIVED(HttpStatus.NOT_FOUND, "사용자가 얻지 않은 보상입니다."),
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 팀입니다."),
     TEAM_USER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 팀원입니다."),
     INVALID_DESTINATION(HttpStatus.NOT_FOUND, "존재하지 않는 구독경로입니다."),

--- a/tlog-was/src/test/java/com/se/Tlog/domain/Reward/Service/RewardInfoServiceTest.java
+++ b/tlog-was/src/test/java/com/se/Tlog/domain/Reward/Service/RewardInfoServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import com.se.Tlog.domain.Reward.application.RewardInfoService;
+import com.se.Tlog.domain.Reward.controller.dto.CreateRewardInfoRequest;
 import com.se.Tlog.domain.Reward.domain.RewardCriteria;
 import com.se.Tlog.domain.Reward.domain.RewardCriteriaType;
 import com.se.Tlog.domain.Reward.domain.RewardInfo;
@@ -30,10 +31,10 @@ class RewardInfoServiceTest {
 	@DisplayName("새 보상 형식 등록 테스트")
 	void testAddNewRewardInfo() {
 		List<RewardInfo> added = new ArrayList<RewardInfo>();
-		added.add(rewardInfoService.addNewRewardInfo("보상 1", RewardCriteriaType.TEST_NULL_CRITERIA, ""));
-		added.add(rewardInfoService.addNewRewardInfo("보상 2", RewardCriteriaType.IS_DEVELOPER, ""));
-		added.add(rewardInfoService.addNewRewardInfo("보상 3", RewardCriteriaType.TEST_NULL_CRITERIA, ""));
-		added.add(rewardInfoService.addNewRewardInfo("보상 4", RewardCriteriaType.IS_DEVELOPER, ""));
+		added.add(rewardInfoService.addNewRewardInfo(new CreateRewardInfoRequest("보상 1", RewardCriteriaType.TEST_NULL_CRITERIA, "")));
+		added.add(rewardInfoService.addNewRewardInfo(new CreateRewardInfoRequest("보상 2", RewardCriteriaType.IS_DEVELOPER, "")));
+		added.add(rewardInfoService.addNewRewardInfo(new CreateRewardInfoRequest("보상 3", RewardCriteriaType.TEST_NULL_CRITERIA, "")));
+		added.add(rewardInfoService.addNewRewardInfo(new CreateRewardInfoRequest("보상 4", RewardCriteriaType.IS_DEVELOPER, "")));
 		
 		assertThat(rewardInfoRepository.findAll())
 		.containsAll(added);

--- a/tlog-was/src/test/java/com/se/Tlog/domain/Reward/Service/RewardInfoServiceTest.java
+++ b/tlog-was/src/test/java/com/se/Tlog/domain/Reward/Service/RewardInfoServiceTest.java
@@ -31,10 +31,10 @@ class RewardInfoServiceTest {
 	@DisplayName("새 보상 형식 등록 테스트")
 	void testAddNewRewardInfo() {
 		List<RewardInfo> added = new ArrayList<RewardInfo>();
-		added.add(rewardInfoService.addNewRewardInfo(new CreateRewardInfoRequest("보상 1", RewardCriteriaType.TEST_NULL_CRITERIA, "")));
-		added.add(rewardInfoService.addNewRewardInfo(new CreateRewardInfoRequest("보상 2", RewardCriteriaType.IS_DEVELOPER, "")));
-		added.add(rewardInfoService.addNewRewardInfo(new CreateRewardInfoRequest("보상 3", RewardCriteriaType.TEST_NULL_CRITERIA, "")));
-		added.add(rewardInfoService.addNewRewardInfo(new CreateRewardInfoRequest("보상 4", RewardCriteriaType.IS_DEVELOPER, "")));
+		added.add(rewardInfoService.addNewRewardInfo(new CreateRewardInfoRequest("", "보상 1", "테스트 보상 1", RewardCriteriaType.TEST_NULL_CRITERIA, "")));
+		added.add(rewardInfoService.addNewRewardInfo(new CreateRewardInfoRequest("", "보상 2", "테스트 보상 2", RewardCriteriaType.IS_DEVELOPER, "")));
+		added.add(rewardInfoService.addNewRewardInfo(new CreateRewardInfoRequest("", "보상 3", "테스트 보상 3", RewardCriteriaType.TEST_NULL_CRITERIA, "")));
+		added.add(rewardInfoService.addNewRewardInfo(new CreateRewardInfoRequest("", "보상 4", "테스트 보상 4", RewardCriteriaType.IS_DEVELOPER, "")));
 		
 		assertThat(rewardInfoRepository.findAll())
 		.containsAll(added);
@@ -45,10 +45,10 @@ class RewardInfoServiceTest {
 	@DisplayName("보상 형식 조회 테스트")
 	void testGetAllRewardInfo() {
 		List<RewardInfo> added = new ArrayList<RewardInfo>();
-		added.add(rewardInfoRepository.save(RewardInfo.create("보상 1", RewardCriteria.create(RewardCriteriaType.TEST_NULL_CRITERIA, ""))));
-		added.add(rewardInfoRepository.save(RewardInfo.create("보상 2", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""))));
-		added.add(rewardInfoRepository.save(RewardInfo.create("보상 3", RewardCriteria.create(RewardCriteriaType.TEST_NULL_CRITERIA, ""))));
-		added.add(rewardInfoRepository.save(RewardInfo.create("보상 4", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""))));
+		added.add(rewardInfoRepository.save(RewardInfo.create("", "보상 1", "테스트 보상 1", RewardCriteria.create(RewardCriteriaType.TEST_NULL_CRITERIA, ""))));
+		added.add(rewardInfoRepository.save(RewardInfo.create("", "보상 2", "테스트 보상 2", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""))));
+		added.add(rewardInfoRepository.save(RewardInfo.create("", "보상 3", "테스트 보상 3", RewardCriteria.create(RewardCriteriaType.TEST_NULL_CRITERIA, ""))));
+		added.add(rewardInfoRepository.save(RewardInfo.create("", "보상 4", "테스트 보상 4", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""))));
 		
 		assertThat(rewardInfoService.getAllRewardInfo())
 		.containsAll(added);
@@ -59,10 +59,10 @@ class RewardInfoServiceTest {
 	@DisplayName("보상 형식 제거 테스트")
 	void testDeleteRewardInfo() {
 		List<RewardInfo> added = new ArrayList<RewardInfo>();
-		added.add(rewardInfoRepository.save(RewardInfo.create("보상 1", RewardCriteria.create(RewardCriteriaType.TEST_NULL_CRITERIA, ""))));
-		added.add(rewardInfoRepository.save(RewardInfo.create("보상 2", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""))));
-		added.add(rewardInfoRepository.save(RewardInfo.create("보상 3", RewardCriteria.create(RewardCriteriaType.TEST_NULL_CRITERIA, ""))));
-		added.add(rewardInfoRepository.save(RewardInfo.create("보상 4", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""))));
+		added.add(rewardInfoRepository.save(RewardInfo.create("", "보상 1", "테스트 보상 1", RewardCriteria.create(RewardCriteriaType.TEST_NULL_CRITERIA, ""))));
+		added.add(rewardInfoRepository.save(RewardInfo.create("", "보상 2", "테스트 보상 2", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""))));
+		added.add(rewardInfoRepository.save(RewardInfo.create("", "보상 3", "테스트 보상 3", RewardCriteria.create(RewardCriteriaType.TEST_NULL_CRITERIA, ""))));
+		added.add(rewardInfoRepository.save(RewardInfo.create("", "보상 4", "테스트 보상 4", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""))));
 		
 		rewardInfoService.deleteRewardInfo(added.get(1).getId());
 		rewardInfoService.deleteRewardInfo(added.get(3).getId());

--- a/tlog-was/src/test/java/com/se/Tlog/domain/Reward/Service/RewardServiceTest.java
+++ b/tlog-was/src/test/java/com/se/Tlog/domain/Reward/Service/RewardServiceTest.java
@@ -41,7 +41,7 @@ class RewardServiceTest {
 		        new UserRegisterInfo(
 		                new SsoUserInfo("TEST_PROVIDER_ID", "TEST_EMAIL", "dev.DEVELOPER_NAME", "NULL"),
 		                new RegisterUserProfileDto("00000000")));
-		RewardInfo testReward = RewardInfo.create("보상 1", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""));
+		RewardInfo testReward = RewardInfo.create("", "보상 1", "테스트 보상 1", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""));
 
 		userRepository.save(testUser);
 		rewardInfoRepository.save(testReward);
@@ -59,10 +59,10 @@ class RewardServiceTest {
 		                new RegisterUserProfileDto("00000000")));
 		
 		List<RewardInfo> added = new ArrayList<RewardInfo>();
-		added.add(rewardInfoRepository.save(RewardInfo.create("보상 1", RewardCriteria.create(RewardCriteriaType.TEST_NULL_CRITERIA, ""))));
-		added.add(rewardInfoRepository.save(RewardInfo.create("보상 2", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""))));
-		added.add(rewardInfoRepository.save(RewardInfo.create("보상 3", RewardCriteria.create(RewardCriteriaType.TEST_NULL_CRITERIA, ""))));
-		added.add(rewardInfoRepository.save(RewardInfo.create("보상 4", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""))));
+		added.add(rewardInfoRepository.save(RewardInfo.create("", "보상 1", "테스트 보상 1", RewardCriteria.create(RewardCriteriaType.TEST_NULL_CRITERIA, ""))));
+		added.add(rewardInfoRepository.save(RewardInfo.create("", "보상 2", "테스트 보상 2", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""))));
+		added.add(rewardInfoRepository.save(RewardInfo.create("", "보상 3", "테스트 보상 3", RewardCriteria.create(RewardCriteriaType.TEST_NULL_CRITERIA, ""))));
+		added.add(rewardInfoRepository.save(RewardInfo.create("", "보상 4", "테스트 보상 4", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""))));
 		
 		userRepository.save(testUser);
 		

--- a/tlog-was/src/test/java/com/se/Tlog/domain/Reward/Service/RewardServiceTest.java
+++ b/tlog-was/src/test/java/com/se/Tlog/domain/Reward/Service/RewardServiceTest.java
@@ -1,7 +1,7 @@
 package com.se.Tlog.domain.Reward.Service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import com.se.Tlog.domain.Reward.application.RewardService;
+import com.se.Tlog.domain.Reward.controller.dto.UserRewardDto;
 import com.se.Tlog.domain.Reward.domain.RewardCriteria;
 import com.se.Tlog.domain.Reward.domain.RewardCriteriaType;
 import com.se.Tlog.domain.Reward.domain.RewardInfo;
@@ -71,7 +72,11 @@ class RewardServiceTest {
 		assertThatNoException().isThrownBy(()->rewardService.addRewardToUser(testUser.getId(), added.get(2).getId()));
 		assertThatNoException().isThrownBy(()->rewardService.addRewardToUser(testUser.getId(), added.get(3).getId()));
 		
-		assertThat(rewardService.getAllRewardOfUser(testUser.getId()))
-		.containsAll(added);
+		List<UserRewardDto> result = rewardService.getAllRewardOfUser(testUser.getId());
+		assertEquals(result.size(), added.size());
+		for (int i = 0; i < result.size(); i++) {
+		    assertEquals(result.get(i).rewardId(), added.get(i).getId());
+		    assertEquals(result.get(i).name(), added.get(i).getName());
+		}
 	}
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #166 
- #167 

## 추가 및 변경사항
### 1) 보상 데이터에 아이콘, 설명 데이터 추가
- `RewardInfo` 엔티티에 `iconImageUrl`, `description` 속성이 추가되었습니다.
- 사용자에게 표시될 보상 정보를 나타내는 `UserRewardDto`가 추가되었습니다.
  - 사용자의 보상 조회시 이 DTO로 반환됩니다.
### 2) 사용자의 기본 표시 보상 기능 추가
- 마이페이지, 프로필 등에 기본으로 표시할 보상을 설정합니다.
- `Reward` 엔티티에 `isDefault` 속성이 추가되었습니다.
- 기본 보상을 설정하는 API가 추가되었습니다.
### 3) 기타 로직 리팩토링
- 보상 생성 API에 대한 DTO 파싱 로직이 기존 표현 계층(Controller)에서 응용 계층(Service)으로 이동되었습니다.
- 보상 조회 및 갱신과 관련된 쿼리의 N+1 문제가 개선되었습니다.

## 테스트 결과
- 이상 무.
  - 보상 데이터에 이미지, 설명이 포함됨 :
    <img src="https://github.com/user-attachments/assets/650ac86e-df6a-4734-b9b2-3f2185088b37" width="400"/>
    <img src="https://github.com/user-attachments/assets/53bf7da6-7568-4153-b908-824b67f8b874" width="400"/>
  - 사용자가 얻은 보상에서 기본 보상 설정
    <img src="https://github.com/user-attachments/assets/29becb2c-b284-47f5-b1aa-de86cd4d97cb" width="500"/>

## 📌 기타
