### PR TITLE
Feature: ci/cd 파이프라인 구축

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,40 @@
+name: Continuous Deployment
+
+on:
+  push:
+    branches: ["develop"]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Docker build & push
+        run: |
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/tlog:latest .
+          docker push ${{ secrets.DOCKER_USERNAME }}/tlog:latest
+
+
+      - name: Deploy to server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          port: ${{ secrets.EC2_SSH_PORT }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+            docker system prune -a -f
+            docker-compose down
+            docker rmi ${{ secrets.DOCKER_USERNAME }}/tlog:latest
+            docker pull ${{ secrets.DOCKER_USERNAME }}/tlog:latest
+            docker-compose up -d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,11 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      # 1. Compare branch 코드 내려 받기
-      - uses: actions/checkout@v4
+
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
 
       - uses: actions/setup-java@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
+FROM gradle:8.4-jdk17 AS builder
+
+WORKDIR /app
+
+COPY . /app
+
+WORKDIR /app/tlog-was
+RUN ./gradlew build -x test
+
+
 FROM openjdk:17-jdk-slim
 
 LABEL authors="gojungsu"
 
-ARG JAR_FILE=../tlog-was/build/libs/*.jar
-COPY ${JAR_FILE} app.jar
+COPY --from=builder /app/tlog-was/build/libs/*.jar app.jar
 
 ENTRYPOINT ["java", "-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE}", "-jar", "/app.jar"]

--- a/tlog-docker/docker-compose-prod.yml
+++ b/tlog-docker/docker-compose-prod.yml
@@ -7,9 +7,7 @@ secrets:
 services:
   spring:
     container_name: tlog-spring
-    build:
-      context: ..
-      dockerfile: Dockerfile
+    image: ${{secrets.DOCKER_USERNAME}}/tlog:latest
     ports:
       - "8080:8080"
     depends_on:


### PR DESCRIPTION
## 작업 동기 및 이슈
- ci/cd 파이프라인 구축
- 기존의 불편한 EC2 환경에서의 build 방식 -> docker image 빌드 방식으로 변경

## 작업 내용

develop 브런치에 push 이벤트 발생시 자동 배포 되는 환경으로 변경 했습니다. 
cd.yml 파일에서의 주요 과정 Docker build & push, Deploy to server

1. docker image 빌드(Dockerfile 기준으로) -> DockerHub에 push 
2. EC2 서버 접속 -> docker login 하여 최신 이미지 빌드

현재 구조로 인해 더이상 EC2 서버에서 방대한 코드를 삭제해도 괜찮을 것 같아서 삭제 했습니다. 현재 유지중인 구조는 firebase.key , tlog-docker 등 최소한의 폴더만 유지중입니다. 더이상 .git 파일 등도 없어도 될 것 같기도 하고 아니면 cd 파일 스크립트에 불필요 파일 삭제하는 코드를 넣어서 자동으로 관리해도 될 것같은데 의견 부탁드립니다.

로컬 환경에서는 기존 테스트 대로 docker-compose-dev.yml 파일로 빠르게 빌드하여 테스트 하면 될 것 같습니다!

## 📌 기타
- 테스트 해본 결과 이상 없습니다!
