### PR TITLE
Feature: 팔로우 사용자 조회시 데이터 추가

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/application/FollowService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/application/FollowService.java
@@ -9,9 +9,6 @@ import com.se.Tlog.domain.User.controller.dto.UserSummaryDto;
 import com.se.Tlog.domain.User.domain.service.UserDomainService;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 
 
 import java.util.List;
@@ -43,24 +40,24 @@ public class FollowService {
         }
     }
 
-    public Page<UserSummaryDto> getFollowingList(UUID fromUserId, Pageable pageable) {
+    public List<UserSummaryDto> getFollowingList(UUID fromUserId) {
         userDomainService.validateExists(fromUserId);
 
-        Page<UUID> pagedToUserIds = followRepository.findToUserIdsByFromUserId(fromUserId,pageable);
+        List<UUID> pagedToUserIds = followRepository.findToUserIdsByFromUserId(fromUserId);
 
-        List<UserSummaryDto> userSummaryDtoList = userDomainService.getUserByIds(pagedToUserIds.getContent());
+        List<UserSummaryDto> userSummaryDtoList = userDomainService.getUserByIds(pagedToUserIds);
 
-        return new PageImpl<>(userSummaryDtoList, pageable, pagedToUserIds.getTotalElements());
+        return userSummaryDtoList;
     }
 
-    public Page<UserSummaryDto> getFollowerList(UUID toUserId, Pageable pageable) {
+    public List<UserSummaryDto> getFollowerList(UUID toUserId) {
         userDomainService.validateExists(toUserId);
 
-        Page<UUID> pagedFromUserIds = followRepository.findFromUserIdsByToUserId(toUserId,pageable);
+        List<UUID> pagedFromUserIds = followRepository.findFromUserIdsByToUserId(toUserId);
 
-        List<UserSummaryDto> userSummaryDtoList = userDomainService.getUserByIds(pagedFromUserIds.getContent());
+        List<UserSummaryDto> userSummaryDtoList = userDomainService.getUserByIds(pagedFromUserIds);
 
-        return new PageImpl<>(userSummaryDtoList, pageable, pagedFromUserIds.getTotalElements());
+        return userSummaryDtoList;
 
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/controller/FollowController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/controller/FollowController.java
@@ -12,13 +12,11 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @Controller
@@ -62,10 +60,8 @@ public class FollowController {
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류")
             }
     )
-    public ResponseEntity<SuccessRes<Page<UserSummaryDto>>> getFollowingList(
-            @PathVariable UUID userId,
-            @PageableDefault(size = 10) Pageable pageable) {
-        return ResponseEntity.ok(SuccessRes.from(followService.getFollowingList(userId,pageable)));
+    public ResponseEntity<SuccessRes<List<UserSummaryDto>>> getFollowingList(@PathVariable UUID userId) {
+        return ResponseEntity.ok(SuccessRes.from(followService.getFollowingList(userId)));
     }
 
     // 나를 팔로우하는 사람들
@@ -79,10 +75,8 @@ public class FollowController {
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류")
             }
     )
-    public ResponseEntity<SuccessRes<Page<UserSummaryDto>>> getFollowerList(
-            @PathVariable UUID userId,
-            @PageableDefault(size = 10) Pageable pageable) {
-        return ResponseEntity.ok(SuccessRes.from(followService.getFollowerList(userId,pageable)));
+    public ResponseEntity<SuccessRes<List<UserSummaryDto>>> getFollowerList(@PathVariable UUID userId) {
+        return ResponseEntity.ok(SuccessRes.from(followService.getFollowerList(userId)));
     }
 
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/repository/jpa/FollowRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Follow/repository/jpa/FollowRepository.java
@@ -1,13 +1,12 @@
 package com.se.Tlog.domain.Social.Follow.repository.jpa;
 
 import com.se.Tlog.domain.Social.Follow.domain.Follow;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -16,10 +15,10 @@ public interface FollowRepository extends JpaRepository<Follow, UUID> {
     Optional<Follow> findByFromUserIdAndToUserId(UUID fromUserId, UUID toUserId);
 
     @Query("select f.toUserId from Follow  f where f.fromUserId = :fromUserId")
-    Page<UUID> findToUserIdsByFromUserId(@Param("fromUserId") UUID fromUserId, Pageable pageable);
+    List<UUID> findToUserIdsByFromUserId(@Param("fromUserId") UUID fromUserId);
 
     @Query("select f.fromUserId from Follow f where f.toUserId = :toUserId")
-    Page<UUID> findFromUserIdsByToUserId(@Param("toUserId") UUID toUserId, Pageable pageable);
+    List<UUID> findFromUserIdsByToUserId(@Param("toUserId") UUID toUserId);
     
     int countByFromUserId(UUID fromUserId);
     int countByToUserId(UUID toUserId);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/application/PostService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Post/application/PostService.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -106,10 +105,7 @@ public class PostService {
     public Slice<PostDetailRes> getRecentFollowersPosts(int size, String lastPostId, UUID userId) {
         if (size <= 0) size = 10;
         
-        List<UUID> followings = followRepository.findToUserIdsByFromUserId(
-                userId, 
-                PageRequest.of(0, Integer.MAX_VALUE)
-                ).toList();
+        List<UUID> followings = followRepository.findToUserIdsByFromUserId(userId);
         Slice<Post> posts = postQueryRepository.findAllRecentPosts(size, lastPostId, followings);
         Map<UUID, User> authors = userRepository.findAllById(posts.map(post -> post.getAuthor()).toSet())
                 .stream().collect(Collectors.toMap(

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/UserSummaryDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/UserSummaryDto.java
@@ -6,9 +6,17 @@ import java.util.UUID;
 
 public record UserSummaryDto(
         UUID uuid,
-        String name
+        String name,
+        String snsName,
+        String profileImageUrl,
+        int tbtiValue
 ) {
     public static UserSummaryDto from(User user){
-        return new UserSummaryDto(user.getId(), user.getName());
+        return new UserSummaryDto(
+                user.getId(), 
+                user.getName(), 
+                user.getSnsId(), 
+                user.getProfileImage(), 
+                user.getTbti());
     }
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #203 

## 추가 및 변경사항
- **UserSummayDto에 다음 필드가 추가되었습니다.**
  - `snsName` : snsId 값입니다.
  - `profileImageUrl` : 프로필 사진입니다.
  - `tbtiValue` : 8자리의 TBTI 성향 코드입니다.
- **팔로우 정보 조회시 페이징 기법이 제거되었습니다.**
  - 팔로우 데이터는 대량의 데이터는 아니라고 판단,
    간단한 처리를 위해 전체 조회 방식으로 변경하였습니다.

## 테스트 결과
- 이상 무.
  <img src="https://github.com/user-attachments/assets/43f23f68-8a6c-4798-a718-963ece564c51" width="500"/>

## 📌 기타
