### PR TITLE
Fix: Swagger에서 https 요청을 하지 않는 문제 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/config/openapi/OpenApiConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/openapi/OpenApiConfig.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.servers.Server;
 
 @OpenAPIDefinition( // Swagger UI 페이지 설정
         info = @Info(
@@ -15,7 +16,10 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
                 description = "Tlog 백엔드 서버의 API 명세를 기록한 문서입니다."
                 // license = @License(name = "Apache 2.0", url = "http://foo.bar"),
                 // contact = @Contact(url = "http://myserver.com", name = "name", email = "name@email.com")
-        )
+        ),
+        servers = {
+                @Server(url = "/", description = "서버 선택")
+        }
 )
 @SecurityScheme ( // Swagger UI 페이지 내 인증 기능 설정
 		name = "JwtAuthScheme",


### PR DESCRIPTION
## 작업 동기 및 이슈
- #179 
- 도메인을 적용하고 nginx를 도입하게 되면서 네트워크가 https 환경으로 구성되었으나,
  swagger는 **여전히 http 요청만** 보내고 있는 문제가 발생했습니다.

## 추가 및 변경사항
- Swagger 설정에 요청 주소 자동지정이 추가되었습니다.
  - 요청에 사용할 URL 주소에 `/`을 지정하면
    **해당 페이지를 불러온 url 호스트**로 자동 지정하게 됩니다.

## 테스트 결과
- 이상 무.
  기존엔 http로 요청되었으나, 이제 https로 원활히 요청됩니다.
  <img src="https://github.com/user-attachments/assets/82ace3dc-06ad-47af-9ee4-7219d634dcbf" width="500"/>

## 📌 기타
