### PR TITLE
Feature: SNS 프로필(마이페이지) 조회 및 프로필 설명 변경 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/repository/jpa/FollowRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/repository/jpa/FollowRepository.java
@@ -20,4 +20,7 @@ public interface FollowRepository extends JpaRepository<Follow, UUID> {
 
     @Query("select f.fromUserId from Follow f where f.toUserId = :toUserId")
     Page<UUID> findFromUserIdsByToUserId(@Param("toUserId") UUID toUserId, Pageable pageable);
+    
+    int countByFromUserId(UUID fromUserId);
+    int countByToUserId(UUID toUserId);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Profile/application/SnsProfileService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Profile/application/SnsProfileService.java
@@ -1,0 +1,61 @@
+package com.se.Tlog.domain.Social.Profile.application;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Social.Follow.repository.jpa.FollowRepository;
+import com.se.Tlog.domain.Social.Post.application.PostService;
+import com.se.Tlog.domain.Social.Post.controller.dto.PostPreviewRes;
+import com.se.Tlog.domain.Social.Profile.controller.dto.SnsProfileRes;
+import com.se.Tlog.domain.Social.Profile.controller.dto.UpdateSnsDescriptionReq;
+import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class SnsProfileService {
+    private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+    private final PostService postService;
+    
+    private static final int POST_COUNT_OF_FIRST_PAGE = 24;
+    private static final String DEFAULT_SNS_DESCRIPTION = "나에 대한 설명글을 입력하세요";
+    
+    @Transactional
+    public void updateSnsDescription(UUID userId, UpdateSnsDescriptionReq request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
+        if (request == null || request.description() == null)
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        user.updateSnsDescription(request.description());
+    }
+    
+    public SnsProfileRes getSnsProfile(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
+        String snsDescription = (null == user.getSnsDescription())
+                ? DEFAULT_SNS_DESCRIPTION
+                : user.getSnsDescription();
+        
+        int followerCount = followRepository.countByToUserId(userId);
+        int followingCount = followRepository.countByFromUserId(userId);
+        Page<PostPreviewRes> posts = postService.getPreviewUserPosts(userId, PageRequest.of(0, POST_COUNT_OF_FIRST_PAGE));
+        
+        return new SnsProfileRes(
+                user.getName(),
+                user.getProfileImage(),
+                snsDescription,
+                posts.getTotalElements(),
+                followerCount,
+                followingCount,
+                posts);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Profile/controller/SnsProfileController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Profile/controller/SnsProfileController.java
@@ -1,0 +1,79 @@
+package com.se.Tlog.domain.Social.Profile.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.se.Tlog.domain.Social.Profile.application.SnsProfileService;
+import com.se.Tlog.domain.Social.Profile.controller.dto.SnsProfileRes;
+import com.se.Tlog.domain.Social.Profile.controller.dto.UpdateSnsDescriptionReq;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.error.ErrorType;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+import com.se.Tlog.global.security.dto.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/api/sns/profile")
+@RequiredArgsConstructor
+@Tag(name = "SNS 프로필")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
+public class SnsProfileController {
+    private final SnsProfileService snsProfileService;
+    
+    @PostMapping("/sns-description")
+    @Operation (
+            summary = "SNS 프로필의 한 줄 설명글 변경",
+            description = "SNS 프로필의 한 줄 설명글을 변경합니다."
+                        + "<br><br><b>인증 토큰이 필요합니다!</b>",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<?>> updateSnsDescription(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody UpdateSnsDescriptionReq request) {
+        if (user == null)
+            throw new CustomException(ErrorType.UN_AUTHENTICATION);
+        
+        snsProfileService.updateSnsDescription(UUID.fromString(user.getId()), request);
+        return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+    }
+    
+    @GetMapping
+    @Operation (
+            summary = "SNS 프로필 조회",
+            description = "사용자의 SNS 프로필을 조회합니다."
+                        + "<br><br><b>인증 토큰이 필요합니다!</b>",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<SnsProfileRes>> getSnsProfile(
+            @AuthenticationPrincipal CustomUserDetails user) {
+        if (user == null)
+            throw new CustomException(ErrorType.UN_AUTHENTICATION);
+        
+        return ResponseEntity.ok(SuccessRes.from(
+                snsProfileService.getSnsProfile((UUID.fromString(user.getId())))));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Profile/controller/dto/SnsProfileRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Profile/controller/dto/SnsProfileRes.java
@@ -1,0 +1,22 @@
+package com.se.Tlog.domain.Social.Profile.controller.dto;
+
+import org.springframework.data.domain.Page;
+
+import com.se.Tlog.domain.Social.Post.controller.dto.PostPreviewRes;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "SNS 프로필을 조회하는 데이터 형식입니다.")
+public record SnsProfileRes(
+        String username,
+        String profileImageUrl,
+        String snsDescription,
+        
+        Long postCount,
+        int followerCount,
+        int followingCount,
+        
+        @Schema(description = "프로필에서 보여줄 게시글 미리보기의 첫 페이징입니다. (첫 갯수 24개) -> 추가 조회는 게시글 미리보기 api를 사용할 것!")
+        Page<PostPreviewRes> posts) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Profile/controller/dto/UpdateSnsDescriptionReq.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Profile/controller/dto/UpdateSnsDescriptionReq.java
@@ -1,0 +1,9 @@
+package com.se.Tlog.domain.Social.Profile.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "SNS 프로필에 표시할 한 줄 설명글을 변경하는 데이터형식입니다.")
+public record UpdateSnsDescriptionReq(
+        String description) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/User.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/User.java
@@ -25,6 +25,7 @@ public class User {
     private String email;
 
     private String snsId;
+    private String snsDescription;
     
     private int tbti;
     //private String telephoneNumber; 사용자가 동의하지 않은 경우 못받을 수 있음 nullable 하게 관리
@@ -60,6 +61,7 @@ public class User {
 
     public void updateEmail(String email) {this.email = email;}
     public void updateSnsId(String snsId) {this.snsId = snsId;}
+    public void updateSnsDescription(String snsDescription) {this.snsDescription = snsDescription;}
     public void updateProfileImage(String profileImage) {this.profileImage = profileImage;}
     public void updateTbti(Tbti tbti) {this.tbti = tbti.getTbtiCode();}
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #181 
- SNS 프로필의 한 줄 설명 변경기능 추가

## 추가 및 변경사항
### 1) SNS 프로필 조회 기능 추가
- 몇가지의 사용자 정보와 한 줄 설명(**없을 경우 기본 문구 표시**)이 포함됩니다.
- 해당 사용자의 게시글은 페이징된 첫 페이지가 표시됩니다. (첫 페이지 갯수는 24개)
  <img src="https://github.com/user-attachments/assets/296f5b3a-24e7-47f3-ab76-08a4f46789bc" width="400"/>
  <img src="https://github.com/user-attachments/assets/2f73e43e-88f7-4dcb-b87e-8d4d75de9f64" width="400"/>

### 2) SNS 프로필 한 줄 설명 변경 기능 추가
- User 엔티티에 snsDescription 속성이 추가되었습니다.
- 한 줄 설명을 변경하는 API가 추가되었습니다.
   <img src="https://github.com/user-attachments/assets/c8702125-d7d2-47ad-a057-1bc302bf3f31" width="400"/>

## 테스트 결과
- 이상 무.

## 📌 기타
