### PR TITLE
Feature: TBTI 정보에 선호/상극 유형 추가 및 이미지 로컬 관리

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiInfoService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiInfoService.java
@@ -22,10 +22,11 @@ public class TbtiInfoService {
         
         tbtiInfoRepository.save(
                 TbtiInfo.create(
-                        new Tbti(request.tbtiString()), 
-                        request.imageUrl(), 
+                        new Tbti(request.tbtiString()),
                         request.secondName(), 
-                        request.description()));
+                        request.description(),
+                        new Tbti(request.preferredtbtiString()),
+                        new Tbti(request.notPreferredtbtiString())));
     }
     
     public TbtiInfoRes getTbtiInfo(Tbti tbti) {
@@ -35,9 +36,10 @@ public class TbtiInfoService {
         else
             return new TbtiInfoRes(
                     tbti.toString(),
-                    tbtiInfo.getImageUrl(),
                     tbtiInfo.getSecondName(),
-                    tbtiInfo.getDescription());
+                    tbtiInfo.getDescription(),
+                    tbtiInfo.getPreferred(),
+                    tbtiInfo.getNotPreferred());
     }
     
     public TbtiInfoRes getTbtiInfo(String tbtiString) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/CreateTbtiInfoReq.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/CreateTbtiInfoReq.java
@@ -7,14 +7,17 @@ public record CreateTbtiInfoReq(
         @Schema(description = "TBTI 유형입니다.", example = "RENA")
         String tbtiString,
         
-        @Schema(description = "TBTI 캐릭터 일러스트입니다.")
-        String imageUrl,
-        
         @Schema(description = "TBTI 유형의 다른 이름입니다.", example = "자연 속 즉흥 사색가")
         String secondName,
         
         @Schema(description = "TBTI 설명입니다.", example = "자연의 향기와 소리를 ~")
-        String description
+        String description,
+
+        @Schema(description = "어울리는 TBTI 유형입니다.", example = "RENA")
+        String preferredtbtiString,
+
+        @Schema(description = "상극인 TBTI 유형입니다.", example = "RENA")
+        String notPreferredtbtiString
         ) {
 
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiInfoRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiInfoRes.java
@@ -7,16 +7,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "TBTI 특성에 관한 정보를 표시하는 데이터입니다.")
 public record TbtiInfoRes(
         String tbtiString,
-        String imageUrl,
         String secondName,
-        String description) {
+        String description,
+        String preferredTbti,
+        String notPreferredTbti) {
 
     public static TbtiInfoRes getNullDto(Tbti tbti) {
         String tbtiStr = tbti.toString();
         return new TbtiInfoRes(
-                tbtiStr, 
-                "", 
-                "아직 " + tbtiStr + "의 정보가 없어요...", 
-                "아직 " + tbtiStr + "가 어떤 성향인지 조사하고 있어요!");
+                tbtiStr,
+                "아직 " + tbtiStr + "의 정보가 없어요...",
+                "아직 " + tbtiStr + "가 어떤 성향인지 조사하고 있어요!",
+                tbtiStr,
+                tbtiStr);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiInfoRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiInfoRes.java
@@ -6,10 +6,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "TBTI 특성에 관한 정보를 표시하는 데이터입니다.")
 public record TbtiInfoRes(
+        @Schema(description = "TBTI 유형입니다.", example = "RENA")
         String tbtiString,
+        @Schema(description = "TBTI 유형의 다른 이름입니다.", example = "자연 속 즉흥 사색가")
         String secondName,
+        @Schema(description = "TBTI 설명입니다.", example = "자연의 향기와 소리를 ~")
         String description,
+        @Schema(description = "어울리는 TBTI 유형입니다.", example = "RENA")
         String preferredTbti,
+        @Schema(description = "상극인 TBTI 유형입니다.", example = "RENA")
         String notPreferredTbti) {
 
     public static TbtiInfoRes getNullDto(Tbti tbti) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiInfo.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiInfo.java
@@ -25,26 +25,30 @@ public class TbtiInfo {
     
     private String tbtiString;
     
-    private String imageUrl;
-    
     private String secondName;
     
     private String description;
+
+    private String preferred;
+
+    private String notPreferred;
     
-    private TbtiInfo(String tbtiString, String imageUrl, String secondName, String description) {
+    private TbtiInfo(String tbtiString, String secondName, String description, String preferred, String notPreferred) {
         this.tbtiString = tbtiString;
-        this.imageUrl = imageUrl;
         this.secondName = secondName;
         this.description = description;
+        this.preferred = preferred;
+        this.notPreferred = notPreferred;
     }
     
-    public static TbtiInfo create(Tbti tbti, String imageUrl, String secondName, String description) {
+    public static TbtiInfo create(Tbti tbti, String secondName, String description, Tbti preferred, Tbti notPreferred) {
         if (tbti == null
-                || imageUrl == null
                 || secondName == null
-                || description == null)
+                || description == null
+                || preferred == null
+                || notPreferred == null)
             throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
         
-        return new TbtiInfo(tbti.toString(), imageUrl, secondName, description);
+        return new TbtiInfo(tbti.toString(), secondName, description, preferred.toString(), notPreferred.toString());
     }
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #231 
- #232 

## 추가 및 변경사항

### 기능상 변경점
  API 상에서 DTO에 imageUrl이 삭제되고 preferred/notPreferred 관련 필드가 추가되었습니다.

### 코드 변경점
- **`TbtiInfo` 테이블**
  - `imageUrl` 필드 제거 : 불필요한 필드를 계속 유지하기보다 미리 제거하는 것이 나을 것으로 판단, 제거했습니다.
  - `preferred` 필드 추가 : 이 TBTI가 선호하는 TBTI의 알파벳 문자열입니다. ex) `RENA`
  - `notPreferred` 필드 추가 : 이 TBTI와 상극인 TBTI의 알파벳 문자열입니다. ex) `RENA`
- **DTO 변경**
  - `CreateTbtiInfoReq` 및 `TbtiInfoRes`에서
    imageUrl 데이터 제거, preferred/notPreferred 관련 데이터가 추가되었습니다.
- **`TbtiInfoService`에 변경사항 반영**

## 테스트 결과
- 이상 무.
  <img width="500" src="https://github.com/user-attachments/assets/2e7bddca-bb71-43d1-9f67-109381be6d36" />

## 📌 기타
서버에 변경사항 반영하는대로 TBTI 설명의 선호/상극 정보도 업로드 예정입니다.