### PR TITLE
Fix: 권한 없는 사용자가 팀을 삭제할 수 있는 문제 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
@@ -90,9 +90,12 @@ public class TeamService {
 		.toList();
 	}
 	
-	public void deleteTeam(UUID teamId) {
+	public void deleteTeam(UUID requesterId, UUID teamId) {
 		if (!teamRepository.existsById(teamId))
 			throw new CustomException(ErrorType.TEAM_NOT_FOUND);
+		TeamUserJpaEntity teamUser = teamUserRepository.findByTeam_IdAndUser_Id(teamId, requesterId).orElse(null);
+		if (teamUser == null || !teamUser.isLeader())
+		    throw new CustomException(ErrorType.UN_AUTHORIZATION);
 		
 		teamDomainService.deleteTeamData(teamRepository.findById(teamId).get());
 		teamRepository.deleteById(teamId);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/TeamController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/TeamController.java
@@ -28,11 +28,16 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @Controller
 @RequestMapping("/api/team")
 @RequiredArgsConstructor
+@Tag(name = "팀 관리")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
 public class TeamController {
 	private final TeamService teamService;
 	
@@ -40,10 +45,6 @@ public class TeamController {
 	@Operation (
 			summary = "팀 생성",
     		description = "새로운 여행 팀을 생성하고 팀 채팅방이 자동으로 생성됩니다.",
-			tags = {"팀 관리"},
-			security = @SecurityRequirement(
-					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
-					scopes = {"scope1", "scope2"}),
 			responses = {
 					@ApiResponse(responseCode = "200", description = "채팅방이 자동으로 생성되었습니다. 팀원들과 소통을 시작해보세요!"),
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류. 팀 생성에 실패했습니다.",
@@ -58,10 +59,6 @@ public class TeamController {
 	@Operation (
 			summary = "팀 조회",
     		description = "특정 유저가 속한 팀을 모두 표시합니다.",
-			tags = {"팀 관리"},
-			security = @SecurityRequirement(
-					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
-					scopes = {"scope1", "scope2"}),
 			responses = {
 					@ApiResponse(responseCode = "200", description = "처리 성공."),
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류. 팀 생성에 실패했습니다.",
@@ -76,11 +73,6 @@ public class TeamController {
 	@Operation(
 			summary = "특정 팀 상세 정보 조회",
 			description = "특정 팀의 상세 정보와 장바구니 여행지 목록을 함께 반환합니다.",
-			tags = {"팀 관리"},
-			security = @SecurityRequirement(
-					name = "JwtAuthScheme",
-					scopes = {"scope1", "scope2"}
-			),
 			parameters = {
 					@Parameter(name = "teamId", description = "조회할 팀의 UUID", required = true)
 			},
@@ -99,10 +91,6 @@ public class TeamController {
 	@Operation (
 			summary = "팀 삭제",
     		description = "기존 팀을 삭제합니다.",
-			tags = {"팀 관리"},
-			security = @SecurityRequirement(
-					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
-					scopes = {"scope1", "scope2"}),
 			parameters = {
 					@Parameter(name = "teamId", description = "삭제할 팀의 id")
 			},
@@ -120,10 +108,6 @@ public class TeamController {
 	@Operation (
 			summary = "팀원 초대",
     		description = "새로운 팀원을 초대합니다.",
-			tags = {"팀 관리"},
-			security = @SecurityRequirement(
-					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
-					scopes = {"scope1", "scope2"}),
 			responses = {
 					@ApiResponse(responseCode = "200", description = "처리 성공. 해당 유저에게 초대 요청을 보냅니다."),
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류. 유저 초대에 실패했습니다.",
@@ -138,10 +122,6 @@ public class TeamController {
 	@Operation (
 			summary = "팀원 가입",
     		description = "특정 유저를 팀에 추가합니다.",
-			tags = {"팀 관리"},
-			security = @SecurityRequirement(
-					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
-					scopes = {"scope1", "scope2"}),
 			responses = {
 					@ApiResponse(responseCode = "200", description = "처리 성공. 해당 유저에게 초대 요청을 보냅니다."),
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류. 유저 초대에 실패했습니다.",
@@ -156,10 +136,6 @@ public class TeamController {
 	@Operation (
 			summary = "팀원 삭제",
     		description = "팀에서 특정 유저를 삭제합니다.",
-			tags = {"팀 관리"},
-			security = @SecurityRequirement(
-					name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
-					scopes = {"scope1", "scope2"}),
 			parameters = {
 					@Parameter(name = "teamId", description = "팀원이 제거될 팀의 id"),
 					@Parameter(name = "userId", description = "제거될 유저의 id")

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/TeamController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/TeamController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import com.se.Tlog.domain.Team.controller.dto.TeamCreateRes;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,9 +19,12 @@ import com.se.Tlog.domain.Team.application.TeamService;
 import com.se.Tlog.domain.Team.controller.dto.CreateTeamRequestDto;
 import com.se.Tlog.domain.Team.controller.dto.TeamResponseDto;
 import com.se.Tlog.domain.Team.controller.dto.TeamUserRequestDto;
+import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.error.ErrorType;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
+import com.se.Tlog.global.security.dto.CustomUserDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -51,6 +55,7 @@ public class TeamController {
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
 	public ResponseEntity<SuccessRes<TeamCreateRes>> createTeam(@RequestBody CreateTeamRequestDto request) {
+	    // 추후 인증 토큰을 사용해, 타 사용자의 명의로 팀을 생성하지 못하도록 변경 예정
 		return ResponseEntity.ok(SuccessRes.of(SuccessType.TEAM_CREATE_SUCCESS,
 				teamService.createTeam(request)));
 	}
@@ -65,6 +70,7 @@ public class TeamController {
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
 	public ResponseEntity<SuccessRes<List<TeamResponseDto>>> getMyTeam(@RequestParam(name = "userId") UUID userId) {
+	    // 추후 인증 토큰을 사용해, 타 사용자의 팀을 함부로 조회하지 못하도록 변경 예정
 		return ResponseEntity.ok(SuccessRes.from(
 				teamService.getTeamOfUser(userId)));
 	}
@@ -83,6 +89,7 @@ public class TeamController {
 			}
 	)
 	public ResponseEntity<?> getTeamDetails(@PathVariable UUID teamId) {
+	    // 추후 인증 토큰을 사용해, 타 사용자의 팀을 함부로 조회하지 못하도록 변경 예정
 		return ResponseEntity.
 				ok(SuccessRes.from(teamService.getTeamDetails(teamId)));
 	}
@@ -90,7 +97,9 @@ public class TeamController {
 	@DeleteMapping("/{teamId}")
 	@Operation (
 			summary = "팀 삭제",
-    		description = "기존 팀을 삭제합니다.",
+    		description = "기존 팀을 삭제합니다."
+    		            + "<br>팀장만 팀을 삭제할 수 있습니다."
+    		            + "<br><br><b>인증 토큰이 필요합니다!</b>",
 			parameters = {
 					@Parameter(name = "teamId", description = "삭제할 팀의 id")
 			},
@@ -99,8 +108,13 @@ public class TeamController {
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류. 팀 삭제에 실패했습니다.",
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
-	public ResponseEntity<SuccessRes<?>> deleteTeam(@PathVariable(name = "teamId") UUID teamId) {
-		teamService.deleteTeam(teamId);
+	public ResponseEntity<SuccessRes<?>> deleteTeam(
+	        @AuthenticationPrincipal CustomUserDetails user,
+	        @PathVariable(name = "teamId") UUID teamId) {
+	    if (user == null)
+	        throw new CustomException(ErrorType.UN_AUTHENTICATION);
+	    
+		teamService.deleteTeam(UUID.fromString(user.getId()), teamId);
 		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
 	}
 
@@ -128,6 +142,7 @@ public class TeamController {
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
 	public ResponseEntity<SuccessRes<?>> addUser(@RequestBody TeamUserRequestDto request) {
+	    // 추후 인증 토큰을 사용해, 타 사용자의 팀 가입을 조작하지 못하도록 변경 예정
 		teamService.joinTeamByInviteCode(request);
 		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
 	}
@@ -146,6 +161,7 @@ public class TeamController {
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
 	public ResponseEntity<SuccessRes<?>> deleteTeam(@PathVariable(name = "teamId") UUID teamId, @PathVariable(name = "userId") UUID userId) {
+	    // 추후 인증 토큰을 사용해, 권한 없이 강제 탈퇴를 조작하지 못하도록 변경 예정
 		teamService.leaveTeam(teamId, userId);
 		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
 	}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #173 

## 추가 및 변경사항
- 팀 삭제 로직에서 반드시 인증 토큰을 받도록 변경되었습니다.
- 팀 삭제는 팀장만 허용되도록 변경되었습니다.

## 테스트 결과
- 이상 무.
  <img src="https://github.com/user-attachments/assets/55cce438-5b85-4fc7-ab99-66a61ee52665" width="450"/>

## 📌 기타
- 팀 도메인 외에도, 여러 API에서 다른 사용자를 가장해 기능 실행이 가능한 것으로 보입니다.
  관련 문제는 ![노션 페이지](https://www.notion.so/20ac8b877abb8055b577fa767e5c9d7c?source=copy_link)에 기록되었습니다.
