### PR TITLE
Feature : 채팅방 입장시 채팅로그 반환 및 오류 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/message/ChatConsumerService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/message/ChatConsumerService.java
@@ -50,9 +50,12 @@ public class ChatConsumerService {
         ChatReadUsers chatReadUsers = ChatReadUsers.create(sender, chatMessage);
         chatReadUsersRepository.save(chatReadUsers);
 
+        int totalParticipants = chatRoomUserRepository.countChatRoomJoinUsers(chatRoom.getId());
+        int initialReadCount = 1;
+
         messagingTemplate.convertAndSend(
                 "/sub/chat/room/" + chatRoom.getId(),
-                ChatMessageDto.from(sender, chatRoom, savedChatMessage)
+                ChatMessageDto.from(savedChatMessage, initialReadCount, totalParticipants)
         );
 
         // connectedUserIds = 현재 채팅방 구독중인 유저

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/message/ChatService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/message/ChatService.java
@@ -1,5 +1,7 @@
 package com.se.Tlog.domain.Social.Chat.message;
 
+import com.se.Tlog.domain.Social.Chat.message.dto.ChatHistoryResponse;
+import com.se.Tlog.domain.Social.Chat.message.dto.ChatMessageDto;
 import com.se.Tlog.domain.Social.Chat.message.dto.ChatMessageReadDto;
 import com.se.Tlog.domain.Social.Chat.message.dto.ChatMessageRequestDto;
 import com.se.Tlog.domain.Social.Chat.read.ChatReadUsers;
@@ -7,14 +9,20 @@ import com.se.Tlog.domain.Social.Chat.room.ChatRoom;
 import com.se.Tlog.domain.Social.Chat.message.repository.jpa.ChatMessageRepository;
 import com.se.Tlog.domain.Social.Chat.read.repository.jpa.ChatReadUsersRepository;
 import com.se.Tlog.domain.Social.Chat.room.repository.jpa.ChatRoomRepository;
+import com.se.Tlog.domain.Social.Chat.room.repository.jpa.ChatRoomUserRepository;
 import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.domain.User.domain.service.UserDomainService;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Service
@@ -25,6 +33,7 @@ public class ChatService {
     private final ChatReadUsersRepository chatReadUsersRepository;
     private final RabbitPublisher rabbitPublisher;
     private final UserDomainService userDomainService;
+    private final ChatRoomUserRepository chatRoomUserRepository;
 
     @Transactional
     public void sendChatMessage(ChatMessageRequestDto chatMessageRequestDto) {
@@ -49,5 +58,67 @@ public class ChatService {
             ChatReadUsers chatReadUsers = ChatReadUsers.create(user, chatMessage);
             chatReadUsersRepository.save(chatReadUsers);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public ChatHistoryResponse getChatHistory(Long roomId, Long beforeMessageId, int size) {
+        // 채팅방 존재 확인
+        if (!chatRoomRepository.existsById(roomId)) {
+            throw new CustomException(ErrorType.CHATROOM_NOT_FOUND);
+        }
+
+        // 채팅방 전체 참여자 수
+        int totalParticipants = chatRoomUserRepository.countChatRoomJoinUsers(roomId);
+
+        List<ChatMessage> messages;
+        if (beforeMessageId == null) {
+            // 첫 요청: 최신 메시지부터 size개 가져온다.
+            messages = chatMessageRepository.findRecentMessages(
+                    roomId,
+                    PageRequest.of(0, size) // 0페이지 , size개
+            );
+        } else {
+            /*
+            * 추가 요청 (스크롤해서 과거 메시지 로드)
+            * - beforeMessageId 보다 오래된 메시지 size개 가져옴
+            * */
+            messages = chatMessageRepository.findMessagesBeforeCursor(
+                    roomId,
+                    beforeMessageId,
+                    PageRequest.of(0, size)
+            );
+        }
+
+        List<Long> messageIds = messages.stream()
+                .map(ChatMessage::getId)
+                .toList();
+
+        List<Object[]> readCounts = chatReadUsersRepository.countReadsByMessageIds(messageIds);
+        Map<Long, Integer> readCountMap = new HashMap<>();
+        for (Object[] row : readCounts) {
+            Long messageId = (Long) row[0];
+            Long count = (Long) row[1];
+            readCountMap.put(messageId, count.intValue());
+        }
+
+        List<ChatMessageDto> messageDtos = messages.stream()
+                .map(message -> {
+                    int readCount = readCountMap.getOrDefault(message.getId(), 0);
+                    return ChatMessageDto.from(message, readCount, totalParticipants);
+                })
+                .toList();
+        /*
+        * 다음 커서 계산
+        * - 가져온 메시지 중 가장 오래된 메시지의 ID
+        * - 다음 요청 시 이 ID를 beforeMessageId로 사용
+        * */
+        Long nextCursor = messages.isEmpty() ? null : messages.get(messages.size() - 1).getId();
+        boolean hasMore = messages.size() == size;
+
+        return ChatHistoryResponse.from(
+                messageDtos,
+                nextCursor,
+                hasMore
+        );
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/message/dto/ChatHistoryResponse.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/message/dto/ChatHistoryResponse.java
@@ -1,0 +1,17 @@
+package com.se.Tlog.domain.Social.Chat.message.dto;
+
+import java.util.List;
+
+public record ChatHistoryResponse(
+        List<ChatMessageDto> messages,
+        Long nextCursor,
+        boolean hasMore
+
+) {
+    public static ChatHistoryResponse from(
+            List<ChatMessageDto> messages,
+            Long nextCursor,
+            boolean hasMore) {
+        return new ChatHistoryResponse(messages, nextCursor, hasMore);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/message/dto/ChatMessageDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/message/dto/ChatMessageDto.java
@@ -1,20 +1,28 @@
 package com.se.Tlog.domain.Social.Chat.message.dto;
 
 import com.se.Tlog.domain.Social.Chat.message.ChatMessage;
-import com.se.Tlog.domain.Social.Chat.room.ChatRoom;
-import com.se.Tlog.domain.User.domain.User;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record ChatMessageDto(
+        Long id,
         UUID senderId,
         String senderName,
         Long chatRoomId,
         String content,
-        LocalDateTime sendAt
+        LocalDateTime sendAt,
+        int unreadCount
 ) {
-    static public ChatMessageDto from(User user, ChatRoom chatRoom, ChatMessage chatMessage) {
-        return new ChatMessageDto(user.getId(), user.getName(), chatRoom.getId(), chatMessage.getContent(), chatRoom.getCreateAt());
+    public static ChatMessageDto from(ChatMessage message, int readCount, int totalParticipants) {
+        return new ChatMessageDto(
+                message.getId(),
+                message.getSender().getId(),
+                message.getSender().getName(),
+                message.getChatRoom().getId(),
+                message.getContent(),
+                message.getSendAt(),
+                totalParticipants - readCount
+        );
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/message/repository/jpa/ChatMessageRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/message/repository/jpa/ChatMessageRepository.java
@@ -1,10 +1,13 @@
 package com.se.Tlog.domain.Social.Chat.message.repository.jpa;
 
 import com.se.Tlog.domain.Social.Chat.message.ChatMessage;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
@@ -12,4 +15,29 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     int countUnreadMessages(@Param("roomId") Long roomId, @Param("lastReadMessageId") Long lastReadMessageId);
 
     ChatMessage findFirstByChatRoomIdOrderByIdDesc(Long roomId);
+
+
+    /*
+    * 특정 채팅방의 특정 ID보다 이전 메시지만 최신순 정렬
+    * */
+    @Query("SELECT m FROM ChatMessage m " +
+            "JOIN FETCH m.sender " +
+            "JOIN FETCH m.chatRoom " +
+            "WHERE m.chatRoom.id = :roomId " +
+            "ORDER BY m.id DESC")
+    List<ChatMessage> findMessagesBeforeCursor(
+            @Param("roomId") Long roomId,
+            @Param("beforeId") Long beforeId,
+            Pageable pageable
+    );
+
+    @Query("SELECT m FROM ChatMessage m " +
+            "JOIN FETCH m.sender " +
+            "JOIN FETCH m.chatRoom " +
+            "WHERE m.chatRoom.id = :roomId " +
+            "ORDER BY m.id DESC")
+    List<ChatMessage> findRecentMessages(
+            @Param("roomId") Long roomId,
+            Pageable pageable
+    );
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/read/repository/jpa/ChatReadUsersRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/read/repository/jpa/ChatReadUsersRepository.java
@@ -4,9 +4,27 @@ import com.se.Tlog.domain.Social.Chat.message.ChatMessage;
 import com.se.Tlog.domain.Social.Chat.read.ChatReadUsers;
 import com.se.Tlog.domain.User.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ChatReadUsersRepository extends JpaRepository<ChatReadUsers,Long> {
     Boolean existsByUserAndMessage(User user, ChatMessage message);
+
+    // 메시지별 읽음 수 조회 (효율적인 방법)
+    @Query("SELECT cr.message.id, COUNT(cr) " +
+            "FROM ChatReadUsers cr " +
+            "WHERE cr.message.id IN :messageIds " +
+            "GROUP BY cr.message.id")
+    List<Object[]> countReadsByMessageIds(@Param("messageIds") List<Long> messageIds);
+
+    // 특정 메시지의 읽음 수
+    int countByMessage(ChatMessage message);
+
+    // 메시지 ID로 읽음 수 조회
+    @Query("SELECT COUNT(cr) FROM ChatReadUsers cr WHERE cr.message.id = :messageId")
+    int countByMessageId(@Param("messageId") Long messageId);
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/room/ChatRoomController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Social/Chat/room/ChatRoomController.java
@@ -1,5 +1,6 @@
 package com.se.Tlog.domain.Social.Chat.room;
 
+import com.se.Tlog.domain.Social.Chat.message.ChatService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -18,6 +19,7 @@ import java.util.UUID;
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
+    private final ChatService chatService;
 
     @GetMapping("/room/{hostId}")
     @Operation(
@@ -37,4 +39,26 @@ public class ChatRoomController {
     public ResponseEntity<?> getRoomList(@PathVariable(name = "hostId") UUID hostId) {
         return ResponseEntity.ok().body(SuccessRes.from(chatRoomService.getRoomList(hostId)));
     }
+
+    @GetMapping("/room/{roomId}/messages")
+    @Operation(
+            summary = "채팅방 메시지 히스토리 조회",
+            description = "채팅방 입장 시 과거 메시지를 페이지네이션으로 조회합니다.",
+            tags = {"ChatRoom 관리"},
+            parameters = {
+                    @Parameter(name = "roomId", description = "채팅방 ID"),
+                    @Parameter(name = "size", description = "한 페이지당 메시지 수 (기본값: 50)")
+            }
+    )
+    public ResponseEntity<?> getChatHistory(
+            @PathVariable Long roomId,
+            @RequestParam(defaultValue = "50") int size,
+            @RequestParam(required = false) Long beforeMessageId
+    ) {
+        return ResponseEntity.ok()
+                .body(SuccessRes.from(
+                        chatService.getChatHistory(roomId, beforeMessageId, size)
+                ));
+    }
+
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #250 

## 추가 및 변경사항
- 채팅방 입장시 채팅로그 50개를 반환합니다. -> 프론트는 버퍼 같은 곳에 저장해두고 특정 임계점 마다 10~15개 정도 반환하면 될 것 같습니다. 그리고 무한스크롤 형식으로 작성했기 때문에 반환되는 dto에 있는  nextCursor를 저장해두고 함께 api 요청하면 됩니다.
- 기존에는 없었던 메시지 반환할 때 읽지 않은 사용자의 수도 함께 반환되게끔 수정했습니다.
- 메시지 dto에 id가 누락된 부분 수정했습니다.

## 테스트 결과
- 프론트엔드팀과 테스트해보며 수정할 부분 찾아보겠습니다!
