### PR TITLE
Feature: 사용자 TBTI 갱신 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiInfoService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiInfoService.java
@@ -28,8 +28,7 @@ public class TbtiInfoService {
                         request.description()));
     }
     
-    public TbtiInfoRes getTbtiInfo(String tbtiString) {
-        Tbti tbti = new Tbti(tbtiString);
+    public TbtiInfoRes getTbtiInfo(Tbti tbti) {
         TbtiInfo tbtiInfo = tbtiInfoRepository.findByTbtiString(tbti.toString());
         if (tbtiInfo == null)
             return TbtiInfoRes.getNullDto(tbti);
@@ -39,6 +38,10 @@ public class TbtiInfoService {
                     tbtiInfo.getImageUrl(),
                     tbtiInfo.getSecondName(),
                     tbtiInfo.getDescription());
+    }
+    
+    public TbtiInfoRes getTbtiInfo(String tbtiString) {
+        return getTbtiInfo(new Tbti(tbtiString));
     }
     
     public void deleteTbtiInfo(String tbtiString) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/UserService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/UserService.java
@@ -1,6 +1,9 @@
 package com.se.Tlog.domain.User.application;
 
 
+import com.se.Tlog.domain.Tbti.application.TbtiInfoService;
+import com.se.Tlog.domain.Tbti.controller.dto.TbtiInfoRes;
+import com.se.Tlog.domain.Tbti.domain.Tbti;
 import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.global.exception.CustomException;
@@ -20,6 +23,7 @@ import java.util.UUID;
 public class UserService {
     private final AccessTokenProvider accessTokenProvider;
     private final UserRepository userRepository;
+    private final TbtiInfoService tbtiInfoService;
 
     /*@Transactional
     public void updateEmail(UUID userId, String email) {
@@ -38,11 +42,21 @@ public class UserService {
                 .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
 
         user.updateSnsId(snsId);
+        // 위험 : 이전 토큰이 무효화되지 않아 이전 토큰이 여전히 사용가능!
         return accessTokenProvider.generateToken(
                 user.getId().toString(),
                 user.getRole().getValue(),
                 user.getSnsId()
         );
+    }
+    
+    @Transactional
+    public TbtiInfoRes updateUserTbti(UUID userId, int tbtiValue) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
+        Tbti newTbti = new Tbti(tbtiValue);
+        user.updateTbti(newTbti);
+        return tbtiInfoService.getTbtiInfo(newTbti);
     }
 
     @Transactional

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/UserController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.se.Tlog.domain.User.controller;
 
+import com.se.Tlog.domain.Tbti.controller.dto.TbtiInfoRes;
 import com.se.Tlog.domain.User.application.UserService;
 
 import com.se.Tlog.domain.User.controller.dto.ProfileImageRequest;
@@ -8,6 +9,7 @@ import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
 import com.se.Tlog.global.security.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -115,5 +117,23 @@ public class UserController {
         return ResponseEntity
                 .status(SuccessType.OK.getStatus())
                 .body(SuccessRes.from(SuccessType.OK));
+    }
+
+    @PostMapping("/tbti")
+    @Operation(
+            summary = "사용자 TBTI 변경",
+            description = "사용자의 TBTI를 변경합니다.<br><b>갱신된 TBTI의 설명을 반환합니다.</b>",
+            tags = { "User Profile" },
+            parameters = @Parameter(name = "tbti", example = "00127623", description = "TBTI 숫자 코드입니다. (0~99999999)"),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "사용자 TBTI 업데이트 성공"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    public ResponseEntity<SuccessRes<TbtiInfoRes>> uploadProfileImage(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestParam(name = "tbti") int tbtiValue) {
+        return ResponseEntity.ok(SuccessRes.from(
+                userService.updateUserTbti(UUID.fromString(user.getId()), tbtiValue)));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/UserController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/UserController.java
@@ -12,9 +12,6 @@ import com.se.Tlog.global.response.success.SuccessType;
 import com.se.Tlog.global.security.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Encoding;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
@@ -102,25 +99,21 @@ public class UserController {
 
     @Operation(
             summary = "프로필 이미지 업로드",
-            description = "사용자의 프로필 이미지를 업로드하고 Firebase Storage에 저장된 CDN URL을 반환합니다."
+            description = "사용자의 프로필 이미지를 설정 또는 수정합니다."
                         + "<br><br><b>인증 토큰이 필요합니다!</b>",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    required = true,
-                    content = @Content(
-                            mediaType = "multipart/form-data",
-                            schema = @Schema(type = "object", requiredProperties = { "file" }),
-                            encoding = @Encoding(name = "file", contentType = "image/*")
-                    )
+                    description = "프로필 이미지 업데이트 요청 (imageUrl 필드 필수)",
+                    required = true
             ),
             responses = {
-                    @ApiResponse(responseCode = "200", description = "이미지 업로드 성공 (imageUrl 반환)"),
+                    @ApiResponse(responseCode = "200", description = "이미지 업로드 성공"),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 데이터 입니다."),
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류")
             },
             tags = { "User Profile" }
     )
     @PostMapping("/profile-image")
-    public ResponseEntity<?> uploadProfileImage(
+    public ResponseEntity<SuccessRes<?>> uploadProfileImage(
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestBody ProfileImageRequest request
     ) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/UserController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/UserController.java
@@ -5,6 +5,8 @@ import com.se.Tlog.domain.User.application.UserService;
 
 import com.se.Tlog.domain.User.controller.dto.ProfileImageRequest;
 import com.se.Tlog.domain.User.controller.dto.SnsIdUpdateRequest;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
 import com.se.Tlog.global.security.dto.CustomUserDetails;
@@ -14,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,6 +28,9 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
 public class UserController {
 
     private final UserService userService;
@@ -37,7 +43,7 @@ public class UserController {
     /*@PatchMapping("/email")
     @Operation(
             summary = "사용자 email 업데이트",
-            description = "사용자 본인의 이메일을 설정 또는 수정합니다.",
+            description = "사용자 본인의 이메일을 설정 또는 수정합니다.<br><br><b>인증 토큰이 필요합니다!</b>",
             tags = {"User"},
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "사용자 이메일 업데이트 합니다.",
@@ -52,6 +58,8 @@ public class UserController {
     public ResponseEntity<?> updateEmail(
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestBody EmailUpdateRequest request) {
+        if (user == null)
+            throw new CustomException(ErrorType.UN_AUTHENTICATION);
 
         userService.updateEmail(UUID.fromString(user.getId()),request.email());
         return ResponseEntity
@@ -64,7 +72,8 @@ public class UserController {
             summary = "SNS ID(유저명) 업데이트",
             description = """
         사용자 본인의 SNS ID(서비스 내 고유 사용자명)를 설정 또는 수정합니다.  
-        중복된 SNS ID는 사용할 수 없습니다. 
+        중복된 SNS ID는 사용할 수 없습니다.
+        <br><br><b>인증 토큰이 필요합니다!</b>
         """,
             tags = {"User"},
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -81,6 +90,8 @@ public class UserController {
     public ResponseEntity<?> updateSnsId(
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestBody SnsIdUpdateRequest request) {
+        if (user == null)
+            throw new CustomException(ErrorType.UN_AUTHENTICATION);
 
         String newAccessToken = userService.updateSnsId(UUID.fromString(user.getId()), request.snsId());
         return ResponseEntity
@@ -91,7 +102,8 @@ public class UserController {
 
     @Operation(
             summary = "프로필 이미지 업로드",
-            description = "사용자의 프로필 이미지를 업로드하고 Firebase Storage에 저장된 CDN URL을 반환합니다.",
+            description = "사용자의 프로필 이미지를 업로드하고 Firebase Storage에 저장된 CDN URL을 반환합니다."
+                        + "<br><br><b>인증 토큰이 필요합니다!</b>",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
                     content = @Content(
@@ -112,6 +124,8 @@ public class UserController {
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestBody ProfileImageRequest request
     ) {
+        if (user == null)
+            throw new CustomException(ErrorType.UN_AUTHENTICATION);
         userService.uploadProfileImage(user.getId(), request.imageUrl());
 
         return ResponseEntity
@@ -122,7 +136,8 @@ public class UserController {
     @PostMapping("/tbti")
     @Operation(
             summary = "사용자 TBTI 변경",
-            description = "사용자의 TBTI를 변경합니다.<br><b>갱신된 TBTI의 설명을 반환합니다.</b>",
+            description = "사용자의 TBTI를 변경합니다.<br><b>갱신된 TBTI의 설명을 반환합니다.</b>"
+                        + "<br><br><b>인증 토큰이 필요합니다!</b>",
             tags = { "User Profile" },
             parameters = @Parameter(name = "tbti", example = "00127623", description = "TBTI 숫자 코드입니다. (0~99999999)"),
             responses = {
@@ -133,6 +148,8 @@ public class UserController {
     public ResponseEntity<SuccessRes<TbtiInfoRes>> uploadProfileImage(
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestParam(name = "tbti") int tbtiValue) {
+        if (user == null)
+            throw new CustomException(ErrorType.UN_AUTHENTICATION);
         return ResponseEntity.ok(SuccessRes.from(
                 userService.updateUserTbti(UUID.fromString(user.getId()), tbtiValue)));
     }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/User.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/User.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
+import com.se.Tlog.domain.Tbti.domain.Tbti;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -57,4 +59,5 @@ public class User {
     public void updateEmail(String email) {this.email = email;}
     public void updateSnsId(String snsId) {this.snsId = snsId;}
     public void updateProfileImage(String profileImage) {this.profileImage = profileImage;}
+    public void updateTbti(Tbti tbti) {this.tbti = tbti.getTbtiCode();}
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #171 

## 추가 및 변경사항
### 1) 사용자 TBTI 갱신 기능 추가
- 사용자의 TBTI를 갱신하는 API가 추가되었습니다.
  <img src="https://github.com/user-attachments/assets/12f902ad-e094-4107-87ba-e1ab82ff80da" width="400"/>
### 2) 사용자 프로필사진 변경 API 수정
- 프로필사진 변경 API의 Swagger 문서화가 옛 버전이라, 최신 상태로 업데이트하였습니다.
  <img src="https://github.com/user-attachments/assets/20e2f64f-3220-4c75-8d4d-25f503c2ef91" width="400"/>
### 3) 기타 변경사항
- User도메인 내 토큰 인증이 요구되는 API마다
  인증 실패시 500 에러 대신 401 에러를 반환하도록 변경되었습니다.

## 테스트 결과
- 이상 무.

## 📌 기타
