### PR TITLE
Feature: 회원가입시 각 태그별 여행지 표시 API 추가 / 선호 태그 입력 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -8,6 +8,7 @@ import com.se.Tlog.domain.Travel.domain.*;
 import com.se.Tlog.domain.Travel.repository.mongo.CustomTagRepositoryExtension;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepository;
 import com.se.Tlog.domain.Travel.repository.mongo.DestinationRepositoryExtension;
+import com.se.Tlog.domain.Travel.repository.mongo.TagRepository;
 import com.se.Tlog.domain.Travel.repository.mongo.UnapprovedDestinationRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
@@ -17,17 +18,20 @@ import org.springframework.data.domain.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 @ApplicationService
 @RequiredArgsConstructor
 public class DestinationService {
+    private final CustomTagRepositoryExtension customTagRepositoryExtension;
     private final DestinationRepositoryExtension destinationRepoExtension;
     private final DestinationRepository destinationRepository;
     private final UnapprovedDestinationRepository unapprovedDestinationRepository;
+    private final TagRepository tagRepository;
+    
     private final CustomTagService customTagService;
     private final TagService tagService;
     private final ReviewDomainService reviewDomainService;
-    private final CustomTagRepositoryExtension customTagRepositoryExtension;
 
     public void generateNewDestination(DestinationDto destinationDto) {
         if (destinationRepository.existsByName(destinationDto.getName()))
@@ -110,5 +114,49 @@ public class DestinationService {
 
         List<DestinationSimilarDto> relatedDestinations = customTagRepositoryExtension.findRelatedDestinations(destination.getId(), topTags);
         return DestinationDetailsRes.from(destination, topTags, top2Reviews, relatedDestinations);
+    }
+    
+    public List<DestinationByTagDto> getDestinationOfEachTag(int tbtiCode) {
+        /* 25.7.28
+         *   tbtiCode 값은
+         *   나중에 TBTI 성향에 따라 태그 범위를 조정하는 기능에 사용될 예정입니다.
+         *   ex) TBTI가 자연 성향 -> 산, 바다, 계곡과 같은 자연 태그를 더 많이 표시  
+         */
+        // Tbti tbti = new Tbti(tbtiCode);
+        
+        final int SAMPLE_SIZE = 10;
+        
+        // 전체 태그를 사용하지 않고 일부(최대 10개)만 무작위로 추출해 사용
+        List<Tag> tags = tagRepository.findAll();
+        List<Tag> sampleTags = null;
+        if (tags.size() <= SAMPLE_SIZE)
+            sampleTags = tags;
+        else {
+            sampleTags = new ArrayList<>(SAMPLE_SIZE);
+            Random random = new Random(System.nanoTime());
+            boolean[] select = new boolean[tags.size()];
+            while (sampleTags.size() < SAMPLE_SIZE) {
+                int idx = random.nextInt(tags.size());
+                if (!select[idx]) {
+                    select[idx] = true;
+                    sampleTags.add(tags.get(idx));
+                }
+            }
+        }
+        
+        Map<String, Destination> destinationMap = destinationRepoExtension.findAllByEachTags(
+                sampleTags.stream().map(Tag::getId).toList());
+        
+        return sampleTags.stream()
+                .filter(tag -> destinationMap.containsKey(tag.getId()))
+                .map(tag -> {
+                    Destination dest = destinationMap.get(tag.getId());
+                    return new DestinationByTagDto(
+                        dest.getName(),
+                        dest.getImageUrl(),
+                        tag.getName(), 
+                        tag.getId());
+                    })
+                .toList();
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -128,20 +129,10 @@ public class DestinationService {
         
         // 전체 태그를 사용하지 않고 일부(최대 10개)만 무작위로 추출해 사용
         List<Tag> tags = tagRepository.findAll();
-        List<Tag> sampleTags = null;
-        if (tags.size() <= SAMPLE_SIZE)
-            sampleTags = tags;
-        else {
-            sampleTags = new ArrayList<>(SAMPLE_SIZE);
-            Random random = new Random(System.nanoTime());
-            boolean[] select = new boolean[tags.size()];
-            while (sampleTags.size() < SAMPLE_SIZE) {
-                int idx = random.nextInt(tags.size());
-                if (!select[idx]) {
-                    select[idx] = true;
-                    sampleTags.add(tags.get(idx));
-                }
-            }
+        List<Tag> sampleTags = tags;
+        if (SAMPLE_SIZE < tags.size()) {
+            Collections.shuffle(sampleTags, new Random(System.nanoTime()));
+            sampleTags = sampleTags.subList(0, SAMPLE_SIZE);
         }
         
         Map<String, Destination> destinationMap = destinationRepoExtension.findAllByEachTags(

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
@@ -1,6 +1,7 @@
 package com.se.Tlog.domain.Travel.controller;
 
 import com.se.Tlog.domain.Travel.application.DestinationService;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationByTagDto;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationDetailsRes;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationDto;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
@@ -12,6 +13,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
@@ -87,5 +91,26 @@ public class DestinationController {
         return ResponseEntity
                 .status(SuccessType.DESTINATION_GET_SUCCESS.getStatus())
                 .body(SuccessRes.from(destinationService.getDestinationById(id)));
+    }
+
+    @GetMapping("/of-each-tag")
+    @Operation(
+            summary = "사용자 성향 파악용 여행지 조회",
+            description = "사용자 성향을 파악하기 위한 여행지 미리보기를 불러옵니다."
+                        + "<br> 최대 10개까지의 태그가 제시되며,"
+                        + "<br> 각 태그에는 하나의 여행지가 제시됩니다.",
+            tags = {"Travel 도메인"},
+            security = @SecurityRequirement(
+                    name = "JwtAuthScheme",
+                    scopes = {"scope1", "scope2"}),
+            parameters = {@Parameter(name = "tbtiCode", description = "사용자의 TBTI 코드입니다.")},
+            responses = {
+                    @ApiResponse( responseCode = "200", description = "성공"),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            }
+    )
+    public ResponseEntity<SuccessRes<List<DestinationByTagDto>>> getDestinationOfEachTag(@RequestParam int tbtiCode) {
+        return ResponseEntity.ok(SuccessRes.from(
+                destinationService.getDestinationOfEachTag(tbtiCode)));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationByTagDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/dto/DestinationByTagDto.java
@@ -1,0 +1,19 @@
+package com.se.Tlog.domain.Travel.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "태그를 대표하는 여행지 데이터입니다.")
+public record DestinationByTagDto(
+        @Schema(description = "여행지 이름")
+        String name,
+        
+        @Schema(description = "여행지 사진 url")
+        String imageUrl,
+        
+        @Schema(description = "대표태그 이름")
+        String tagName,
+        
+        @Schema(description = "대표태그 id")
+        String tagId) {
+
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/DestinationRepositoryExtension.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/DestinationRepositoryExtension.java
@@ -4,12 +4,19 @@ import com.mongodb.client.result.UpdateResult;
 import com.se.Tlog.domain.Review.domain.Review;
 import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.domain.DestinationSortType;
+import com.se.Tlog.domain.Travel.repository.mongo.dto.DestinationOfTagProjection;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
+
+import org.bson.types.ObjectId;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.*;
+import org.springframework.data.mongodb.core.aggregation.ArithmeticOperators.Floor;
+import org.springframework.data.mongodb.core.aggregation.ArithmeticOperators.Multiply;
+import org.springframework.data.mongodb.core.aggregation.ArrayOperators.ArrayElemAt;
+import org.springframework.data.mongodb.core.aggregation.ArrayOperators.Size;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
@@ -19,6 +26,9 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 
 @Component
 @RequiredArgsConstructor
@@ -98,5 +108,67 @@ public class DestinationRepositoryExtension {
 
         return new ArrayList<>(mongoTemplate.aggregate(aggregation, "destinations", Destination.class)
                 .getMappedResults());
+    }
+    
+    public Map<String, Destination> findAllByEachTags(List<String> tagsId) {
+        /*      // 25.7.29
+                // 쿼리 테스트를 위한 동일기능의 JSON형태 쿼리
+                [
+                    { $unwind: '$tags' },
+                    { $match: { 'tags._id': { $in: [  ] } } },
+                    { $group: { _id: '$tags._id', dests: { $push: '$_id' } } },
+                    { 
+                        $project: {
+                            selectedDestId: {
+                                $arrayElemAt: [
+                                    // 여행지
+                                    '$dests',
+                                    // 랜덤 인덱스 추출
+                                    { $floor: { $multiply: [ { $rand: {} }, { $size: '$dests' } ] } }
+                                ]
+                            }
+                        }
+                    },
+                    { 
+                        $lookup: { 
+                            from: 'destinations', 
+                            localField: 'selectedDestId',
+                            foreignField: '_id',
+                            as: 'selectedDest' 
+                        } 
+                    },
+                    { $project: { _id:1, selectedDest: { $arrayElemAt: [ "$selectedDest" , 0 ] } } }
+                ]
+        */
+        UnwindOperation pipe_unwind = Aggregation.unwind("tags");
+        MatchOperation pipe_match = Aggregation.match(Criteria.where("tags._id").in(tagsId.stream().map(ObjectId::new).toList()));
+        GroupOperation pipe_group = Aggregation.group("tags._id")
+                                    .push("_id").as("dests");
+        ProjectionOperation pipe_project1 = Aggregation.project()
+                                    .and(ArrayElemAt.arrayOf("dests")
+                                                    .elementAt(
+                                                            Floor.floorValueOf(
+                                                                Multiply
+                                                                    .valueOf(ArithmeticOperators.rand())
+                                                                    .multiplyBy(Size.lengthOfArray("dests")))))
+                                    .as("selectedDestId");
+        LookupOperation pipe_lookup = Aggregation.lookup("destinations", "selectedDestId", "_id", "selectedDest");
+        ProjectionOperation pipe_project2 = Aggregation.project()
+                                    .andInclude("_id")
+                                    .and("selectedDest").arrayElementAt(0).as("selectedDest");
+        
+        Aggregation aggregation = Aggregation.newAggregation(
+                pipe_unwind, 
+                pipe_match, 
+                pipe_group, 
+                pipe_project1,
+                pipe_lookup,
+                pipe_project2);
+        
+        AggregationResults<DestinationOfTagProjection> results = mongoTemplate.aggregate(aggregation, "destinations", DestinationOfTagProjection.class);
+        return results.getMappedResults().stream()
+                .collect(Collectors.toMap(
+                        dto -> dto.getId(),
+                        dto -> dto.getSelectedDest()));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/dto/DestinationOfTagProjection.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/dto/DestinationOfTagProjection.java
@@ -1,0 +1,14 @@
+package com.se.Tlog.domain.Travel.repository.mongo.dto;
+
+import com.se.Tlog.domain.Travel.domain.Destination;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DestinationOfTagProjection {
+    private String id;
+    private Destination selectedDest;
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -4,7 +4,10 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.se.Tlog.domain.User.repository.api.SsoService;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.domain.User.repository.jpa.UserTagRepository;
 import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Travel.domain.Tag;
+import com.se.Tlog.domain.Travel.repository.mongo.TagRepository;
 import com.se.Tlog.domain.User.controller.dto.LoginRequest;
 import com.se.Tlog.domain.User.controller.dto.RegisterRequest;
 import com.se.Tlog.domain.User.controller.dto.RegisterUserProfileDto;
@@ -13,6 +16,7 @@ import com.se.Tlog.domain.User.controller.dto.TokenDto;
 import com.se.Tlog.domain.User.domain.SsoType;
 import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.domain.User.domain.UserRegisterInfo;
+import com.se.Tlog.domain.User.domain.UserTagInfo;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import com.se.Tlog.global.util.jwt.AccessTokenProvider;
@@ -23,6 +27,7 @@ import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -32,6 +37,8 @@ import java.util.Optional;
 public class SsoAuthService {
     private final Map<SsoType, SsoService> ssoServiceMap;
     private final UserRepository userRepository;
+    private final UserTagRepository userTagRepository;
+    private final TagRepository tagRepository;
     private final AccessTokenProvider accessTokenProvider;
     private final RefreshTokenProvider refreshTokenProvider;
     private final RedisUtil redisUtil;
@@ -69,8 +76,12 @@ public class SsoAuthService {
     }
     
     private User registerNewUser(SsoUserInfo ssoUserInfo, RegisterUserProfileDto userProfiles) {
-        return userRepository.save(
+        User newUser = userRepository.save(
                 User.create(new UserRegisterInfo(ssoUserInfo, userProfiles)));
+        List<Tag> tags = tagRepository.findAllById(userProfiles.preferTagIds());
+        if (0 < tags.size())
+            userTagRepository.saveAll(UserTagInfo.of(newUser, tags));
+        return newUser;
     }
     
     public TokenDto login(LoginRequest loginRequest) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/RegisterUserProfileDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/RegisterUserProfileDto.java
@@ -1,9 +1,14 @@
 package com.se.Tlog.domain.User.controller.dto;
 
+import java.util.List;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "로그인시 입력해야하는 사용자 기본 정보입니다.")
 public record RegisterUserProfileDto(
         @Schema(description = "TBTI 검사 결과. 00000000 ~ 99999999 사이의 값이어야 합니다.", example = "00137501")
-        String tbtiValue) {
+        String tbtiValue,
+        
+        @Schema(description = "사용자가 선호하는 여행지 태그의 id입니다.", example = "[\"1a2b3c4d5e6f7g8h9i0j1k2l\", \"2b3c4d5e6f7g8h9i0j1k2l3m\"]")
+        List<String> preferTagIds) {
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/UserTagInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/UserTagInfo.java
@@ -2,7 +2,10 @@ package com.se.Tlog.domain.User.domain;
 
 import static jakarta.persistence.FetchType.LAZY;
 
+import java.util.List;
 import java.util.UUID;
+
+import com.se.Tlog.domain.Travel.domain.Tag;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -10,12 +13,15 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
 @Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "tagId"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserTagInfo {
@@ -37,5 +43,9 @@ public class UserTagInfo {
     public UserTagInfo(User user, String tagId) {
         this.user = user;
         this.tagId = tagId;
+    }
+    
+    public static List<UserTagInfo> of(User user, List<Tag> tags) {
+        return tags.stream().map(tag -> new UserTagInfo(user, tag.getId())).toList();
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/UserTagInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/UserTagInfo.java
@@ -1,0 +1,41 @@
+package com.se.Tlog.domain.User.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserTagInfo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+    
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    @NonNull
+    private User user;
+    
+    @NonNull
+    private String tagId;
+    
+    // 25.7.28
+    //   특별히 복잡한 로직이 요구되지 않는 부분이라
+    //   static으로 분리하지 않고 그대로 생성자를 사용하도록 구성했습니다.
+    public UserTagInfo(User user, String tagId) {
+        this.user = user;
+        this.tagId = tagId;
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/repository/jpa/UserTagRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/repository/jpa/UserTagRepository.java
@@ -1,0 +1,11 @@
+package com.se.Tlog.domain.User.repository.jpa;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.se.Tlog.domain.User.domain.UserTagInfo;
+
+public interface UserTagRepository extends JpaRepository<UserTagInfo, UUID> {
+
+}

--- a/tlog-was/src/test/java/com/se/Tlog/domain/Reward/Service/RewardServiceTest.java
+++ b/tlog-was/src/test/java/com/se/Tlog/domain/Reward/Service/RewardServiceTest.java
@@ -41,7 +41,7 @@ class RewardServiceTest {
 		User testUser = User.create(
 		        new UserRegisterInfo(
 		                new SsoUserInfo("TEST_PROVIDER_ID", "TEST_EMAIL", "dev.DEVELOPER_NAME", "NULL"),
-		                new RegisterUserProfileDto("00000000")));
+		                new RegisterUserProfileDto("00000000", new ArrayList<>())));
 		RewardInfo testReward = RewardInfo.create("", "보상 1", "테스트 보상 1", RewardCriteria.create(RewardCriteriaType.IS_DEVELOPER, ""));
 
 		userRepository.save(testUser);
@@ -57,7 +57,7 @@ class RewardServiceTest {
 		User testUser = User.create(
 		        new UserRegisterInfo(
 		                new SsoUserInfo("TEST_PROVIDER_ID", "TEST_EMAIL", "dev.DEVELOPER_NAME", "NULL"), 
-		                new RegisterUserProfileDto("00000000")));
+		                new RegisterUserProfileDto("00000000", new ArrayList<>())));
 		
 		List<RewardInfo> added = new ArrayList<RewardInfo>();
 		added.add(rewardInfoRepository.save(RewardInfo.create("", "보상 1", "테스트 보상 1", RewardCriteria.create(RewardCriteriaType.TEST_NULL_CRITERIA, ""))));


### PR DESCRIPTION
## 작업 동기 및 이슈
- #229 
- 회원가입시 선호하는 태그 입력할 수 있을 것

## 추가 및 변경사항
### 1) 태그별 여행지 표시 API 작성
- **회원가입 직전, 사용자 선호를 알기 위한 용도입니다.**
- 추후 TBTI별로 태그를 세부화하기 위해 사용자 TBTI를 받지만, **아직은 해당 기능은 없습니다.**
- 각 여행지 태그별로 간략하게 여행지 이름과 사진이 표시됩니다.
  <img width="400"  src="https://github.com/user-attachments/assets/a40ae628-8bcf-4880-ab55-fe8eddaf97e9" />
  <img width="400"  src="https://github.com/user-attachments/assets/badbb19f-1ffb-4e61-961f-415417468a9c" />

- **코드 변경사항**
  - `DestinationController` : `/of-each-tag` API가 추가되었습니다.
  - `DestinationByTagDto` : API용 DTO입니다.
  - `DestinationRepositoryExtention` : 태그별 여행지를 무작위로 하나 추출하는 쿼리가 추가되었습니다. `findAllByEachTags()`
  - `DestinationService` : 전체 태그 중 최대 10개를 조회해 각 태그별 대표 여행지를 반환합니다. `getDestinationOfEachTag()`

### 2) 회원가입시 사용자 선호 태그 입력
- 회원가입 과정에서 선호 태그 정보도 추가할 수 있습니다. **(preferTagIds)**
  태그는 없어도 무관합니다.
  <img width="250" src="https://github.com/user-attachments/assets/9eff2a17-fd0e-474d-afe2-46af0875a410" />

- **코드 변경사항**
  - `UserTagInfo` : 사용자의 선호 태그를 저장하는 엔티티입니다. 별도의 테이블로 관리하도록 구성했습니다.
  - `UserTagRepository` : 새 엔티티에 대한 DB 접근 리포지토리입니다.
  - `RegisterUserProfileDto` : 회원가입 정보를 받는 DTO에 사용자 선호 태그 id를 입력하는 항목이 추가되었습니다.
  - `SsoAuthService` : 사용자 정보를 저장할 때 사용자 선호 태그를 저장하는 로직이 추가되었습니다.

## 테스트 결과
- 이상 무.
  DB 확인 이상 무 (사용자-선호태그 쌍이 유일하도록 무결성 규칙 동작함)
  API 확인 이상 무 (각 태그별 무작위 여행지 표시됨 / 태그 수 제한 등)

## 📌 기타
