### PR TITLE
Feature: 팀 리스트 보내줄 때 팀원 prifileImage 추가

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
@@ -101,7 +101,7 @@ public class TeamService {
 				teamLeaderName = user.getName();
 
 			memberSimpleDtoList.add(
-					TeamMemberSimpleDto.from(user.getId(), user.getTbtiString())
+					TeamMemberSimpleDto.from(user)
 			);
 		}
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/CreateTeamRequestDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/CreateTeamRequestDto.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "팀 생성에 요구되는 DTO 형식입니다.")
 public record CreateTeamRequestDto(
-		@Schema(description = "팀 이름")
+		@Schema(description = "팀 이름", example = "my team 1")
 		String name,
 
 		@Schema(description = "팀 생성자")

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
@@ -13,8 +13,8 @@ public record TeamDetailDto(
         String teamName,
         String tbtiString,
         String inviteCode,
-        LocalDate startDate,
-        LocalDate endDate,
+        LocalDate createdAt,
+        LocalDate expiredAt,
         List<TeamMemberDto> members,
         List<WishlistDestinationRes> wishlist,
         TravelPlanDto travelPlanDto

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamMemberSimpleDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamMemberSimpleDto.java
@@ -1,16 +1,20 @@
 package com.se.Tlog.domain.Team.controller.dto;
 
 
+import com.se.Tlog.domain.User.domain.User;
+
 import java.util.UUID;
 
 public record TeamMemberSimpleDto(
         UUID memberId,
-        String tbtiString
+        String tbtiString,
+        String profileImage
 ) {
-    public static TeamMemberSimpleDto from(UUID userId,String tbtiString) {
+    public static TeamMemberSimpleDto from(User user) {
         return new TeamMemberSimpleDto(
-                userId,
-                tbtiString
+                user.getId(),
+                user.getTbtiString(),
+                user.getProfileImage()
         );
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamResponseDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamResponseDto.java
@@ -1,5 +1,6 @@
 package com.se.Tlog.domain.Team.controller.dto;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -12,7 +13,8 @@ public record TeamResponseDto(
 		String teamName,
 		String teamLeaderName,
 		List<TeamMemberSimpleDto> memberSimpleDtoList, //유저들 id + profile 예정
-		TravelPlanDto travelPlanDto
+		TravelPlanDto travelPlanDto,
+		LocalDate createAt
 		) {
 	public static TeamResponseDto from(Team team, String teamLeaderName, List<TeamMemberSimpleDto> memberSimpleDtoList,TravelPlanDto travelPlanDto) {
 		return new TeamResponseDto(
@@ -20,7 +22,8 @@ public record TeamResponseDto(
 				team.getName(),
 				teamLeaderName,
 				memberSimpleDtoList,
-				travelPlanDto
+				travelPlanDto,
+				team.getCreatedAt().toLocalDate()
 		);
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TravelPlanDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TravelPlanDto.java
@@ -10,10 +10,10 @@ import java.util.Map;
 @Schema(description = "여행 계획 정보 DTO")
 public record TravelPlanDto(
 
-        @Schema(description = "여행 도시")
+        @Schema(description = "여행 도시", example = "서울")
         String city,
 
-        @Schema(description = "여행 지역")
+        @Schema(description = "여행 지역", example = "[\"서울 강서구\", \"서울 은평구\"]")
         List<String> regionList,
 
         @Schema(description = "반려견 동반 여부")
@@ -28,7 +28,7 @@ public record TravelPlanDto(
         @Schema(description = "여행 종료일")
         LocalDate endDate,
 
-        @Schema(description = "일자별 방문 여행지 수 설정")
+        @Schema(description = "일자별 방문 여행지 수 설정", example = "{\"1\" : 3, \"2\" : 2, \"3\" : 5}")
         Map<Integer, Integer> visitCountPerDay
 ) {
         public static TravelPlanDto from(TravelPlan travelPlan) {


### PR DESCRIPTION
## 작업 동기 및 이슈
프론트엔드 수정 사항
- 팀 리스트 보내줄 때 팀원 ImageUrl 필요
- 팀 정보 보내줄 때 date 제대로 넘어오지 않음 (생성 시 날짜가 넘어오지 않음)

## 추가 및 변경사항
- 수정사항 반영 팀 리스트 보내줄 때 유저 profileImage 포함 반환
- 팀 리스트 반환시 createAt 필드 추가

## 테스트 결과
<img width="744" height="390" alt="스크린샷 2025-09-24 오후 6 12 06" src="https://github.com/user-attachments/assets/59c5a793-5c7a-4bea-8c3a-3a98a38473ea" />

## 📌 기타

