### PR TITLE
Feature : STOMP CONNECTED 응답 시 user-name 헤더 누락 방지 코드 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/global/security/handler/StompHandler.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/security/handler/StompHandler.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
@@ -32,5 +33,20 @@ public class StompHandler implements ChannelInterceptor {
         }
 
         return ChannelInterceptor.super.preSend(message, channel);
+    }
+
+    @Override
+    public void postSend(Message<?> message, MessageChannel channel, boolean sent) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            Principal user = accessor.getUser();
+            if (user instanceof CustomPrincipal customPrincipal) {
+                String nickname = customPrincipal.nickname();
+                accessor.addNativeHeader("user-name", nickname != null ? nickname : "null");
+            } else {
+                accessor.addNativeHeader("user-name", "null");
+            }
+        }
     }
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #177 

## 추가 및 변경사항
프론트엔드 쪽에서  STOMP CONNECT 프레임 응답시 user-name 헤더에 대해 강제 파싱이 되는 구조인 듯 합니다. 그래서 user-name에 대한 값을 기존에 넣지 않아서 프론트측에서 파싱 오류(항상 user-name에 대한 값이 있다고 가정 하여 없을 때 오류)가 발생하는 문제가 발생하였습니다. 따라서 항상 "user-name"에 값을 넣어주는 구조로 작성하였습니다!

## 📌 기타
- 프론트측과 계속해서 테스트 하며 수정하도록 하겠습니다.
