### PR TITLE
Feature: 팔로워들의 최근 게시물 조회 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Course/repository/mongo/CourseRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Course/repository/mongo/CourseRepository.java
@@ -1,8 +1,10 @@
 package com.se.Tlog.domain.Course.repository.mongo;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
@@ -15,12 +17,8 @@ import com.se.Tlog.domain.Course.repository.dto.CourseDistrictsDto;
 public interface CourseRepository extends MongoRepository<Course, String> {
     List<Course> findAllByOwnerIdAndOwnerType(UUID ownerId, OwnerType ownerType);
     
-    @Aggregation(pipeline = {
-            // Course 조회
-            """
-            { $match: { _id: ObjectId(?0) } }
-            """,
-            // Course 내 모든 여행지의 id 추출
+    // Course 내 모든 여행지의 id 추출
+    static final String DISTRICT_QUERY_1 = 
             """
             { 
                 $project: { 
@@ -45,8 +43,9 @@ public interface CourseRepository extends MongoRepository<Course, String> {
                     }
                 }
             }
-            """,
-            // 여행지 컬렉션과 join
+            """;
+    // 여행지 컬렉션과 join
+    static final String DISTRICT_QUERY_2 =
             """
             { 
                 $lookup: {
@@ -57,8 +56,9 @@ public interface CourseRepository extends MongoRepository<Course, String> {
                     as: 'districts'
                 }
             }
-            """,
-            // DTO에 매핑
+            """;
+    // DTO에 매핑
+    static final String DISTRICT_QUERY_3 =
             """
             {
                 $project: {
@@ -72,7 +72,27 @@ public interface CourseRepository extends MongoRepository<Course, String> {
                     }
                 } 
             }
+            """;
+    
+    @Aggregation(pipeline = {
+            // Course 조회
             """
+            { $match: { _id: ObjectId(?0) } }
+            """,
+            DISTRICT_QUERY_1,
+            DISTRICT_QUERY_2,
+            DISTRICT_QUERY_3
     })
     CourseDistrictsDto findAllDestinationNameInCourse(String courseId);
+    
+    @Aggregation(pipeline = {
+            // Course 조회
+            """
+            { $match: { _id: { $in: ?0 } } }
+            """,
+            DISTRICT_QUERY_1,
+            DISTRICT_QUERY_2,
+            DISTRICT_QUERY_3
+    })
+    List<CourseDistrictsDto> findAllDestinationNameInCourses(Set<ObjectId> courseIds);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/application/PostService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/application/PostService.java
@@ -1,20 +1,28 @@
 package com.se.Tlog.domain.Social.Post.application;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
+import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Course.domain.Course;
 import com.se.Tlog.domain.Course.repository.dto.CourseDistrictsDto;
 import com.se.Tlog.domain.Course.repository.mongo.CourseRepository;
+import com.se.Tlog.domain.Social.Follow.repository.jpa.FollowRepository;
 import com.se.Tlog.domain.Social.Post.controller.dto.CreatePostReq;
 import com.se.Tlog.domain.Social.Post.controller.dto.PostDetailRes;
 import com.se.Tlog.domain.Social.Post.controller.dto.PostPreviewRes;
 import com.se.Tlog.domain.Social.Post.controller.dto.ReplyRes;
 import com.se.Tlog.domain.Social.Post.domain.Post;
+import com.se.Tlog.domain.Social.Post.repository.mongo.PostQueryRepository;
 import com.se.Tlog.domain.Social.Post.repository.mongo.PostRepository;
 import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
@@ -30,8 +38,10 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
+    private final PostQueryRepository postQueryRepository;
     private final UserRepository userRepository;
     private final CourseRepository courseRepository;
+    private final FollowRepository followRepository;
     private final ReplyService replyService;
     
     // 게시물 첫 조회시 기본으로 전송할 댓글 수 입니다.
@@ -91,5 +101,45 @@ public class PostService {
                 post.getImageUrls(),
                 post.getContent(),
                 replies);
+    }
+    
+    public Slice<PostDetailRes> getRecentFollowersPosts(int size, String lastPostId, UUID userId) {
+        if (size <= 0) size = 10;
+        
+        List<UUID> followings = followRepository.findToUserIdsByFromUserId(
+                userId, 
+                PageRequest.of(0, Integer.MAX_VALUE)
+                ).toList();
+        Slice<Post> posts = postQueryRepository.findAllRecentPosts(size, lastPostId, followings);
+        Map<UUID, User> authors = userRepository.findAllById(posts.map(post -> post.getAuthor()).toSet())
+                .stream().collect(Collectors.toMap(
+                        user -> user.getId(),
+                        user -> user));
+        Map<String, CourseDistrictsDto> courseDestinations = courseRepository.findAllDestinationNameInCourses(
+                posts.map(post -> new ObjectId(post.getCourseId())).toSet()
+                ).stream().collect(Collectors.toMap(
+                        dto -> dto.courseId(),
+                        dto -> dto));
+        Map<String, List<ReplyRes>> replies = replyService.getReplyResOfPosts(
+                size, 
+                posts.map(post->post.getId()).toSet());
+        
+        return posts.map(post -> {
+            CourseDistrictsDto courseDestination = courseDestinations.get(post.getCourseId());
+            User author = authors.get(post.getAuthor());
+            List<ReplyRes> postReplies = replies.get(post.getId());
+            return new PostDetailRes(
+                    post.getId(), 
+                    post.getLikeCount(),
+                    post.getId(),
+                    post.getCourseId(), 
+                    null != courseDestination ? courseDestination.districts() : new ArrayList<String>(), 
+                    post.getAuthor(),
+                    null != author ? author.getName() : "탈퇴한 사용자입니다.",
+                    null != author ? author.getProfileImage() : "",
+                    post.getImageUrls(),
+                    post.getContent(),
+                    null != postReplies ? postReplies : new ArrayList<ReplyRes>());
+        });
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/application/ReplyService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/application/ReplyService.java
@@ -2,6 +2,7 @@ package com.se.Tlog.domain.Social.Post.application;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -100,6 +101,41 @@ public class ReplyService {
                         author.getName(),
                         author.getProfileImage());
             }).toList();
+    }
+    
+    public Map<String, List<ReplyRes>> getReplyResOfPosts(int size, Set<String> postIds) {
+        if (size <= 0)
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        
+        Map<String, List<Reply>> replies = replyRepository.findAllOfPosts(size, postIds);
+        Set<UUID> authorIds = replies.values()
+                .stream()
+                .flatMap(list -> list.stream())
+                .map(reply -> reply.getAuthorId())
+                .collect(Collectors.toSet());
+        Map<UUID, User> users = userRepository.findAllById(authorIds)
+                .stream().collect(Collectors.toMap(
+                        u -> u.getId(),
+                        u -> u));
+        if (users.size() != authorIds.size())
+            log.error("댓글 조회 오류 : 게시글 내 댓글 중 탈퇴한 작성자의 댓글이 남아있습니다.");
+        
+        return replies.keySet().stream()
+                .collect(Collectors.toMap(
+                        postId -> postId,
+                        postId -> replies.get(postId).stream()
+                                .filter(reply -> users.containsKey(reply.getAuthorId()))
+                                .map(reply -> {
+                                    User author = users.get(reply.getAuthorId());
+                                    return new ReplyRes(
+                                            reply.getId(),
+                                            reply.getContent(),
+                                            reply.getNestedReplyCount(),
+                                            author.getId(),
+                                            author.getName(),
+                                            author.getProfileImage());
+                                }).toList()
+                        ));
     }
     
     public List<ReplyRes> getReplyResOfReply(int size, String lastReplyId, String replyId) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/PostController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/controller/PostController.java
@@ -4,22 +4,29 @@ import java.util.UUID;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.se.Tlog.domain.Social.Post.application.PostService;
 import com.se.Tlog.domain.Social.Post.controller.dto.CreatePostReq;
 import com.se.Tlog.domain.Social.Post.controller.dto.PostDetailRes;
 import com.se.Tlog.domain.Social.Post.controller.dto.PostPreviewRes;
+import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.error.ErrorType;
 import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.security.dto.CustomUserDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -78,5 +85,30 @@ public class PostController {
     public ResponseEntity<SuccessRes<PostDetailRes>> getDetailPost(@PathVariable(name = "postId") String postId) {
         return ResponseEntity.ok(SuccessRes.from(
                 postService.getPostDetail(postId)));
+    }
+    
+    @GetMapping("/posts")
+    @Operation (
+            summary = "팔로잉 사용자들의 최근 게시물",
+            description = "현재 팔로우중인 사용자들의 게시물의 상세 정보를 조회합니다."
+                        + "<br><br><b>인증 토큰이 필요합니다!</b>",
+            parameters = {
+                    @Parameter(name = "lastPostId", description = "이 게시글 이후부터 조회합니다. 없으면 null 또는 0으로 기입합니다."),
+                    @Parameter(name = "size", description = "추가 조회할 게시물의 갯수입니다. (paging과 유사)")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<Slice<PostDetailRes>>> getRecentPost(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestParam(name = "lastPostId", required = false) String lastPostId,
+            @RequestParam(name = "size") int size) {
+        if (user == null)
+            throw new CustomException(ErrorType.UN_AUTHENTICATION);
+            
+        return ResponseEntity.ok(SuccessRes.from(
+                postService.getRecentFollowersPosts(size, lastPostId, UUID.fromString(user.getId()))));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/repository/mongo/PostQueryRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/repository/mongo/PostQueryRepository.java
@@ -1,0 +1,35 @@
+package com.se.Tlog.domain.Social.Post.repository.mongo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Component;
+
+import com.se.Tlog.domain.Social.Post.domain.Post;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PostQueryRepository {
+    private final RawPostQueryRepository postQueryRepository;
+    
+    private static final String NULL_LAST_POST_ID = "ffffffffffffffffffffffff";
+    
+    public Slice<Post> findAllRecentPosts(int size, String lastPostId, List<UUID> followingList) {
+        if (size <= 0) size = 10;
+        if (lastPostId == null || !ObjectId.isValid(lastPostId)) lastPostId = NULL_LAST_POST_ID;
+        if (followingList == null) followingList = new ArrayList<UUID>();
+        
+        List<Post> results = new ArrayList<Post>(
+                postQueryRepository.findAllRecentPosts(size + 1, lastPostId, followingList));
+        boolean hasNext = (size + 1 == results.size());
+        if (hasNext) results.remove(size);
+        return new SliceImpl<Post>(results, PageRequest.ofSize(size), hasNext);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/repository/mongo/RawPostQueryRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/repository/mongo/RawPostQueryRepository.java
@@ -1,0 +1,21 @@
+package com.se.Tlog.domain.Social.Post.repository.mongo;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.mongodb.repository.Aggregation;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import com.se.Tlog.domain.Social.Post.domain.Post;
+
+@Repository
+interface RawPostQueryRepository extends MongoRepository<Post, String> {
+    @Aggregation(pipeline = {
+            "{ $sort: { _id: -1 } }",
+            "{ $match: { $expr: { $lt: [ '$_id', ObjectId(?1) ] } } }",
+            "{ $match: { author: { $in: ?2 } } }",
+            "{ $limit: ?0 }"
+    })
+    List<Post> findAllRecentPosts(int size, String lastPostId, List<UUID> followingList);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/repository/mongo/ReplyRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/repository/mongo/ReplyRepository.java
@@ -1,6 +1,10 @@
 package com.se.Tlog.domain.Social.Post.repository.mongo;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -35,6 +39,22 @@ public interface ReplyRepository extends MongoRepository<Reply, String> {
     List<Reply> findAllByPostId(int limit, String lastReplyId, String postId);
     
     @Aggregation(pipeline = {
+            // 결과 쿼리
+            """
+            {
+                $match: {
+                    postId: { $in: ?1 },
+                    parentId: "000000000000000000000000"
+                }
+            }
+            """,
+            """
+            { $limit: ?0 }
+            """
+    })
+    List<Reply> findAllByPostIds(int limit, Set<String> postId);
+    
+    @Aggregation(pipeline = {
             // id 기반 페이징 (-> 성능상 좀 더 우수)
             """
             { $sort: { _id: 1 } }
@@ -54,6 +74,21 @@ public interface ReplyRepository extends MongoRepository<Reply, String> {
             
     })
     List<Reply> findAllByParentId(int limit, String lastReplyId, String parentId);
+    
+    default Map<String, List<Reply>> findAllOfPosts(int size, Set<String> postIds) {
+        List<Reply> replies = findAllByPostIds(size, postIds);
+        Map<String, List<Reply>> result = new HashMap<String, List<Reply>>();
+        for (Reply r : replies) {
+            if (result.containsKey(r.getPostId()))
+                result.get(r.getPostId()).add(r);
+            else {
+                List<Reply> newList = new ArrayList<Reply>();
+                newList.add(r);
+                result.put(r.getPostId(), newList);
+            }
+        }
+        return result;
+    }
 
     default List<Reply> findAllOfPost(int size, String lastRelyId, String postId) {
         return findAllByPostId(


### PR DESCRIPTION
## 작업 동기 및 이슈
- #189 

## 추가 및 변경사항
### 1) 팔로워들의 최근 게시물 조회 기능 추가
- 사용자가 팔로잉하고 있는 주변 사용자들의 게시물들을 최신 순서대로 조회합니다.
- 반환 타입은 상세조회 DTO의 리스트입니다.
- Slice 방식을 적용하며, 빠른 조회(유사 skip방식)를 위해 마지막 게시글의 id와 size를 입력받습니다.
- **없어진 코스, 없어진 사용자가 존재하더라도 데이터는 조회됩니다.**
  -> 그러나 코스 정보 및 사용자 프로필 사진 등이 빈 값으로 표시될 수 있습니다.
  <img src="https://github.com/user-attachments/assets/8f2be262-cf50-4c7a-a1e3-fc979ec7a04a" width="350"/>
  <img src="https://github.com/user-attachments/assets/82de7677-8894-40b3-a378-99c8f2053ffe" width="350"/>
### 2) 각종 쿼리 추가
- `PostQueryRepository` : 게시물을 최근 순서대로 조회하는 쿼리 추가
- `CourseRepository` : 여러 코스마다 여행지 명을 일괄 추출하는 쿼리 추가
- `ReplyRepository` : 여러 게시글의 댓글을 일괄 추출하는 쿼리 추가
### 3) 관련 기술상 명세
- **현재 게시물 및 댓글에는 작성일자 값은 없습니다.**
  대신, mongoDB의 ObjectId가 시간 순서대로 생성되는 점을 사용해,
  `최신순 == ObjectId의 역순`으로 구현하고 있습니다.

## 테스트 결과
- 이상 무.
  ok : 팔로잉 사용자들만 조회
  ok : 최근 작성 순서로 조회 (= 작성일자의 내림차순)
  ok : 여행 코스 및 작성자, 댓글 데이터 조회
  ok : 존재하지 않는 사용자/코스/댓글 정보가 있어도 조회

## 📌 기타
