### PR TITLE
Feature: 지역 축제/ 팝업스토어 행사 표시 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/GuideController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/GuideController.java
@@ -1,0 +1,50 @@
+package com.se.Tlog.domain.Guide.controller;
+
+import com.se.Tlog.domain.Guide.controller.dto.GuideDto;
+import com.se.Tlog.domain.Guide.service.GuideService;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.success.SuccessRes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/local-guide")
+@RequiredArgsConstructor
+@Tag(name = "메인페이지 - 지역 행사 관련")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
+public class GuideController {
+    private final GuideService guideService;
+
+    @GetMapping
+    @Operation(
+            summary = "지역 행사 조회",
+            description = "사용자의 위치를 기반으로 지역 행사를 조회합니다."
+                        + "<br>위치가 주어지지 않거나 잘못 입력되면 근처 행사는 조회되지 않습니다.",
+            parameters = {
+                    @Parameter(name = "latitude", description = "사용자의 위치정보 (위도, -90~90)"),
+                    @Parameter(name = "longitude", description = "사용자의 위치정보 (경도, -180~180)")},
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공. 사용자의 코스 리스트를 반환합니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류. 조회에 실패했습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<Page<GuideDto>>> getLocalGuide(
+            @RequestParam(name = "latitude", defaultValue = "-1000") Double latitude,
+            @RequestParam(name = "longitude", defaultValue = "-1000") Double longitude,
+            Pageable pageable) {
+        return ResponseEntity.ok(SuccessRes.from(
+                guideService.getLocalGuides(latitude, longitude, pageable)));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/dto/GuideDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/dto/GuideDto.java
@@ -1,0 +1,23 @@
+package com.se.Tlog.domain.Guide.controller.dto;
+
+import com.se.Tlog.domain.Guide.domain.Guide;
+
+import java.util.List;
+
+public record GuideDto(
+        String imageUrl,
+        String title,
+        String description,
+        List<String>property,
+        String infoUrl
+) {
+    public static GuideDto from(Guide guide) {
+        return new GuideDto(
+                guide.getImageUrl(),
+                guide.getTitle(),
+                guide.getDescription(),
+                List.of(guide.getProperty().split("/")),
+                guide.getInfoUrl()
+        );
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/domain/Guide.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/domain/Guide.java
@@ -1,0 +1,31 @@
+package com.se.Tlog.domain.Guide.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Guide {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    private String imageUrl;
+
+    private String title;
+
+    private String description;
+
+    // '/' 문자로 구분합니다. (부산/지역맛집/등등)
+    private String property;
+
+    private double minLatitude;
+    private double minLongitude;
+    private double maxLatitude;
+    private double maxLongitude;
+
+    private String infoUrl;
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/repository/jpa/GuideRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/repository/jpa/GuideRepository.java
@@ -1,0 +1,19 @@
+package com.se.Tlog.domain.Guide.repository.jpa;
+
+import com.se.Tlog.domain.Guide.domain.Guide;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GuideRepository extends JpaRepository<Guide, Integer> {
+    @Query("""
+        SELECT g 
+        FROM Guide g  
+        WHERE (:latitude BETWEEN g.minLatitude AND g.maxLatitude)
+            AND (:longitude BETWEEN g.minLongitude AND g.maxLongitude)
+        """)
+    Page<Guide> findLocalGuide(double latitude, double longitude, Pageable pageable);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/service/GuideService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/service/GuideService.java
@@ -1,0 +1,23 @@
+package com.se.Tlog.domain.Guide.service;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Guide.controller.dto.GuideDto;
+import com.se.Tlog.domain.Guide.domain.Guide;
+import com.se.Tlog.domain.Guide.repository.jpa.GuideRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class GuideService {
+    private final GuideRepository guideRepository;
+
+    public Page<GuideDto> getLocalGuides(double latitude, double longitude, Pageable pageable) {
+        if (90.0 < Math.abs(latitude)) latitude = 360.0;
+        if (180.0 < Math.abs(longitude)) longitude = 360.0;
+
+        Page<Guide> localguides = guideRepository.findLocalGuide(latitude, longitude, pageable);
+        return localguides.map(GuideDto::from);
+    }
+}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #248 

## 추가 및 변경사항
- **메인페이지 화면에 표시할 지역 행사 데이터를 반환합니다.**
  - `Guide` 엔티티 및 테이블 추가
  - API 추가
    <img width="400" src="https://github.com/user-attachments/assets/84413176-66d3-4573-b81f-bf235a6808ae" />
  - 각 행사들의 표시 범위가 위도/경도로 미리 설정됩니다.
  - 주어진 위도/경도에서 범위를 필터링해 행사를 표시합니다.

## 테스트 결과
- 이상 무.
  <img width="400" src="https://github.com/user-attachments/assets/d89d8638-42e9-40d4-98c9-b43abd411e25" />


## 📌 기타
