### PR TITLE
Feature: 팀 정보 반환시 팀장 id 추가 반환

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
@@ -89,23 +89,23 @@ public class TeamService {
 	) {
 		List<TeamUserJpaEntity> teamMembers = entry.getValue();
 		Team team = teamMembers.get(0).getTeam();
-		String teamLeaderName = null;
 		List<TeamMemberSimpleDto> memberSimpleDtoList = new ArrayList<>();
 
 		TravelPlan travelPlan = travelPlanMap.get(entry.getKey().toString());
 		TravelPlanDto travelPlanDto = travelPlan != null ? TravelPlanDto.from(travelPlan) : null;
 
+		User teamLeader = null;
 		for (TeamUserJpaEntity teamUserInTeam : teamMembers) {
 			User user = teamUserInTeam.getUser();
 			if (teamUserInTeam.isLeader())
-				teamLeaderName = user.getName();
+				teamLeader = user;
 
 			memberSimpleDtoList.add(
 					TeamMemberSimpleDto.from(user)
 			);
 		}
 
-		return TeamResponseDto.from(team, teamLeaderName, memberSimpleDtoList, travelPlanDto);
+		return TeamResponseDto.from(team, teamLeader, memberSimpleDtoList, travelPlanDto);
 	}
 	
 	public void deleteTeam(UUID requesterId, UUID teamId) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamMemberSimpleDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamMemberSimpleDto.java
@@ -2,11 +2,13 @@ package com.se.Tlog.domain.Team.controller.dto;
 
 
 import com.se.Tlog.domain.User.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.UUID;
 
 public record TeamMemberSimpleDto(
         UUID memberId,
+        @Schema(description = "팀원의 TBTI 유형입니다.", example = "RENA")
         String tbtiString,
         String profileImage
 ) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamResponseDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamResponseDto.java
@@ -5,22 +5,25 @@ import java.util.List;
 import java.util.UUID;
 
 import com.se.Tlog.domain.Team.domain.Team;
+import com.se.Tlog.domain.User.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "팀 정보를 표시하는 DTO입니다.")
 public record TeamResponseDto(
 		UUID teamId,
 		String teamName,
+		UUID teamLeaderId,
 		String teamLeaderName,
 		List<TeamMemberSimpleDto> memberSimpleDtoList, //유저들 id + profile 예정
 		TravelPlanDto travelPlanDto,
 		LocalDate createAt
 		) {
-	public static TeamResponseDto from(Team team, String teamLeaderName, List<TeamMemberSimpleDto> memberSimpleDtoList,TravelPlanDto travelPlanDto) {
+	public static TeamResponseDto from(Team team, User teamLeader, List<TeamMemberSimpleDto> memberSimpleDtoList, TravelPlanDto travelPlanDto) {
 		return new TeamResponseDto(
 				team.getId(),
 				team.getName(),
-				teamLeaderName,
+				teamLeader.getId(),
+				teamLeader.getName(),
 				memberSimpleDtoList,
 				travelPlanDto,
 				team.getCreatedAt().toLocalDate()


### PR DESCRIPTION
## 작업 동기 및 이슈
- #244 

## 추가 및 변경사항
- `TeamResponseDto`에 `teamLeaderId` 필드가 추가되었습니다.
- 관련 DTO의 Swagger UI 문서화가 보완되었습니다.

(`teamLeaderId` 필드 추가된 Json 결과)
<img width="500" src="https://github.com/user-attachments/assets/6e7ec2e5-78fd-4d9f-bf24-1408f1bcc8ba" />


## 테스트 결과
- 이상 무.

## 📌 기타
