### PR TITLE
Feature: 개발자 피드백 및 게시글 신고 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/application/OperationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/application/OperationService.java
@@ -4,6 +4,8 @@ import com.se.Tlog.domain.Admin.controller.dto.CreateFeedbackReq;
 import com.se.Tlog.domain.Admin.domain.Feedback;
 import com.se.Tlog.domain.Admin.repository.mongo.FeedbackRepository;
 import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 
 import java.util.UUID;
@@ -14,6 +16,11 @@ public class OperationService {
     private final FeedbackRepository feedbackRepository;
 
     public void makeFeedback(UUID userId, CreateFeedbackReq request) {
+        if (userId == null)
+            throw new CustomException(ErrorType.UN_AUTHORIZATION);
+        if (request == null)
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+
         Feedback newFeedback = Feedback.create(
                 userId,
                 request.title(),

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/application/OperationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/application/OperationService.java
@@ -1,9 +1,13 @@
 package com.se.Tlog.domain.Admin.application;
 
 import com.se.Tlog.domain.Admin.controller.dto.CreateFeedbackReq;
+import com.se.Tlog.domain.Admin.controller.dto.CreateReportToPostReq;
 import com.se.Tlog.domain.Admin.domain.Feedback;
+import com.se.Tlog.domain.Admin.domain.ReportOfPost;
 import com.se.Tlog.domain.Admin.repository.mongo.FeedbackRepository;
+import com.se.Tlog.domain.Admin.repository.mongo.ReportOfPostRepository;
 import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Social.Post.repository.mongo.PostRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +18,8 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class OperationService {
     private final FeedbackRepository feedbackRepository;
+    private final PostRepository postRepository;
+    private final ReportOfPostRepository reportOfPostRepository;
 
     public void makeFeedback(UUID userId, CreateFeedbackReq request) {
         if (userId == null)
@@ -27,5 +33,19 @@ public class OperationService {
                 request.content(),
                 request.refImageUrls());
         feedbackRepository.save(newFeedback);
+    }
+
+    public void makeReportToPost(UUID reporterId, CreateReportToPostReq request) {
+        if (reporterId == null)
+            throw new CustomException(ErrorType.UN_AUTHORIZATION);
+        if (request == null || request.postId() == null)
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        if (!postRepository.existsById(request.postId()))
+            throw new CustomException(ErrorType.POST_NOT_FOUND);
+
+        ReportOfPost report = reportOfPostRepository.findByPostId(request.postId());
+        if (report != null) report.addReport(reporterId);
+        else report = ReportOfPost.create(request.postId(), reporterId);
+        reportOfPostRepository.save(report);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/application/OperationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/application/OperationService.java
@@ -1,0 +1,24 @@
+package com.se.Tlog.domain.Admin.application;
+
+import com.se.Tlog.domain.Admin.controller.dto.CreateFeedbackReq;
+import com.se.Tlog.domain.Admin.domain.Feedback;
+import com.se.Tlog.domain.Admin.repository.mongo.FeedbackRepository;
+import com.se.Tlog.domain.ApplicationService;
+import lombok.RequiredArgsConstructor;
+
+import java.util.UUID;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class OperationService {
+    private final FeedbackRepository feedbackRepository;
+
+    public void makeFeedback(UUID userId, CreateFeedbackReq request) {
+        Feedback newFeedback = Feedback.create(
+                userId,
+                request.title(),
+                request.content(),
+                request.refImageUrls());
+        feedbackRepository.save(newFeedback);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/OperationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/OperationController.java
@@ -2,6 +2,7 @@ package com.se.Tlog.domain.Admin.controller;
 
 import com.se.Tlog.domain.Admin.application.OperationService;
 import com.se.Tlog.domain.Admin.controller.dto.CreateFeedbackReq;
+import com.se.Tlog.domain.Admin.controller.dto.CreateReportToPostReq;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorRes;
 import com.se.Tlog.global.response.error.ErrorType;
@@ -50,6 +51,25 @@ public class OperationController {
         if (user == null)
             throw new CustomException(ErrorType.UN_AUTHENTICATION);
         operationService.makeFeedback(UUID.fromString(user.getId()), request);
+        return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+    }
+
+    @PostMapping("/report/post")
+    @Operation(
+            summary = "게시물 신고",
+            description = "SNS 게시물을 신고합니다."
+                    + "<br><br><b>인증 토큰이 필요합니다!</b>",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공. 별도로 반환되는 정보는 없습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<?>> reportPost(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody CreateReportToPostReq request) {
+        if (user == null)
+            throw new CustomException(ErrorType.UN_AUTHENTICATION);
+        operationService.makeReportToPost(UUID.fromString(user.getId()), request);
         return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/OperationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/OperationController.java
@@ -34,7 +34,7 @@ import java.util.UUID;
 public class OperationController {
     private final OperationService operationService;
 
-    @PostMapping("/destinations")
+    @PostMapping("/feedback")
     @Operation(
             summary = "개발자에게 피드백",
             description = "피드백을 전달합니다."
@@ -44,7 +44,7 @@ public class OperationController {
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
                             content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
     )
-    public ResponseEntity<SuccessRes<?>> approvedDestination(
+    public ResponseEntity<SuccessRes<?>> makeFeedback(
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestBody CreateFeedbackReq request) {
         if (user == null)

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/OperationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/OperationController.java
@@ -1,0 +1,55 @@
+package com.se.Tlog.domain.Admin.controller;
+
+import com.se.Tlog.domain.Admin.application.OperationService;
+import com.se.Tlog.domain.Admin.controller.dto.CreateFeedbackReq;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.error.ErrorType;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.response.success.SuccessType;
+import com.se.Tlog.global.security.dto.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.UUID;
+
+@Controller
+@RequestMapping("/api/operation")
+@RequiredArgsConstructor
+@Tag(name = "서비스 운영 관련")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
+public class OperationController {
+    private final OperationService operationService;
+
+    @PostMapping("/destinations")
+    @Operation(
+            summary = "개발자에게 피드백",
+            description = "피드백을 전달합니다."
+                        + "<br><br><b>인증 토큰이 필요합니다!</b>",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공. 별도로 반환되는 정보는 없습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<?>> approvedDestination(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody CreateFeedbackReq request) {
+        if (user == null)
+            throw new CustomException(ErrorType.UN_AUTHENTICATION);
+        operationService.makeFeedback(UUID.fromString(user.getId()), request);
+        return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/dto/CreateFeedbackReq.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/dto/CreateFeedbackReq.java
@@ -1,0 +1,20 @@
+package com.se.Tlog.domain.Admin.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+import java.util.List;
+
+public record CreateFeedbackReq(
+        /* // 이 필드는 jwt Token을 통해 받을 수 있는 정보이므로 생략합니다.
+         * @Schema(description = "피드백을 생성한 사용자")
+         * UUID userId
+         */
+        @Schema(example = "조회가 안됩니다")
+        String title,
+        @Schema(example = "이전에 다녀온 여행지를 조회하고 싶은데 표시되지 않습니다 고쳐주세요")
+        String content,
+        @Schema(requiredMode = RequiredMode.NOT_REQUIRED, example = "[\"imageUrl1\", \"imageUrl2\"]")
+        List<String> refImageUrls
+) {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/dto/CreateReportToPostReq.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/controller/dto/CreateReportToPostReq.java
@@ -1,0 +1,15 @@
+package com.se.Tlog.domain.Admin.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CreateReportToPostReq(
+        @Schema(description = "신고할 게시글의 id", example = "1a2b3c4d5e6f7g8h9i0j1k2l")
+        String postId
+
+        /* // 추후 확장시 본문도 포함가능합니다.
+        private String title;
+
+        private String content;
+         */
+) {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/domain/Feedback.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/domain/Feedback.java
@@ -1,0 +1,46 @@
+package com.se.Tlog.domain.Admin.domain;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Document(collection = "feedback")
+@Getter
+public class Feedback {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    private UUID sender;
+
+    private String title;
+
+    private String content;
+
+    private List<String> refImageUrls;
+
+    private Feedback(UUID sender, String title, String content, List<String> refImageUrls) {
+        this.sender = sender;
+        this.title = title;
+        this.content = content;
+        this.refImageUrls = refImageUrls;
+    }
+
+    public static Feedback create(UUID sender, String title, String content, List<String> refImageUrls) {
+        if (sender == null
+            || title == null || title.trim().isBlank()
+            || content == null || content.trim().isBlank())
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        if (refImageUrls == null)
+            refImageUrls = new ArrayList<>();
+        return new Feedback(sender, title, content, refImageUrls);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/domain/Feedback.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/domain/Feedback.java
@@ -16,7 +16,6 @@ import java.util.UUID;
 @Getter
 public class Feedback {
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     private String id;
 
     private UUID sender;

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/domain/Feedback.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/domain/Feedback.java
@@ -2,12 +2,11 @@ package com.se.Tlog.domain.Admin.domain;
 
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -18,6 +17,8 @@ public class Feedback {
     @Id
     private String id;
 
+    private LocalDateTime writtenAt;
+
     private UUID sender;
 
     private String title;
@@ -27,6 +28,7 @@ public class Feedback {
     private List<String> refImageUrls;
 
     private Feedback(UUID sender, String title, String content, List<String> refImageUrls) {
+        this.writtenAt = LocalDateTime.now();
         this.sender = sender;
         this.title = title;
         this.content = content;

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/domain/ReportOfPost.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/domain/ReportOfPost.java
@@ -1,0 +1,59 @@
+package com.se.Tlog.domain.Admin.domain;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Document(collection = "report_post")
+@Getter
+@NoArgsConstructor
+public class ReportOfPost {
+    @Id
+    private String id;
+
+    private String postId;
+
+    private List<ReportData> reports;
+
+    @Getter
+    public static class ReportData {
+        private UUID reporterId;
+
+        private LocalDateTime reportedAt;
+
+        /* // 추후 확장시 본문도 포함가능합니다.
+        private String title;
+
+        private String content;
+         */
+
+        private ReportData(UUID reporterId) {
+            this.reporterId = reporterId;
+            this.reportedAt = LocalDateTime.now();
+        }
+    }
+
+    public void addReport(UUID reporterId) {
+        this.reports.add(new ReportData(reporterId));
+    }
+
+    private ReportOfPost(String postId, UUID reporterId) {
+        this.postId = postId;
+        this.reports = new ArrayList<>();
+        addReport(reporterId);
+    }
+
+    public static ReportOfPost create(String postId, UUID reporterId) {
+        if (postId == null || reporterId == null)
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        return new ReportOfPost(postId, reporterId);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/repository/mongo/FeedbackRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/repository/mongo/FeedbackRepository.java
@@ -1,0 +1,9 @@
+package com.se.Tlog.domain.Admin.repository.mongo;
+
+import com.se.Tlog.domain.Admin.domain.Feedback;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeedbackRepository extends MongoRepository<Feedback, String> {
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Admin/repository/mongo/ReportOfPostRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Admin/repository/mongo/ReportOfPostRepository.java
@@ -1,0 +1,10 @@
+package com.se.Tlog.domain.Admin.repository.mongo;
+
+import com.se.Tlog.domain.Admin.domain.ReportOfPost;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportOfPostRepository extends MongoRepository<ReportOfPost, String> {
+    ReportOfPost findByPostId(String postId);
+}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #234 
- #235 

## 추가 및 변경사항
- 위 기능은 서비스 운영과 관련이 깊어,
  관련 코드들은 `Admin` 도메인의 `Operation`으로 배정되었습니다.
  <img width="350" src="https://github.com/user-attachments/assets/450bdb46-c93a-4ad2-a557-37d4bb5b0a26" />
### 1) 개발자 피드백 기능
- 데이터는 MongoDB의 `feedback` 컬렉션에 저장됩니다.
  : MySQL에 저장해도 무방하나, 좀 더 복잡한 쿼리로 필터링하기 용이해 우선 MongoDB에 배정했습니다.
- 요구한 명세 외에, 참고 이미지인 `refImageUrls` 필드도 추가되었습니다. 대신, 필수로 요구되지는 않습니다.
  <img width="500" src="https://github.com/user-attachments/assets/13d2d334-bd1e-4693-88ea-cf87b91103ca" />

### 2) 게시글 신고 기능
- 데이터는 MongoDB의 `report_post` 컬렉션에 저장됩니다.
  : 추후 누적 신고 수 추적과 같이 Post 데이터와의 연계를 용이하게 하기 위해 MongoDB에 배정했습니다.
- 추후 신고 기능의 확장을 고려해 엔티티는 `ReportOfPost` 내에 `ReportData`가 임베딩 된 구조로 설계했습니다.
  (fdf8f726fffd046bf9b88d79088cb8b04004e1c9)
  <img width="500" src="https://github.com/user-attachments/assets/e9778f5d-90b0-4028-ba4e-57b2feea684c" />

## 테스트 결과
- 이상 무.
  **개발자 피드백 :**
  <img width="500" src="https://github.com/user-attachments/assets/d5265546-6d4b-4702-9ef3-8b6368271328" />
  **게시글 신고 :**
  <img width="500" src="https://github.com/user-attachments/assets/c0ef0093-1a9c-40f3-9584-c330ea73761b" />


## 📌 기타
