### PR TITLE
Feature: 팀 조회시 채팅방 id 추가 반환

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/room/ChatRoomService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/room/ChatRoomService.java
@@ -65,4 +65,10 @@ public class ChatRoomService {
 
         return ChatRoomListResponseDto.from(room.getId(), content, lastMessageSentAt,countChatRoomJoinUsers,unreadCount);
     }
+
+    public Long getRoomIdByTeam(UUID teamId) {
+        return chatRoomRepository.findByTeamId(teamId)
+                .orElseThrow(() -> new CustomException(ErrorType.CHATROOM_NOT_FOUND))
+                .getId();
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/application/TeamService.java
@@ -164,6 +164,11 @@ public class TeamService {
 				.orElseThrow(() -> new CustomException(ErrorType.TRAVEL_PLAN_NOT_FOUND));
 
 		TravelPlanDto travelPlanDto = TravelPlanDto.from(travelPlan);
-		return TeamDetailDto.from(team, memberDtoList, wishList, travelPlanDto);
+		return TeamDetailDto.from(
+				team,
+				chatRoomService.getRoomIdByTeam(team.getId()),
+				memberDtoList,
+				wishList,
+				travelPlanDto);
 	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/TeamController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/TeamController.java
@@ -3,7 +3,7 @@ package com.se.Tlog.domain.Team.controller;
 import java.util.List;
 import java.util.UUID;
 
-import com.se.Tlog.domain.Team.controller.dto.TeamCreateRes;
+import com.se.Tlog.domain.Team.controller.dto.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -16,9 +16,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.se.Tlog.domain.Team.application.TeamService;
-import com.se.Tlog.domain.Team.controller.dto.CreateTeamRequestDto;
-import com.se.Tlog.domain.Team.controller.dto.TeamResponseDto;
-import com.se.Tlog.domain.Team.controller.dto.TeamUserRequestDto;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorRes;
 import com.se.Tlog.global.response.error.ErrorType;
@@ -84,11 +81,13 @@ public class TeamController {
 			},
 			responses = {
 					@ApiResponse(responseCode = "200", description = "팀 상세 정보 반환 성공"),
-					@ApiResponse(responseCode = "404", description = "존재하지 않는 팀입니다."),
-					@ApiResponse(responseCode = "500", description = "서버 내부 오류")
+					@ApiResponse(responseCode = "404", description = "존재하지 않는 팀입니다.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class))),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))
 			}
 	)
-	public ResponseEntity<?> getTeamDetails(@PathVariable UUID teamId) {
+	public ResponseEntity<SuccessRes<TeamDetailDto>> getTeamDetails(@PathVariable UUID teamId) {
 	    // 추후 인증 토큰을 사용해, 타 사용자의 팀을 함부로 조회하지 못하도록 변경 예정
 		return ResponseEntity.
 				ok(SuccessRes.from(teamService.getTeamDetails(teamId)));

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
@@ -13,19 +13,21 @@ public record TeamDetailDto(
         String teamName,
         String tbtiString,
         String inviteCode,
+        Long chatRoomId,
         LocalDate createdAt,
         LocalDate expiredAt,
         List<TeamMemberDto> members,
         List<WishlistDestinationRes> wishlist,
         TravelPlanDto travelPlanDto
 ) {
-    public static TeamDetailDto from(Team team, List<TeamMemberDto> members,
+    public static TeamDetailDto from(Team team, Long chatRoomId, List<TeamMemberDto> members,
                                      List<WishlistDestinationRes> wishlist, TravelPlanDto travelPlanDto) {
         return new TeamDetailDto(
                 team.getId(),
                 team.getName(),
                 team.getTbtiString(), // 만약 TBTI 설명까지 추가해야 할 경우, 여기서 처리하지 않고 외부에서 설명 DTO를 파라미터로 받을 것!
                 InviteCodeUtil.longToStr(team.getInviteCode()),
+                chatRoomId,
                 team.getCreatedAt().toLocalDate(),
                 LocalDate.now(),
                 members,

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamDetailDto.java
@@ -3,15 +3,20 @@ package com.se.Tlog.domain.Team.controller.dto;
 import com.se.Tlog.domain.Team.domain.InviteCodeUtil;
 import com.se.Tlog.domain.Team.domain.Team;
 import com.se.Tlog.domain.Wishlist.domain.dto.WishlistDestinationRes;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+@Schema
 public record TeamDetailDto(
         UUID teamId,
+        @Schema(example = "나의 팀")
         String teamName,
+        @Schema(example = "RENA")
         String tbtiString,
+        @Schema(example = "aBcdEF")
         String inviteCode,
         Long chatRoomId,
         LocalDate createdAt,

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamMemberDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Team/controller/dto/TeamMemberDto.java
@@ -1,13 +1,16 @@
 package com.se.Tlog.domain.Team.controller.dto;
 
 import com.se.Tlog.domain.User.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.UUID;
 
+@Schema
 public record TeamMemberDto(
         UUID userId,
         String profileImageUrl,
         String name,
+        @Schema(example = "RENA")
         String tbtiString,
         boolean isLeader
 ) {


### PR DESCRIPTION
## 작업 동기 및 이슈
- #246 

## 추가 및 변경사항
- 관련 API 문서화가 보완되었습니다. (표시되지 않는 문제 수정)
- `teamDetailDto`에 `chatRoomId` 필드가 추가되었습니다.
  <img width="500" src="https://github.com/user-attachments/assets/75b39f3d-0c96-4e7d-bd5d-523fba8a7a48" />

## 테스트 결과
- 이상 무.

## 📌 기타
