### PR TITLE
Feature: 에러 처리기에 httpMessageNotReadable 예외 처리로직 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/global/exception/GlobalExceptionHandler.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/exception/GlobalExceptionHandler.java
@@ -3,7 +3,9 @@ package com.se.Tlog.global.exception;
 import com.se.Tlog.global.response.error.ErrorRes;
 import com.se.Tlog.global.response.error.ErrorType;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -29,6 +31,15 @@ public class GlobalExceptionHandler {
     	ErrorRes error = ErrorRes.of(INTERNAL_SERVER_ERROR.getStatusCode(), INTERNAL_SERVER_ERROR.getMessage());
     	log.error("Error occurred : Task rejected - Server Thread Overflow!!");
     	log.error("\t\t : [errorCode={}, message={}]", e.getClass(), e.getMessage(), e);
+        return ResponseEntity.status(error.status()).body(error);
+    }
+
+    // 클라이언트 요청을 파싱하는 중 발생한 에러
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<?> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.error("Error occurred : There is a problem with the HTTP Request Body");
+        log.error("Exception occurred", e);  // stacktrace 출력!
+        ErrorRes error = ErrorRes.of(HttpStatus.BAD_REQUEST.value(), "[Parse Error] HTTP Request Body가 잘못되었습니다.");
         return ResponseEntity.status(error.status()).body(error);
     }
 


### PR DESCRIPTION
## 작업 동기 및 이슈
- #239 
- json 구문 오류와 같은 클라이언트 측 오류가 500 - 서버 에러로 반환되어, 이를 수정합니다.

## 추가 및 변경사항
- GlobalExceptionHandler 클래스
  - 구문 분석 오류로 발생하는 `HttpMessageNotReadableException` 예외에 대한 적절한 핸들러 메소드 추가

## 테스트 결과
- 이상 무.
  HTTP 요청 에러에 대해서는 400 - BAD REQUEST를 반환합니다.

## 📌 기타
