### PR TITLE
Feature: 사용자가 참여중인 채팅방 업데이트 내용 갱신하는 로직 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/message/ChatConsumerService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/message/ChatConsumerService.java
@@ -2,9 +2,15 @@ package com.se.Tlog.domain.Social.Chat.message;
 
 import com.se.Tlog.domain.Social.Chat.message.dto.ChatMessageDto;
 import com.se.Tlog.domain.Social.Chat.message.dto.ChatMessageRequestDto;
+import com.se.Tlog.domain.Social.Chat.message.dto.TeamChatSummaryDto;
+import com.se.Tlog.domain.Social.Chat.read.ChatReadUsers;
+import com.se.Tlog.domain.Social.Chat.read.repository.jpa.ChatReadStatusRepository;
+import com.se.Tlog.domain.Social.Chat.read.repository.jpa.ChatReadUsersRepository;
 import com.se.Tlog.domain.Social.Chat.room.ChatRoom;
 import com.se.Tlog.domain.Social.Chat.message.repository.jpa.ChatMessageRepository;
 import com.se.Tlog.domain.Social.Chat.room.repository.jpa.ChatRoomRepository;
+import com.se.Tlog.domain.Social.Chat.room.repository.jpa.ChatRoomUserRepository;
+import com.se.Tlog.domain.Social.Chat.session.repository.jpa.ConnectedUserSessionRepository;
 import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.global.exception.CustomException;
