### PR TITLE
Feature: 사용자 선호 여행지와 관련된 정보 관리 방식 변경

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -116,7 +116,8 @@ public class DestinationService {
         List<DestinationSimilarDto> relatedDestinations = customTagRepositoryExtension.findRelatedDestinations(destination.getId(), topTags);
         return DestinationDetailsRes.from(destination, topTags, top2Reviews, relatedDestinations);
     }
-    
+
+    @Deprecated(since = "사용자 선호 여행지의 관리 방식이 변경되었습니다.", forRemoval = true)
     public List<DestinationByTagDto> getDestinationOfEachTag(int tbtiCode) {
         /* 25.7.28
          *   tbtiCode 값은

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
@@ -93,6 +93,8 @@ public class DestinationController {
                 .body(SuccessRes.from(destinationService.getDestinationById(id)));
     }
 
+    /*
+     * 25.9.23 이 API는 사용자 성향 파악용 정보의 표시 방식이 변경됨에 따라 삭제되었습니다.
     @GetMapping("/of-each-tag")
     @Operation(
             summary = "사용자 성향 파악용 여행지 조회",
@@ -113,4 +115,5 @@ public class DestinationController {
         return ResponseEntity.ok(SuccessRes.from(
                 destinationService.getDestinationOfEachTag(tbtiCode)));
     }
+     */
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -13,10 +13,12 @@ import com.se.Tlog.domain.User.controller.dto.RegisterRequest;
 import com.se.Tlog.domain.User.controller.dto.RegisterUserProfileDto;
 import com.se.Tlog.domain.User.controller.dto.SsoUserInfo;
 import com.se.Tlog.domain.User.controller.dto.TokenDto;
+import com.se.Tlog.domain.User.domain.PreferPhoto;
 import com.se.Tlog.domain.User.domain.SsoType;
 import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.domain.User.domain.UserRegisterInfo;
 import com.se.Tlog.domain.User.domain.UserTagInfo;
+import com.se.Tlog.domain.User.repository.mongo.PreferPhotoRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import com.se.Tlog.global.util.jwt.AccessTokenProvider;
@@ -39,6 +41,7 @@ public class SsoAuthService {
     private final UserRepository userRepository;
     private final UserTagRepository userTagRepository;
     private final TagRepository tagRepository;
+    private final PreferPhotoRepository preferPhotoRepository;
     private final AccessTokenProvider accessTokenProvider;
     private final RefreshTokenProvider refreshTokenProvider;
     private final RedisUtil redisUtil;
@@ -78,9 +81,17 @@ public class SsoAuthService {
     private User registerNewUser(SsoUserInfo ssoUserInfo, RegisterUserProfileDto userProfiles) {
         User newUser = userRepository.save(
                 User.create(new UserRegisterInfo(ssoUserInfo, userProfiles)));
-        List<Tag> tags = tagRepository.findAllById(userProfiles.preferTagIds());
-        if (0 < tags.size())
-            userTagRepository.saveAll(UserTagInfo.of(newUser, tags));
+
+        List<Integer> photoIds = userProfiles.preferPhotoIds();
+        if (photoIds != null && !photoIds.isEmpty()) {
+            List<PreferPhoto> photos = preferPhotoRepository.findAllById(photoIds);
+            List<String> tagIds = photos.stream()
+                    .flatMap(photo -> photo.getTagIds().stream())
+                    .toList(); // 25.9.23 추후 겹치는 태그를 더 강하게 표시하는 등의 목적을 위해 중복값을 허용합니다.
+            List<Tag> tags = tagRepository.findAllById(tagIds);
+            if (!tags.isEmpty())
+                userTagRepository.saveAll(UserTagInfo.of(newUser, tags));
+        }
         return newUser;
     }
     

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
@@ -98,6 +98,7 @@ public class AuthController {
             }
     )
     public ResponseEntity<?> register(@RequestBody RegisterRequest request){
+		RegisterRequest.validate(request); // 추후 Spring Validation을 도입하여 대체 가능
 
         TokenDto tokenDto = ssoAuthService.register(request);
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/RegisterRequest.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/RegisterRequest.java
@@ -1,6 +1,8 @@
 package com.se.Tlog.domain.User.controller.dto;
 
 import com.se.Tlog.domain.User.domain.SsoType;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "SSO 인증을 통한 회원가입 요청 DTO")
@@ -14,4 +16,10 @@ public record RegisterRequest(
         @Schema(description = "회원가입시 입력해야하는 사용자 기본 정보입니다.")
         RegisterUserProfileDto userProfile
 ) {
+        public static void validate(RegisterRequest value) {
+                if (value == null
+                        || value.type == null || value.accessToken == null || value.userProfile == null)
+                        throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+                RegisterUserProfileDto.validate(value.userProfile);
+        }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/RegisterUserProfileDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/RegisterUserProfileDto.java
@@ -11,8 +11,8 @@ public record RegisterUserProfileDto(
         @Schema(description = "TBTI 검사 결과. 00000000 ~ 99999999 사이의 값이어야 합니다.", example = "00137501")
         String tbtiValue,
         
-        @Schema(description = "사용자가 선호하는 여행지 태그의 id입니다.", example = "[\"1a2b3c4d5e6f7g8h9i0j1k2l\", \"2b3c4d5e6f7g8h9i0j1k2l3m\"]")
-        List<String> preferTagIds) {
+        @Schema(description = "사용자가 선호하는 여행지 사진의 id입니다.", example = "[1, 3, 7]")
+        List<Integer> preferPhotoIds) {
 
         public static void validate(RegisterUserProfileDto value) {
                 if (value == null || value.tbtiValue == null)

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/RegisterUserProfileDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/dto/RegisterUserProfileDto.java
@@ -2,6 +2,8 @@ package com.se.Tlog.domain.User.controller.dto;
 
 import java.util.List;
 
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "로그인시 입력해야하는 사용자 기본 정보입니다.")
@@ -11,4 +13,9 @@ public record RegisterUserProfileDto(
         
         @Schema(description = "사용자가 선호하는 여행지 태그의 id입니다.", example = "[\"1a2b3c4d5e6f7g8h9i0j1k2l\", \"2b3c4d5e6f7g8h9i0j1k2l3m\"]")
         List<String> preferTagIds) {
+
+        public static void validate(RegisterUserProfileDto value) {
+                if (value == null || value.tbtiValue == null)
+                        throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/PreferPhoto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/domain/PreferPhoto.java
@@ -1,0 +1,21 @@
+package com.se.Tlog.domain.User.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document(collection = "preferPhotos")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PreferPhoto {
+    @Id
+    private int id;
+
+    private String imageUrl;
+
+    private List<String> tagIds;
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/repository/mongo/PreferPhotoRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/repository/mongo/PreferPhotoRepository.java
@@ -1,0 +1,7 @@
+package com.se.Tlog.domain.User.repository.mongo;
+
+import com.se.Tlog.domain.User.domain.PreferPhoto;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface PreferPhotoRepository extends MongoRepository<PreferPhoto, Integer> {
+}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #241 

## 추가 및 변경사항
- **사용자 선호 여행지정보는 이제 서버단에서 제공되지 않습니다**
  - API `/api/destinations/of-each-tag` 가 제거되었습니다.

- **회원가입시 전달하는 선호 여행지 정보의 형태가 변경되었습니다.**
  - `preferTagIds` -> `preferPhotoIds` 으로 변경
  <img width="221"  src="https://github.com/user-attachments/assets/438c3a9b-567b-4b2e-b553-762b6322efb6" />
  <img width="203"  src="https://github.com/user-attachments/assets/421e6314-14df-4f9c-bbd3-4c0ee61c932d" />

- **관련 DB 데이터가 추가되었습니다.**
  - **PreferPhoto** 엔티티 추가
  - MongoDB의 preferPhotos 컬렉션으로 운영됩니다.
  - 별도의 수정이나 추가가 빈번하지 않으며, 단순히 서비스 운영상 정해진 정책을 저장하는 용도로 사용됩니다.

## 테스트 결과
- 이상 무.
  - 운영되고 있는 태그가 다음과 같이 존재할 경우,
    <img height="300" src="https://github.com/user-attachments/assets/c8be4edd-c82e-4c24-a4c9-d17a163a899a" />

  - 회원가입시 선호하는 사진을 선택하는대로 관련된 태그 정보가 함께 저장됩니다.
    (사용자 선호 태그를 저장하는 `UserTagInfo` 테이블)
    <img width="600" src="https://github.com/user-attachments/assets/6781179b-5052-4db4-936d-49e807850eb2" />


## 📌 기타
