### PR TITLE
Feature: 프론트 요구사항 반영 (팀 생성, 디테일, 리스트 관련 요구 정보 추가)

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/room/ChatRoomService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/room/ChatRoomService.java
@@ -8,7 +8,6 @@ import com.se.Tlog.domain.Social.Chat.room.repository.jpa.ChatRoomUserRepository
 import com.se.Tlog.domain.Social.Chat.read.ChatReadStatusService;
 import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.domain.User.domain.service.UserDomainService;
-import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -21,17 +20,15 @@ import java.util.*;
 @RequiredArgsConstructor
 public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
-    private final UserRepository userRepository;
     private final ChatRoomUserRepository chatRoomUserRepository;
     private final UserDomainService userDomainService;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatReadStatusService chatReadStatusService;
 
-    public Long create(UUID hostId,UUID teamId) {
-        ChatRoom chatRoom = ChatRoom.create(hostId, teamId);
+    public Long create(User user,UUID teamId) {
+        ChatRoom chatRoom = ChatRoom.create(user.getId(), teamId);
         chatRoomRepository.save(chatRoom);
 
-        User user = userRepository.findById(hostId).get();
         ChatRoomUser chatRoomUser = ChatRoomUser.join(chatRoom, user);
 
         chatRoomUserRepository.save(chatRoomUser);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
@@ -1,10 +1,8 @@
 package com.se.Tlog.domain.Team.application;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Social.Chat.room.ChatRoomService;
@@ -15,7 +13,11 @@ import com.se.Tlog.domain.Team.domain.TeamDomainService;
 import com.se.Tlog.domain.Team.repository.jpa.TeamRepository;
 import com.se.Tlog.domain.Team.repository.jpa.TeamUserRepository;
 import com.se.Tlog.domain.Team.repository.jpa.entity.TeamUserJpaEntity;
+import com.se.Tlog.domain.Team.travelplan.TravelPlan;
+import com.se.Tlog.domain.Team.travelplan.repository.mongo.TravelPlanRepository;
+import com.se.Tlog.domain.Team.travelplan.service.TravelPlanService;
 import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.domain.User.domain.service.UserDomainService;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.domain.Wishlist.application.ShoppingCartService;
 import com.se.Tlog.domain.Wishlist.domain.OwnerType;
@@ -32,24 +34,26 @@ public class TeamService {
 	private final UserRepository userRepository;
 	private final TeamRepository teamRepository;
 	private final TeamUserRepository teamUserRepository;
+	private final TravelPlanRepository travelPlanRepository;
 	
 	private final TeamDomainService teamDomainService;
+	private final UserDomainService userDomainService;
 
 	private final ShoppingCartService shoppingCartService;
 	private final ChatRoomService chatRoomService;
+	private final TravelPlanService travelPlanService;
 
 	@Transactional
 	public TeamCreateRes createTeam(CreateTeamRequestDto request) {
 		if (request.name() == null)
 			throw new CustomException(ErrorType.TEAM_NAME_NOT_FOUND);
-		if (!userRepository.existsById(request.creator()))
-			throw new CustomException(ErrorType.USER_NOT_FOUND);
 
-		Team newTeam = teamDomainService.createTeam(
-		        request.name(), 
-		        userRepository.findById(request.creator()).get());
-		
-		Long chatRoomId = chatRoomService.create(request.creator(), newTeam.getId());
+		User user = userDomainService.findByIdOrThrow(request.creator());
+
+		Team newTeam = teamDomainService.createTeam(request.name(), user);
+		travelPlanService.saveTravelPlan(newTeam.getId(), request.travelPlan());
+
+		Long chatRoomId = chatRoomService.create(user, newTeam.getId());
 		return TeamCreateRes.of(newTeam.getId(),chatRoomId);
 	}
 	
@@ -68,19 +72,40 @@ public class TeamService {
 	                teamUser.getTeam().getId(), 
 	                members);
 		}
-		
+		Set<UUID> teamIds = membersOfTeam.keySet();
+		List<TravelPlan> travelPlans = travelPlanRepository.findAllByTeamIdIn(teamIds.stream().map(UUID::toString).toList());
+
+		Map<String, TravelPlan> travelPlanMap = travelPlans.stream()
+				.collect(Collectors.toMap(TravelPlan::getTeamId, Function.identity()));
+
 		// DTO 변환
-		return membersOfTeam.values().stream().map(teamMembers -> {
-		    String teamLeaderName = null;
-		    List<UUID> members = new ArrayList<UUID>();
-		    for (TeamUserJpaEntity teamUserInTeam : teamMembers) {
-		        if (teamUserInTeam.isLeader())
-		            teamLeaderName = teamUserInTeam.getUser().getName();
-                members.add(teamUserInTeam.getUser().getId());
-		    }
-			return TeamResponseDto.from(teamMembers.get(0).getTeam(), teamLeaderName, members);
-		})
-		.toList();
+		return membersOfTeam.entrySet().stream()
+				.map(entry -> toTeamResponseDto(entry, travelPlanMap))
+				.toList();
+	}
+	private TeamResponseDto toTeamResponseDto(
+			Map.Entry<UUID, List<TeamUserJpaEntity>> entry,
+			Map<String, TravelPlan> travelPlanMap
+	) {
+		List<TeamUserJpaEntity> teamMembers = entry.getValue();
+		Team team = teamMembers.get(0).getTeam();
+		String teamLeaderName = null;
+		List<TeamMemberSimpleDto> memberSimpleDtoList = new ArrayList<>();
+
+		TravelPlan travelPlan = travelPlanMap.get(entry.getKey().toString());
+		TravelPlanDto travelPlanDto = travelPlan != null ? TravelPlanDto.from(travelPlan) : null;
+
+		for (TeamUserJpaEntity teamUserInTeam : teamMembers) {
+			User user = teamUserInTeam.getUser();
+			if (teamUserInTeam.isLeader())
+				teamLeaderName = user.getName();
+
+			memberSimpleDtoList.add(
+					TeamMemberSimpleDto.from(user.getId(), user.getTbtiString())
+			);
+		}
+
+		return TeamResponseDto.from(team, teamLeaderName, memberSimpleDtoList, travelPlanDto);
 	}
 	
 	public void deleteTeam(UUID requesterId, UUID teamId) {
@@ -135,6 +160,10 @@ public class TeamService {
 
 		List<WishlistDestinationRes> wishList = shoppingCartService.getCartData(team.getId(), OwnerType.TEAM);
 
-		return TeamDetailDto.from(team, memberDtoList, wishList);
+		TravelPlan travelPlan = travelPlanRepository.findByTeamId(teamId.toString())
+				.orElseThrow(() -> new CustomException(ErrorType.TRAVEL_PLAN_NOT_FOUND));
+
+		TravelPlanDto travelPlanDto = TravelPlanDto.from(travelPlan);
+		return TeamDetailDto.from(team, memberDtoList, wishList, travelPlanDto);
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/CreateTeamRequestDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/CreateTeamRequestDto.java
@@ -8,12 +8,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record CreateTeamRequestDto(
 		@Schema(description = "팀 이름")
 		String name,
-		
+
 		@Schema(description = "팀 생성자")
-		UUID creator //,
-		
+		UUID creator,
+
+		@Schema(description = "여행 계획 정보")
+		TravelPlanDto travelPlan
+
 		//@Schema(description = "팀 TBTI")
 		//String teamTbti
 		) {
-
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
@@ -16,9 +16,11 @@ public record TeamDetailDto(
         LocalDate startDate,
         LocalDate endDate,
         List<TeamMemberDto> members,
-        List<WishlistDestinationRes> wishlist
+        List<WishlistDestinationRes> wishlist,
+        TravelPlanDto travelPlanDto
 ) {
-    public static TeamDetailDto from(Team team, List<TeamMemberDto> members, List<WishlistDestinationRes> wishlist) {
+    public static TeamDetailDto from(Team team, List<TeamMemberDto> members,
+                                     List<WishlistDestinationRes> wishlist, TravelPlanDto travelPlanDto) {
         return new TeamDetailDto(
                 team.getId(),
                 team.getName(),
@@ -27,7 +29,8 @@ public record TeamDetailDto(
                 team.getCreatedAt().toLocalDate(),
                 LocalDate.now(),
                 members,
-                wishlist
+                wishlist,
+                travelPlanDto
         );
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamMemberSimpleDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamMemberSimpleDto.java
@@ -1,0 +1,16 @@
+package com.se.Tlog.domain.Team.controller.dto;
+
+
+import java.util.UUID;
+
+public record TeamMemberSimpleDto(
+        UUID memberId,
+        String tbtiString
+) {
+    public static TeamMemberSimpleDto from(UUID userId,String tbtiString) {
+        return new TeamMemberSimpleDto(
+                userId,
+                tbtiString
+        );
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamResponseDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamResponseDto.java
@@ -11,14 +11,16 @@ public record TeamResponseDto(
 		UUID teamId,
 		String teamName,
 		String teamLeaderName,
-		List<UUID> memberIdList //유저들 id + profile 예정
+		List<TeamMemberSimpleDto> memberSimpleDtoList, //유저들 id + profile 예정
+		TravelPlanDto travelPlanDto
 		) {
-	public static TeamResponseDto from(Team team, String teamLeaderName, List<UUID> memberIdList) {
+	public static TeamResponseDto from(Team team, String teamLeaderName, List<TeamMemberSimpleDto> memberSimpleDtoList,TravelPlanDto travelPlanDto) {
 		return new TeamResponseDto(
 				team.getId(),
 				team.getName(),
 				teamLeaderName,
-				memberIdList
+				memberSimpleDtoList,
+				travelPlanDto
 		);
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TravelPlanDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TravelPlanDto.java
@@ -1,0 +1,45 @@
+package com.se.Tlog.domain.Team.controller.dto;
+
+import com.se.Tlog.domain.Team.travelplan.TravelPlan;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "여행 계획 정보 DTO")
+public record TravelPlanDto(
+
+        @Schema(description = "여행 도시")
+        String city,
+
+        @Schema(description = "여행 지역")
+        List<String> regionList,
+
+        @Schema(description = "반려견 동반 여부")
+        boolean hasPet,
+
+        @Schema(description = "이동수단 사용 여부")
+        boolean hasTransport,
+
+        @Schema(description = "여행 시작일")
+        LocalDate startDate,
+
+        @Schema(description = "여행 종료일")
+        LocalDate endDate,
+
+        @Schema(description = "일자별 방문 여행지 수 설정")
+        Map<Integer, Integer> visitCountPerDay
+) {
+        public static TravelPlanDto from(TravelPlan travelPlan) {
+                return new TravelPlanDto(
+                        travelPlan.getCity(),
+                        travelPlan.getRegion() != null ? List.copyOf(travelPlan.getRegion()) : List.of(),
+                        travelPlan.isHasPet(),
+                        travelPlan.isHasTransport(),
+                        travelPlan.getStartDate(),
+                        travelPlan.getEndDate(),
+                        travelPlan.getVisitCountPerDay() != null ? Map.copyOf(travelPlan.getVisitCountPerDay()) : Map.of()
+                );
+        }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/travelplan/TravelPlan.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/travelplan/TravelPlan.java
@@ -1,0 +1,63 @@
+package com.se.Tlog.domain.Team.travelplan;
+
+import com.se.Tlog.domain.Team.controller.dto.TravelPlanDto;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import lombok.Getter;
+import org.springframework.data.mongodb.core.mapping.Document;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.*;
+
+@Document(collection = "travelPlans")
+@NoArgsConstructor
+@Getter
+public class TravelPlan {
+
+
+    private String teamId;
+
+    private String city;
+
+    private boolean hasPet;
+
+    private boolean hasTransport;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private List<String> region = new ArrayList<>();
+
+    private Map<Integer, Integer> visitCountPerDay = new HashMap<>();
+
+    private TravelPlan(String teamId,String city, List<String> region, boolean hasPet, boolean hasTransport,
+                       LocalDate startDate, LocalDate endDate, Map<Integer, Integer> visitCountPerDay) {
+        this.teamId = teamId;
+        this.city = city;
+        this.region = new ArrayList<>(region);
+        this.hasPet = hasPet;
+        this.hasTransport = hasTransport;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.visitCountPerDay = new HashMap<>(visitCountPerDay);
+    }
+
+    public static TravelPlan of(String teamId,TravelPlanDto dto) {
+        if (dto.startDate() != null && dto.endDate() != null && dto.startDate().isAfter(dto.endDate())) {
+            throw new CustomException(ErrorType.TRAVEL_PLAN_INVALID_DATE);
+        }
+
+        return new TravelPlan(
+                teamId,
+                Optional.ofNullable(dto.city()).orElse(""),
+                Optional.ofNullable(dto.regionList()).orElse(new ArrayList<>()),
+                dto.hasPet(),
+                dto.hasTransport(),
+                dto.startDate(),
+                dto.endDate(),
+                Optional.ofNullable(dto.visitCountPerDay()).orElse(new HashMap<>())
+        );
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/travelplan/repository/mongo/TravelPlanRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/travelplan/repository/mongo/TravelPlanRepository.java
@@ -1,0 +1,14 @@
+package com.se.Tlog.domain.Team.travelplan.repository.mongo;
+
+import com.se.Tlog.domain.Team.travelplan.TravelPlan;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TravelPlanRepository extends MongoRepository<TravelPlan, String> {
+    Optional<TravelPlan> findByTeamId(String teamId);
+    List<TravelPlan> findAllByTeamIdIn(List<String> teamIds);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/travelplan/service/TravelPlanService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/travelplan/service/TravelPlanService.java
@@ -1,0 +1,21 @@
+package com.se.Tlog.domain.Team.travelplan.service;
+
+import com.se.Tlog.domain.Team.controller.dto.TravelPlanDto;
+import com.se.Tlog.domain.Team.travelplan.TravelPlan;
+import com.se.Tlog.domain.Team.travelplan.repository.mongo.TravelPlanRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TravelPlanService {
+
+    private final TravelPlanRepository travelPlanRepository;
+
+    public void saveTravelPlan(UUID teamId, TravelPlanDto travelPlanDto) {
+        TravelPlan travelPlan = TravelPlan.of(teamId.toString(), travelPlanDto);
+        travelPlanRepository.save(travelPlan);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/service/UserDomainService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/service/UserDomainService.java
@@ -56,6 +56,10 @@ public class UserDomainService {
     	
     	userRepository.deleteById(userId);
     }
+    public User findByIdOrThrow(UUID userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
+    }
 
     public void validateExists(UUID userId) {
         if (!userRepository.existsById(userId)) {

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -23,6 +23,7 @@ public enum ErrorType {
     INVALID_REVIEW_RATING(HttpStatus.BAD_REQUEST, "리뷰 평점은 1점 이상 5점 이하여야 합니다."),
     INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "잘못된 이미지 URL 입니다." ),
     QUERY_TOO_SHORT(HttpStatus.BAD_REQUEST, "검색 문구의 길이가 너무 짧습니다." ),
+    TRAVEL_PLAN_INVALID_DATE(HttpStatus.BAD_REQUEST, "여행 시작일은 종료일보다 이후일 수 없습니다."),
     // 사용자로부터 소셜 로그인 인증 실패
     SSO_LOGIN_FAIL(HttpStatus.BAD_REQUEST,"외부 소셜 로그인이 취소되거나 실패했습니다."),
     
@@ -84,6 +85,7 @@ public enum ErrorType {
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 여행 코스입니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 코스 리뷰(게시글)입니다."),
     REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
+    TRAVEL_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "여행 일정이 존재하지 않습니다."),
     //데이터 충돌
     ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 회원가입된 사용자입니다."),
     ALREADY_EXISTS_SNSId(HttpStatus.CONFLICT, "이미 존재하는 Id 입니다."),


### PR DESCRIPTION
## 작업 동기 및 이슈
- #227 
- 기존 코스 클래스를 재활용 하려고 했으나 코스는 AI가 최종 생성한 여행 경로를 의미하기도 하고 미리 반영해서 만들어 두거나 하면 나중에 구조가 더 꼬일 것 같아 새로운 클래스(TravelPlan)로 분리하였습니다. 

## 추가 및 변경사항
### 프론트 요구사항 반영
팀 생성 시 여행정보를 함께 받는 구조로 수정 요구 
- TravelPlan 클래스 도입 (여행 일정 데이터가 Collection형태도 있고 지역 설정할 때 개수가 일관되지 않아 Mongo로 작성하였습니다)
- TravelPlan 작성 (TeamService 내부에서 다 처리할까 하다가 추후 확장성 등을 고려하여 따로 빼두었습니다! -> 서브 도메인 느낌이라 해당 구조처럼 작성했는데 의견 부탁드립니다!)

팀 디테일 정보 반환 API시 여행일정도 함께 반환 
- 아래의 테스트 결과처럼 응답되도록 하였습니다.

팀 리스트 반환시 팀별 유저들의 tbti정보 함께 반환
- 유저가 참여중인 team들의 id를 모아 teamid와 TravelPlan의 Map구조로 변환하여 매핑하는 구조로 작성하였는데 해당 구조로 괜찮을까요? 느낌상 getTeamOfUser 메서드가 너무 무겁기도 하고 많은 책임을 지고 있는건 같아서 성능 우려가 돼서 어떻게 생각하시는지 궁금합니다.

팀 리스트 반환시 endDate도 함께 반환 -> 여행일정 함께 반환하기에 여해일정에 있는 endDate를 사용하면 될 것 같습니다!

리팩토링 사항
- ChatRoomService 에서 불필요한 db 조회가 있어서 삭제하였습니다!
- 추후 최적화와 도메인 규칙등 일관되게 관리하기 위해 UserDomainService에 findByIdOrThrow 작성 했습니다! 조회할경우 해당 메서드로 통일하는건 어떨까요?
## 테스트 결과
### 팀 생성시 요청 구조와 응답 구조
<img width="1011" height="718" alt="스크린샷 2025-07-28 오후 10 16 55" src="https://github.com/user-attachments/assets/49867469-a21b-4573-9c3b-56a6f5bddc43" />

### 팀 상세 조회시 응답 구조
<img width="823" height="447" alt="스크린샷 2025-07-28 오후 10 17 17" src="https://github.com/user-attachments/assets/01608ced-dd94-4f01-a0ee-7a5bc378fe44" />

- 팀 조회 API시 구조 동일하게 여행일정 반환됩니다

## 📌 기타
- 코스 생성시 사용된 여행일정으로 업데이트 되는 로직과 dto가 추가되어야 할 것 같습니다!
- 팀 삭제시 TravelPost도 같이 삭제되게 추가 해야 할 것 같습니다
