### PR TITLE
Feature: 장바구니/스크랩 조회시 위치 정보 포함

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
@@ -16,11 +16,11 @@ import com.se.Tlog.domain.Team.domain.repository.TeamRepositoryService;
 import com.se.Tlog.domain.Team.repository.jpa.TeamRepository;
 import com.se.Tlog.domain.Team.repository.jpa.TeamUserRepository;
 import com.se.Tlog.domain.Team.repository.jpa.entity.TeamUserJpaEntity;
-import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
 import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.domain.Wishlist.application.ShoppingCartService;
 import com.se.Tlog.domain.Wishlist.domain.OwnerType;
+import com.se.Tlog.domain.Wishlist.domain.dto.WishlistDestinationRes;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 
@@ -140,7 +140,7 @@ public class TeamService {
 				        TeamMemberDto.from(teamUser.getUser(), teamUser.isLeader())
 		        ).toList();
 
-		List<SimpleDestinationRes> wishList = shoppingCartService.getCartData(team.getId(), OwnerType.TEAM);
+		List<WishlistDestinationRes> wishList = shoppingCartService.getCartData(team.getId(), OwnerType.TEAM);
 
 		return TeamDetailDto.from(team, memberDtoList, wishList);
 	}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
@@ -2,7 +2,7 @@ package com.se.Tlog.domain.Team.controller.dto;
 
 import com.se.Tlog.domain.Team.domain.InviteCodeUtil;
 import com.se.Tlog.domain.Team.domain.Team;
