### PR TITLE
Fix: 리뷰 조회시 사용자 이름이 올바르게 표시되지 않음

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
@@ -49,9 +49,9 @@ public class ReviewService {
             UUID userId = UUID.fromString(review.getUserId());
             UserProfileInfo userProfileInfo = userProfiles.get(userId);
             if (userProfileInfo != null)
-                return DestinationReviewDto.from(review, review.getUsername(), userProfileInfo);
+                return DestinationReviewDto.from(review, userProfileInfo);
             else
-                return DestinationReviewDto.from(review, "탈퇴한 사용자", UserProfileInfo.getNullProfile());
+                return DestinationReviewDto.from(review, UserProfileInfo.getNullProfile());
         }).toList();
         
         Slice<DestinationReviewDto> reviewDtos = new SliceImpl<>(dtoList, sortedPageable, reviews.hasNext());

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/application/ReviewService.java
@@ -12,6 +12,7 @@ import com.se.Tlog.domain.Travel.application.CustomTagService;
 import com.se.Tlog.domain.Travel.domain.service.DestinationDomainService;
 import com.se.Tlog.domain.User.controller.dto.UserProfileInfo;
 import com.se.Tlog.domain.User.domain.service.UserDomainService;
+import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class ReviewService {
     private final CustomTagService customTagService;
     private final DestinationDomainService destinationDomainService;
     private final UserDomainService userDomainService;
+    private final UserRepository userRepository;
 
     public ReviewsRes getReviewsByDestinationId(String destinationId, SortType sortType, Pageable pageable) {
         Map<Integer, Integer> distributionMap = destinationDomainService.getRatingDistribution(destinationId);
@@ -60,6 +62,15 @@ public class ReviewService {
     }
 
     public void createReview(ReviewCreateDto reviewCreateDto) {
+        UUID userId = null;
+        try {
+            userId = UUID.fromString(reviewCreateDto.userId());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorType.USER_NOT_FOUND);
+        }
+        if (!userRepository.existsById(userId))
+            throw new CustomException(ErrorType.USER_NOT_FOUND);
+        
         Review review = Review.create(reviewCreateDto);
         reviewRepository.save(review);
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/controller/dto/DestinationReviewDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/controller/dto/DestinationReviewDto.java
@@ -17,14 +17,12 @@ public record DestinationReviewDto(
         LocalDateTime createdAt
 ) {
     public static DestinationReviewDto from(
-            Review review, 
-            // 추후 username과 UserProfileInfo를 합쳐 사용자 데이터로 묶는게 좋겠습니다!
-            String username, 
+            Review review,
             UserProfileInfo userProfileInfo) {
         return new DestinationReviewDto(
                 review.getId(),
                 review.getUserId(),
-                username,
+                userProfileInfo.username(),
                 userProfileInfo.imageUrl(),
                 review.getRating(),
                 review.getContent(),

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/controller/dto/ReviewCreateDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/controller/dto/ReviewCreateDto.java
@@ -6,8 +6,10 @@ import com.se.Tlog.global.response.error.ErrorType;
 import java.util.List;
 
 public record ReviewCreateDto(
+        // 사용자 id를 uuid로 받는 것도 고려!
         String userId,
         String destinationId,
+        @Deprecated(since = "사용자 정보는 더 이상 필요없습니다!")
         String username,
         int rating,
         String content,

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/domain/Review.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/domain/Review.java
@@ -27,9 +27,6 @@ public class Review {
 	private String userId;
 	private String destinationId;
 
-	// 추후 리팩토링 소요 : 사용자 정보를 리뷰에서 가지고 있음
-	private String username;
-
 	private int rating;
 	private String content;
 	private List<String> imageUrlList;
@@ -42,8 +39,6 @@ public class Review {
 		return new Review(
 				dto.userId(),
 				dto.destinationId(),
-				// 추후 리팩토링 소요 : 사용자 정보를 리뷰에서 가지고 있음
-				dto.username(),
 				dto.rating(),
 				dto.content(),
 				dto.imageUrlList()
@@ -53,16 +48,12 @@ public class Review {
 	private Review(
 			String userId,
 			String destinationId,
-			// 추후 리팩토링 소요 : 사용자 정보를 리뷰에서 가지고 있음
-			String username,
 			int rating,
 			String content,
 			List<String> imageUrlList
 	){
 		this.userId = userId;
 		this.destinationId = destinationId;
-		// 추후 리팩토링 소요 : 사용자 정보를 리뷰에서 가지고 있음
-		this.username = username;
 		this.rating = rating;
 		this.content = content;
 		this.imageUrlList = imageUrlList;

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Review/domain/service/ReviewDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Review/domain/service/ReviewDomainService.java
@@ -34,9 +34,9 @@ public class ReviewDomainService {
             UUID userId = UUID.fromString(review.getUserId());
             UserProfileInfo userProfileInfo = userProfiles.get(userId);
             if (userProfileInfo != null)
-                return DestinationReviewDto.from(review, review.getUsername(), userProfileInfo);
+                return DestinationReviewDto.from(review, userProfileInfo);
             else
-                return DestinationReviewDto.from(review, "탈퇴한 사용자", UserProfileInfo.getNullProfile());
+                return DestinationReviewDto.from(review, UserProfileInfo.getNullProfile());
         }).toList();
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/UserProfileInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/UserProfileInfo.java
@@ -3,15 +3,17 @@ package com.se.Tlog.domain.User.controller.dto;
 import com.se.Tlog.domain.User.domain.User;
 
 public record UserProfileInfo(
-        String imageUrl
+        String imageUrl,
+        String username
 ) {
     public static UserProfileInfo of(User user){
         return new UserProfileInfo(
-                user.getProfileImage()
+                user.getProfileImage(),
+                user.getName()
         );
     }
     
     public static UserProfileInfo getNullProfile() {
-        return new UserProfileInfo("" /*, "탈퇴한 사용자"*/);
+        return new UserProfileInfo("" , "탈퇴한 사용자");
     }
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #213 

## 원인
- `Review`가 현재 별도의 `username` 필드를 가지고 있으며,
  새 리뷰 생성시 해당 필드를 입력받습니다.
- 따라서 리뷰 정보 조회시 사용자 정보의 이름이 아닌, 작성 당시 기입한 이름이 표시되고 있습니다.

## 변경사항
- `Review` 엔티티에서 `username` 필드가 제거되었습니다.
- 리뷰 조회시 사용자 정보를 받아오는 `UserProfileInfo`는 이제 `username` 속성도 포함합니다.
- 리뷰 생성시 `username`은 **유지되나 내부적으로 더 이상 사용되지 않습니다.**
- 리뷰 조회시 사용자 이름은 실제 사용자 정보에서 가져옵니다.

## 테스트 결과
- 이상 무.

## 📌 기타
