### PR TITLE
Feature: 팀 TBTI 조회 및 갱신 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamProfileService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamProfileService.java
@@ -1,0 +1,28 @@
+package com.se.Tlog.domain.Team.application;
+
+import java.util.UUID;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Tbti.domain.Tbti;
+import com.se.Tlog.domain.Team.domain.Team;
+import com.se.Tlog.domain.Team.repository.jpa.TeamRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class TeamProfileService {
+    private final TeamRepository teamRepository;
+    
+    @Transactional
+    public String updateTeamTbti(UUID teamId, int tbtiCode) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new CustomException(ErrorType.TEAM_NOT_FOUND));
+        team.setTbti(new Tbti(tbtiCode));
+        return team.getTbtiString();
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/TeamProfileController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/TeamProfileController.java
@@ -1,0 +1,52 @@
+package com.se.Tlog.domain.Team.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.se.Tlog.domain.Team.application.TeamProfileService;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/api/team")
+@RequiredArgsConstructor
+@Tag(name = "팀 프로필 관리")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
+public class TeamProfileController {
+	private final TeamProfileService teamProfileService;
+	
+	@PostMapping("/{teamId}/tbti")
+	@Operation (
+			summary = "팀 TBTI 변경",
+    		description = "팀의 TBTI를 변경합니다.<br><b>변경된 TBTI를 반환합니다. (SENA, ROLA 등)</b>",
+	        parameters = @Parameter(name = "tbti", example = "00127623", description = "TBTI 숫자 코드입니다. (0~99999999)"),
+			responses = {
+					@ApiResponse(responseCode = "200", description = "팀 TBTI 변경됨, 변경된 TBTI가 반환됩니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<String>> createTeam(
+	        @PathVariable(name = "teamId") UUID teamId,
+	        @RequestParam(name = "tbti") int tbtiValue) {
+		return ResponseEntity.ok(SuccessRes.of(SuccessType.OK,
+		        teamProfileService.updateTeamTbti(teamId, tbtiValue)));
+	}
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 public record TeamDetailDto(
         UUID teamId,
         String teamName,
-        //String teamTBTI,
+        String tbtiString,
         String inviteCode,
         LocalDate startDate,
         LocalDate endDate,
@@ -22,6 +22,7 @@ public record TeamDetailDto(
         return new TeamDetailDto(
                 team.getId(),
                 team.getName(),
+                team.getTbtiString(), // 만약 TBTI 설명까지 추가해야 할 경우, 여기서 처리하지 않고 외부에서 설명 DTO를 파라미터로 받을 것!
                 InviteCodeUtil.longToStr(team.getInviteCode()),
                 team.getCreatedAt().toLocalDate(),
                 LocalDate.now(),

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamMemberDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamMemberDto.java
@@ -6,14 +6,17 @@ import java.util.UUID;
 
 public record TeamMemberDto(
         UUID userId,
+        String profileImageUrl,
         String name,
+        String tbtiString,
         boolean isLeader
-        // profile, tbti
 ) {
     public static TeamMemberDto from(User user, boolean isLeader) {
         return new TeamMemberDto(
                 user.getId(),
+                user.getProfileImage(),
                 user.getName(),
+                user.getTbtiString(),
                 isLeader
         );
     }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/Team.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/Team.java
@@ -3,6 +3,7 @@ package com.se.Tlog.domain.Team.domain;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.se.Tlog.domain.Tbti.domain.Tbti;
 import com.se.Tlog.domain.Team.domain.repository.TeamRepositoryService;
 import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.global.exception.CustomException;
@@ -31,7 +32,7 @@ public class Team {
 	
 	private String name;
 	
-	// private Tbti tbti;
+	private Integer tbti;
 
 	@CreatedDate
 	@Column(updatable = false)
@@ -40,6 +41,7 @@ public class Team {
 	private Team(String name, Long inviteCode) {
 		this.name = name;
 		this.inviteCode = inviteCode;
+		this.tbti = null;
 	}
 	
 	public static Team create(
@@ -83,5 +85,16 @@ public class Team {
 		// 기타 팀원 삭제 후 처리내용
 		
 		log.info("팀원을 팀 " + this.name + "에서 제거합니다. : " + user.getName());
+	}
+	
+	public void setTbti(Tbti tbti) {
+	    this.tbti = tbti.getTbtiCode();
+	}
+	
+	public String getTbtiString() {
+	    if (tbti == null)
+	        return "아직 TBTI 검사가 진행되지 않았습니다!";
+	    else 
+	        return new Tbti(tbti).toString();
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/Team.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/domain/Team.java
@@ -88,7 +88,10 @@ public class Team {
 	}
 	
 	public void setTbti(Tbti tbti) {
-	    this.tbti = tbti.getTbtiCode();
+	    if (tbti == null)
+	        this.tbti = null;
+	    else
+	        this.tbti = tbti.getTbtiCode();
 	}
 	
 	public String getTbtiString() {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/User.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/User.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
+import com.se.Tlog.domain.Tbti.domain.Tbti;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -53,6 +55,8 @@ public class User {
                 userRegisterInfo.getEmail(), 
                 userRegisterInfo.getTbti().getTbtiCode());
     }
+    
+    public String getTbtiString() {return new Tbti(tbti).toString();}
 
     public void updateEmail(String email) {this.email = email;}
     public void updateSnsId(String snsId) {this.snsId = snsId;}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #169 

## 추가 및 변경사항
### 1) Team 엔티티에 TBTI 속성 추가
- TBTI 속성이 추가되었습니다. Nullable합니다.
- TBTI 속성을 설정하거나, 문자열(SENA)로 반환합니다.
  - null일 경우, TBTI 문자열 대신 안내문구가 표시됩니다.
    <img src="https://github.com/user-attachments/assets/e5b33b9d-b186-4323-ac95-913558d2babc" width="350"/>
### 2) 팀 상세 조회의 데이터 형식 변경
- 팀 TBTI 정보가 함께 반환됩니다.
- 팀원의 프로필 사진과 TBTI 정보가 함께 반환됩니다.
### 3) 팀 TBTI 변경 API 추가
- 팀 TBTI를 변경하는 API가 추가되었습니다.

## 테스트 결과
- 이상 무.
  - 팀 상세 조회의 데이터 변경사항 :
    1) 팀 TBTI 정보 추가
    2) 팀원 프로필사진, TBTI 정보 추가
    <img src="https://github.com/user-attachments/assets/7d8eaee4-05af-4c8b-8c17-42b90c90a934" width="400"/>
  - 팀 TBTI 변경 API
    <img src="https://github.com/user-attachments/assets/18ad35ec-4a5c-4d01-8b09-3dabbbf941cd" width="400"/>


## 📌 기타
