### PR TITLE
Feature: 게시글 검색 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/application/DescriptionSearchService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/application/DescriptionSearchService.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @ApplicationService
 @RequiredArgsConstructor
-public class SearchService {
+public class DescriptionSearchService {
 	private final DestinationSearchRepository searchRepository;
 	private final DestinationService destinationService;
     

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/application/SnsPostSearchService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/application/SnsPostSearchService.java
@@ -1,0 +1,29 @@
+package com.se.Tlog.domain.Search.application;
+
+import org.springframework.data.domain.Slice;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Search.repository.mongo.SnsPostSearchRepository;
+import com.se.Tlog.domain.Social.Post.controller.dto.PostPreviewRes;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.RequiredArgsConstructor;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class SnsPostSearchService {
+    private final SnsPostSearchRepository postSearchRepository;
+    
+    public Slice<PostPreviewRes> searchOfDestinationAndContent(int size, String lastPostId, String query) {
+        if (query == null || query.trim().length() <= 1)
+            throw new CustomException(ErrorType.QUERY_TOO_SHORT);
+        return postSearchRepository.searchOfDestinationsAndContent(size, lastPostId, query)
+                .map(post -> {
+                    if (0 < post.getImageUrls().size())
+                        return new PostPreviewRes(post.getId(), post.getImageUrls().get(0));
+                    else
+                        return new PostPreviewRes(post.getId(), "");
+                });
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/controller/SearchController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/controller/SearchController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import com.se.Tlog.domain.Search.application.SearchService;
+import com.se.Tlog.domain.Search.application.DescriptionSearchService;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
 import com.se.Tlog.global.response.error.ErrorRes;
 import com.se.Tlog.global.response.success.SuccessRes;
@@ -33,7 +33,7 @@ import lombok.RequiredArgsConstructor;
         name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
         scopes = {"scope1", "scope2"})
 public class SearchController {
-	private final SearchService searchService;
+	private final DescriptionSearchService searchService;
 	
 	@GetMapping("/destination/by-name")
 	@Operation (

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/controller/SearchDestinationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/controller/SearchDestinationController.java
@@ -26,16 +26,16 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @Controller
-@RequestMapping("/api/search")
+@RequestMapping("/api/search/destination")
 @RequiredArgsConstructor
 @Tag(name = "검색")
 @SecurityRequirement(
         name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
         scopes = {"scope1", "scope2"})
-public class SearchController {
+public class SearchDestinationController {
 	private final DescriptionSearchService searchService;
 	
-	@GetMapping("/destination/by-name")
+	@GetMapping("/by-name")
 	@Operation (
 			summary = "여행지 이름 자동완성 검색",
     		description = "여행지 이름에 대한 자동완성 검색 결과를 반환합니다.",
@@ -50,7 +50,7 @@ public class SearchController {
 		        searchService.autoCompleteDestinationByName(name)));
 	}
 	
-	@GetMapping("/destination/by-address")
+	@GetMapping("/by-address")
     @Operation (
             summary = "여행지 주소 자동완성 검색",
             description = "여행지 주소에 대한 자동완성 검색 결과를 반환합니다. (현재 결과에 address가 직접 표시되지는 않음)",
@@ -65,7 +65,7 @@ public class SearchController {
                 searchService.autoCompleteDestinationByAddress(address)));
     }
 	
-	@GetMapping("/destination/by-city")
+	@GetMapping("/by-city")
     @Operation (
             summary = "여행지 도시 필터링 검색",
             description = "도시 필터링한 여행지의 전체 결과를 반환합니다.",
@@ -84,7 +84,7 @@ public class SearchController {
                 searchService.searchDestinationByCity(pageable, city)));
     }
     
-    @GetMapping("/destination/by-city-and-city")
+    @GetMapping("/by-city-and-city")
     @Operation (
             summary = "여행지 도시 필터링 검색",
             description = "도시 필터링한 여행지 이름 검색 결과를 반환합니다.",

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/controller/SearchPostController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/controller/SearchPostController.java
@@ -1,0 +1,55 @@
+package com.se.Tlog.domain.Search.controller;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.se.Tlog.domain.Search.application.SnsPostSearchService;
+import com.se.Tlog.domain.Social.Post.controller.dto.PostPreviewRes;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.success.SuccessRes;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/api/search/post")
+@RequiredArgsConstructor
+@Tag(name = "검색")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
+public class SearchPostController {
+    private final SnsPostSearchService postSearchService;
+    
+    @GetMapping("/by-destination-and-content")
+    @Operation (
+            summary = "게시물의 내용 및 코스 내 여행지 이름으로 검색",
+            description = "게시물 내 내용이나 게시물이 참조하는 코스의 여행지 이름으로 게시물을 검색합니다.",
+            parameters = {
+                    @Parameter(name = "lastPostId", description = "이 게시글 이후부터 조회합니다. 없으면 null 또는 0으로 기입합니다."),
+                    @Parameter(name = "size", description = "추가 조회할 게시물의 갯수입니다. (paging과 유사)"),
+                    @Parameter(name = "query", description = "검색어입니다. (게시글 본문 / 여행지 이름이 검색됨) <b>최소 1글자 이상 입력해야 합니다!</b>")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공, 검색된 결과를 반환합니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류. 조회에 실패했습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<Slice<PostPreviewRes>>> searchDestinationByName(
+            @RequestParam(name = "lastPostId", required = false) String lastPostId,
+            @RequestParam(name = "size") int size,
+            @RequestParam(name = "query") String query) {
+        return ResponseEntity.ok(SuccessRes.from(
+                postSearchService.searchOfDestinationAndContent(size, lastPostId, query)));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/repository/mongo/RawSnsPostSearchRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/repository/mongo/RawSnsPostSearchRepository.java
@@ -1,0 +1,145 @@
+package com.se.Tlog.domain.Search.repository.mongo;
+
+import java.util.List;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.Aggregation;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import com.se.Tlog.domain.Social.Post.domain.Post;
+
+/**
+ * 현재는 Mongo Atlas Search를 사용중입니다만,
+ * <br>만약 추가적인 성능이 요구된다면 Elastic Search를 도입하는 것도
+ * <br>고려중에 있습니다.
+ */
+@Repository
+interface RawSnsPostSearchRepository extends MongoRepository<Post, String> {
+    
+    // 최근순 정렬 및 빠른 페이징 처리를 위한 Skip
+    static final String QUERY_1_SORT_BY_RECENT = "{ $sort: { _id: -1 } }";
+    static final String QUERY_1_SKIP = "{ $match: { $expr: { $lt: [ '$_id', ObjectId( ?1 ) ] } } }";
+    
+    // 여행지 검색결과의 join을 위한 전처리  
+    static final String QUERY_1_CONVERT_ID = "{ $addFields: { _courseId: { $convert: { input: '$courseId', to: 'objectId' } } } }";
+    
+    // 여행지 이름이 하나라도 검색되는 코스의 id를 모두 조회
+    // 파이프라인은 다음과 같습니다 :
+    //      [코스의 여행지 id 추출] -> [여행지 중 검색에 매칭되는 항목만 조인] -> [조인 결과가 1개 이상인 항목 필터링] -> [id만 추출]
+    static final String INNER_QUERY_1_SEARCH_COURSE = 
+            """
+            {
+              $project: {
+                _id: 1,
+                destIds: {
+                  $reduce: {
+                    input: "$dates.destinations",
+                    initialValue: [],
+                    in: {
+                      $concatArrays: [
+                        "$$value",
+                        {
+                          $map: {
+                            input: "$$this",
+                            as: "item",
+                            in: {
+                              $convert: {
+                                input: "$$item",
+                                to: "objectId",
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+            {
+              $lookup: {
+                from: "destinations",
+                localField: "destIds",
+                foreignField: "_id",
+                pipeline: [
+                  {
+                    $search: {
+                      index: "destination_index",
+                      text: {
+                        query: ?2,
+                        path: "name",
+                      },
+                    },
+                  },
+                  {
+                    $project: {
+                      _id: 1,
+                    },
+                  },
+                ],
+                as: "result",
+              },
+            },
+            {
+              $match: {
+                $expr: {
+                  $gt: [
+                    {
+                      $size: "$result",
+                    },
+                    0,
+                  ],
+                },
+              },
+            },
+            {
+              $project: {
+                _id: 1,
+              },
+            },
+            """;
+    
+    // 검색된 코스와 join
+    static final String QUERY_1_JOIN_WITH_COURSE_RESULTS = 
+            """
+            {
+                $lookup: {
+                from: "courses",
+                localField: "_courseId",
+                foreignField: "_id",
+                pipeline: [
+                    """
+                    + INNER_QUERY_1_SEARCH_COURSE +
+                    """
+                ],
+                as: "courseLookup",
+                },
+            },
+            """;
+    
+    // 게시글 내용에 검색어가 포함되거나 / 관련 여행지가 검색되어 코스와 조인이 된 게시글을 모두 필터링
+    static final String QUERY_1_FILTER_RESULTS =
+            """
+            {
+              $match: {
+                $or: [
+                  { content: { $regex: ?2 } },
+                  { $expr: { $gt: [ { $size: "$courseLookup" }, 0 ] } }
+                ],
+              },
+            },""";
+    
+    // 페이징 처리를 위한 limit
+    static final String QUERY_1_LIMIT = "{ $limit: ?0 }";
+    
+    @Aggregation(pipeline = {
+            QUERY_1_SORT_BY_RECENT,
+            QUERY_1_SKIP,
+            QUERY_1_CONVERT_ID,
+            QUERY_1_JOIN_WITH_COURSE_RESULTS,
+            QUERY_1_FILTER_RESULTS,
+            QUERY_1_LIMIT
+    })
+    List<Post> searchOfDestinationsAndContent(int size, ObjectId lastPostId, String queryText);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/repository/mongo/SnsPostSearchRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/repository/mongo/SnsPostSearchRepository.java
@@ -1,0 +1,37 @@
+package com.se.Tlog.domain.Search.repository.mongo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Component;
+
+import com.se.Tlog.domain.Social.Post.domain.Post;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SnsPostSearchRepository {
+    private final RawSnsPostSearchRepository postSearchRepository;
+    private static final ObjectId NULL_LAST_POST_ID = new ObjectId("ffffffffffffffffffffffff");
+    
+    public Slice<Post> searchOfDestinationsAndContent(int size, String lastPostIdStr, String queryText) {
+        if (size <= 0) size = 10;
+        ObjectId lastPostId = NULL_LAST_POST_ID;
+        if (lastPostIdStr != null && ObjectId.isValid(lastPostIdStr)) lastPostId = new ObjectId(lastPostIdStr); 
+        if (queryText == null || queryText.trim().length() <= 1)
+            throw new CustomException(ErrorType.QUERY_TOO_SHORT);
+        
+        List<Post> results = new ArrayList<Post>(
+                postSearchRepository.searchOfDestinationsAndContent(size + 1, lastPostId, queryText));
+        boolean hasNext = (size + 1 == results.size());
+        if (hasNext) results.remove(size);
+        return new SliceImpl<Post>(results, PageRequest.ofSize(size), hasNext);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -22,6 +22,7 @@ public enum ErrorType {
     INSUFFICIENT_INFO_FOR_REGISTER(HttpStatus.BAD_REQUEST, "회원가입을 위한 정보가 부족합니다."),
     INVALID_REVIEW_RATING(HttpStatus.BAD_REQUEST, "리뷰 평점은 1점 이상 5점 이하여야 합니다."),
     INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "잘못된 이미지 URL 입니다." ),
+    QUERY_TOO_SHORT(HttpStatus.BAD_REQUEST, "검색 문구의 길이가 너무 짧습니다." ),
     // 사용자로부터 소셜 로그인 인증 실패
     SSO_LOGIN_FAIL(HttpStatus.BAD_REQUEST,"외부 소셜 로그인이 취소되거나 실패했습니다."),
     


### PR DESCRIPTION
## 작업 동기 및 이슈
- #198 

## 추가 및 변경사항
- **게시글 검색 기능이 추가되었습니다.**
  - 입력에는 1자 이상의 검색어 `query` 외에도,
    Slicing을 위한 `lastPostId`, `Size` 정보를 포함합니다.
  - 출력은 게시글 미리보기 형태로 주어집니다.
    <img src="https://github.com/user-attachments/assets/6cded680-98c6-4bc9-9b14-60bbe2e9aacd" width="350"/>
    <img src="https://github.com/user-attachments/assets/bc7bc5ee-4225-46af-8344-786f7dfec699" width="350"/>

- **검색 쿼리 구현**
  - MongoDB Search를 활용한 검색 쿼리가 구성되었습니다.
    **너무 복잡해진 쿼리로 인해, 많은 요청이 몰릴 경우 성능이 우려됩니다. -> 서비스 규모가 커질 경우 고려**
    - 여행지 내용에 대한 검색이 들어가야 한다면 어쩔 수 없이 Join이 발생합니다.
      해당 문제는 단순히 여행지 정보 자체도 게시글에 포함시켜 개선할 수 있고,
      혹은 게시글마다 관련 키워드를 인덱싱하는 방법도 있겠습니다.
      단, 여행지 정보 업데이트시 어떻게 동기화할지가 문제입니다.
      이러한 **검색 성능 문제는 데이터의 구조와도 연관이 깊으므로**, 우선 추후 시간을 들여 고민할 문제로 넘기도록 하겠습니다.

- **기존 SearchService 및 SearchController의 분리**
  - 여행지 검색과의 혼동을 피하고 관리를 용이하게 하도록
    기존 검색은 SearchDestination~ 으로 분리되었습니다.

## 테스트 결과
- 이상 무.

## 📌 기타