@@ -14,6 +20,8 @@ import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.*;
+
 @Service
 @RequiredArgsConstructor
 public class ChatConsumerService {
@@ -21,6 +29,11 @@ public class ChatConsumerService {
     private final ChatMessageRepository chatMessageRepository;
     private final SimpMessageSendingOperations messagingTemplate;
     private final UserRepository userRepository;
+    private final ChatRoomUserRepository chatRoomUserRepository;
+    private final ChatReadUsersRepository chatReadUsersRepository;
+    private final ChatReadStatusRepository chatReadStatusRepository;
+    private final ConnectedUserSessionRepository connectedUserSessionRepository;
+
 
     @Transactional
     public void receivedChatMessage(ChatMessageRequestDto chatMessageRequestDto) {
@@ -34,9 +47,45 @@ public class ChatConsumerService {
 
         chatRoom.modifyLastMessage(chatMessage.getId());
 
+        ChatReadUsers chatReadUsers = ChatReadUsers.create(sender, chatMessage);
+        chatReadUsersRepository.save(chatReadUsers);
+
         messagingTemplate.convertAndSend(
                 "/sub/chat/room/" + chatRoom.getId(),
                 ChatMessageDto.from(sender, chatRoom, savedChatMessage)
         );
+
+        // connectedUserIds = 현재 채팅방 구독중인 유저
+        Set<UUID> connectedUserIds = connectedUserSessionRepository.findConnectedUserIdsByRoomId(chatRoom.getId());
+        List<User> participants = chatRoomUserRepository.findParticipantsByChatRoomId(chatRoom.getId());
+
+        // 모두가 구독중인 경우 실시간 채팅 목록 갱신해줄 필요 x
+        boolean allConnected = participants.stream()
+                .allMatch(user -> connectedUserIds.contains(user.getId()));
+        if (allConnected) {
+            return;
+        }
+
+        List<UUID> targetUserIds = participants.stream()
+                .map(User::getId)
+                .filter(userId -> !connectedUserIds.contains(userId))
+                .toList();
+        List<Object[]> readStatuses = chatReadStatusRepository.findLastReadMessageIdsForParticipants(targetUserIds, chatRoom.getId());
+        Map<UUID, Long> lastReadMap = new HashMap<>();
+
+        for (Object[] row : readStatuses) {
+            UUID userId = (UUID) row[0];
+            Long lastReadMessageId = (Long) row[1];
+            lastReadMap.put(userId, lastReadMessageId);
+        }
+
+        for (UUID targetUserId : targetUserIds) {
+            Long lastReadMessage = lastReadMap.getOrDefault(targetUserId, 0L);
+            int unreadCount = chatMessageRepository.countUnreadMessages(chatRoom.getId(), lastReadMessage);
+            messagingTemplate.convertAndSend(
+                    "/sub/chat/room" + targetUserId,
+                    TeamChatSummaryDto.from(targetUserId, chatRoom.getId(), savedChatMessage, unreadCount)
+            );
+        }
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/message/dto/TeamChatSummaryDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/message/dto/TeamChatSummaryDto.java
@@ -1,0 +1,18 @@
+package com.se.Tlog.domain.Social.Chat.message.dto;
+
+import com.se.Tlog.domain.Social.Chat.message.ChatMessage;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record TeamChatSummaryDto(
+        UUID userId,
+        Long roomId,
+        String content,
+        int unreadCount,
+        LocalDateTime sendAt
+) {
+    public static TeamChatSummaryDto from(UUID userId, Long roomId, ChatMessage chatMessage, int unreadCount) {
+        return new TeamChatSummaryDto(userId, roomId, chatMessage.getContent(), unreadCount, chatMessage.getSendAt());
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/read/repository/jpa/ChatReadStatusRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/read/repository/jpa/ChatReadStatusRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Repository
-public interface ChatReadStatusRepository extends JpaRepository<ChatReadStatus,Long> {
+public interface ChatReadStatusRepository extends JpaRepository<ChatReadStatus, Long> {
 
 
     @Query("select crs from ChatReadStatus crs join fetch crs.chatRoom " +
@@ -21,4 +21,10 @@ public interface ChatReadStatusRepository extends JpaRepository<ChatReadStatus,L
     @Query("select crs from ChatReadStatus crs where crs.user.id = :userId and crs.chatRoom.id = :chatRoomId")
     ChatReadStatus findByUserIdAndChatRoomId(@Param("userId") UUID userId,
                                              @Param("chatRoomId") Long chatRoomId);
+
+    @Query("select crs.user.id, crs.lastReadMessageId " +
+            " from ChatReadStatus crs " +
+            "where crs.user.id IN :targetUserIds AND crs.chatRoom.id = :roomId")
+    List<Object[]> findLastReadMessageIdsForParticipants(@Param("targetUserIds") List<UUID> targetUserIds,
+                                                         @Param("roomId") Long roomId);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/room/repository/jpa/ChatRoomUserRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/room/repository/jpa/ChatRoomUserRepository.java
@@ -2,6 +2,7 @@ package com.se.Tlog.domain.Social.Chat.room.repository.jpa;
 
 
 import com.se.Tlog.domain.Social.Chat.room.ChatRoomUser;
+import com.se.Tlog.domain.User.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,11 +11,14 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.UUID;
 @Repository
-public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, UUID> {
+public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long> {
 
     @Query("SELECT cru from ChatRoomUser cru join fetch cru.chatRoom where cru.user.id = :userId")
     List<ChatRoomUser> findChatRoomByUserId(@Param("userId") UUID hostId);
 
     @Query("select count(cru) from ChatRoomUser cru where cru.chatRoom.id = :roomId")
     int countChatRoomJoinUsers(@Param("roomId") Long roomId);
+
+    @Query("SELECT cru.user FROM ChatRoomUser cru WHERE cru.chatRoom.id = :chatRoomId")
+    List<User> findParticipantsByChatRoomId(@Param("chatRoomId") Long roomId);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/session/repository/jpa/ConnectedUserSessionRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/session/repository/jpa/ConnectedUserSessionRepository.java
@@ -2,8 +2,15 @@ package com.se.Tlog.domain.Social.Chat.session.repository.jpa;
 
 import com.se.Tlog.domain.Social.Chat.session.ConnectedUserSession;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+import java.util.UUID;
 
 @Repository
 public interface ConnectedUserSessionRepository extends JpaRepository<ConnectedUserSession, String> {
+    @Query("SELECT cus.userId from ConnectedUserSession cus where cus.roomId = :roomId")
+    Set<UUID> findConnectedUserIdsByRoomId(@Param("roomId") Long roomId);
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #207 

## 추가 및 변경사항
- 사용자가 채팅방 목록에 있는 경우에 "/sub/chat/room/{userId}"를 구독합니다. (채팅방 자체 구독은 x, 해당 경로를 통해 사용자가 참여중인 모든 방에서 업데이트 되는 경우의 dto를 받게 됩니다.)
- 해당 사용자가 참여중인 채팅방에서 채팅이 온다면 해당 경로를 구독중인 사용자에게만 요약dto를 전송합니다. (카카오톡을 가능한한 따라해서 요약 dto를 작성했는데 더 필요한 부분이 있다면 추가하겠습니다!)

## 📌 기타
- 현재 읽지않은 메시지 카운트가 단일쿼리로 전송되는데 이부분 비효율성 인지하고 있고 여유될때 수정하도록 하겠습니다!
- 현재 채팅방 목록에 대한 부분에 대해 정확한 방향을 프로젝트에서 정하진 않았지만 아마 필요할 것 같아서 미리 작성했습니다.