-import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
+import com.se.Tlog.domain.Wishlist.domain.dto.WishlistDestinationRes;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -16,9 +16,9 @@ public record TeamDetailDto(
         LocalDate startDate,
         LocalDate endDate,
         List<TeamMemberDto> members,
-        List<SimpleDestinationRes> wishlist
+        List<WishlistDestinationRes> wishlist
 ) {
-    public static TeamDetailDto from(Team team, List<TeamMemberDto> members, List<SimpleDestinationRes> wishlist) {
+    public static TeamDetailDto from(Team team, List<TeamMemberDto> members, List<WishlistDestinationRes> wishlist) {
         return new TeamDetailDto(
                 team.getId(),
                 team.getName(),

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ScrapService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ScrapService.java
@@ -6,12 +6,12 @@ import java.util.UUID;
 
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Travel.application.CustomTagService;
-import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
 import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.domain.TagCount;
 import com.se.Tlog.domain.Wishlist.domain.OwnerType;
 import com.se.Tlog.domain.Wishlist.domain.WishlistService;
 import com.se.Tlog.domain.Wishlist.domain.WishlistType;
+import com.se.Tlog.domain.Wishlist.domain.dto.WishlistDestinationRes;
 import com.se.Tlog.domain.Wishlist.domain.dto.WishlistOwnerDto;
 
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,7 @@ public class ScrapService {
 	private final WishlistService wishlistService;
 	private final CustomTagService customTagService;
 	
-	public List<SimpleDestinationRes> getScrapData(UUID userId) {
+	public List<WishlistDestinationRes> getScrapData(UUID userId) {
 	    List<Destination> destinations = 
 	            wishlistService.getWishlistData(
 	                    new WishlistOwnerDto(
@@ -36,7 +36,7 @@ public class ScrapService {
                 3);
         
 		return destinations.stream()
-		        .map(destination ->  SimpleDestinationRes.from(
+		        .map(destination ->  WishlistDestinationRes.from(
 		                destination, 
 		                tagCountMap.get(destination.getId())))
 		        .toList();

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ShoppingCartService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/application/ShoppingCartService.java
@@ -6,12 +6,12 @@ import java.util.UUID;
 
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Travel.application.CustomTagService;
-import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
 import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.domain.TagCount;
 import com.se.Tlog.domain.Wishlist.domain.OwnerType;
 import com.se.Tlog.domain.Wishlist.domain.WishlistService;
 import com.se.Tlog.domain.Wishlist.domain.WishlistType;
+import com.se.Tlog.domain.Wishlist.domain.dto.WishlistDestinationRes;
 import com.se.Tlog.domain.Wishlist.domain.dto.WishlistOwnerDto;
 
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,7 @@ public class ShoppingCartService {
 	private final WishlistService wishlistService;
 	private final CustomTagService customTagService;
 
-	public List<SimpleDestinationRes> getCartData(UUID ownerId, OwnerType ownerType) {
+	public List<WishlistDestinationRes> getCartData(UUID ownerId, OwnerType ownerType) {
 	    List<Destination> destinations = 
                 wishlistService.getWishlistData(
                         new WishlistOwnerDto(
@@ -36,7 +36,7 @@ public class ShoppingCartService {
                 3);
         
         return destinations.stream()
-                .map(destination ->  SimpleDestinationRes.from(
+                .map(destination ->  WishlistDestinationRes.from(
                         destination, 
                         tagCountMap.get(destination.getId())))
                 .toList();

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ScrapController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ScrapController.java
@@ -3,7 +3,6 @@ package com.se.Tlog.domain.Wishlist.contoller;
 import java.util.List;
 import java.util.UUID;
 
-import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.se.Tlog.domain.Wishlist.application.ScrapService;
+import com.se.Tlog.domain.Wishlist.domain.dto.WishlistDestinationRes;
 import com.se.Tlog.global.response.error.ErrorRes;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
@@ -48,7 +48,7 @@ public class ScrapController {
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
-	public ResponseEntity<SuccessRes<List<SimpleDestinationRes>>> getScrapList(@PathVariable(name = "userId") UUID userId) {
+	public ResponseEntity<SuccessRes<List<WishlistDestinationRes>>> getScrapList(@PathVariable(name = "userId") UUID userId) {
 		return ResponseEntity.ok(SuccessRes.from(
 				scrapService.getScrapData(userId)));
 	}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ShoppingCartController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/contoller/ShoppingCartController.java
@@ -3,7 +3,6 @@ package com.se.Tlog.domain.Wishlist.contoller;
 import java.util.List;
 import java.util.UUID;
 
-import com.se.Tlog.domain.Travel.controller.dto.SimpleDestinationRes;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.se.Tlog.domain.Wishlist.application.ShoppingCartService;
 import com.se.Tlog.domain.Wishlist.domain.OwnerType;
+import com.se.Tlog.domain.Wishlist.domain.dto.WishlistDestinationRes;
 import com.se.Tlog.global.response.error.ErrorRes;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
@@ -49,7 +49,7 @@ public class ShoppingCartController {
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
-	public ResponseEntity<SuccessRes<List<SimpleDestinationRes>>> getCartOfUser(@PathVariable(name = "userId") UUID userId) {
+	public ResponseEntity<SuccessRes<List<WishlistDestinationRes>>> getCartOfUser(@PathVariable(name = "userId") UUID userId) {
 		return ResponseEntity.ok(SuccessRes.from(
 				shoppingCartService.getCartData(userId, OwnerType.USER)));
 	}
@@ -100,7 +100,7 @@ public class ShoppingCartController {
 					@ApiResponse(responseCode = "500", description = "서버 내부 오류.",
 							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
 	)
-	public ResponseEntity<SuccessRes<List<SimpleDestinationRes>>> getCartOfTeam(@PathVariable(name = "teamId") UUID teamId) {
+	public ResponseEntity<SuccessRes<List<WishlistDestinationRes>>> getCartOfTeam(@PathVariable(name = "teamId") UUID teamId) {
 		return ResponseEntity.ok(SuccessRes.from(
 				shoppingCartService.getCartData(teamId, OwnerType.TEAM)));
 	}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/dto/WishlistDestinationRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Wishlist/domain/dto/WishlistDestinationRes.java
@@ -1,0 +1,28 @@
+package com.se.Tlog.domain.Wishlist.domain.dto;
+
+
+import com.se.Tlog.domain.Travel.domain.Destination;
+import com.se.Tlog.domain.Travel.domain.Location;
+import com.se.Tlog.domain.Travel.domain.TagCount;
+
+import java.util.List;
+
+public record WishlistDestinationRes(
+        String id,
+        String name,
+        Location location,
+        String imageUrl,
+        String description,
+        List<TagCount> tagCountList
+) {
+    public static WishlistDestinationRes from(Destination destination, List<TagCount> topTags) {
+        return new WishlistDestinationRes(
+                destination.getId(),
+                destination.getName(),
+                destination.getLocation(),
+                destination.getImageUrl(),
+                destination.getDescription(),
+                topTags
+        );
+    }
+}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #187 

## 추가 및 변경사항
- Wishlist 도메인의 별도 DTO 도입
  - 기존 장바구니/스크랩에서 여행지 정보는 `SimpleDestinationRes`을 사용하고 있었음.
  - 그러나 장바구니/스크랩 고유의 여행지 정보가 요구됨 -> 기존 DTO의 의존성을 유지하면 다른 영역까지 변경의 영향이 미침
  - 이에 따라 `WishlistDestinationRes`를 도입했습니다.
- 장바구니/스크랩 정보 조회시 기존 대비 `location` 필드 하나가 더 추가되었습니다.

## 테스트 결과
- 이상 무.
  장바구니/스크랩 조회 결과에 `location` 필드가 추가되었습니다.
  <img src="https://github.com/user-attachments/assets/1fadc035-b8e8-477f-b93d-7834ce9bfdde" width="400"/>


## 📌 기타
