### PR TITLE
Feature: 메인페이지 배너, 추천여행지, 추천게시글 API 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/RecommendController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/RecommendController.java
@@ -1,0 +1,104 @@
+package com.se.Tlog.domain.Guide.controller;
+
+import com.se.Tlog.domain.Guide.controller.dto.BannerDto;
+import com.se.Tlog.domain.Guide.controller.dto.RecommendDestDto;
+import com.se.Tlog.domain.Guide.controller.dto.RecommendPostDto;
+import com.se.Tlog.domain.Guide.service.RecommendService;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorRes;
+import com.se.Tlog.global.response.error.ErrorType;
+import com.se.Tlog.global.response.success.SuccessRes;
+import com.se.Tlog.global.security.dto.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/recommend")
+@RequiredArgsConstructor
+@Tag(name = "메인페이지 - 여행지, 게시글 추천")
+@SecurityRequirement(
+        name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
+        scopes = {"scope1", "scope2"})
+public class RecommendController {
+    private final RecommendService recommendService;
+
+    @GetMapping("/banners")
+    @Operation(
+            summary = "배너 조회 (인증 토큰 필요)",
+            description = "메인페이지의 배너를 조회합니다."
+                        + "<br><br><b>인증 토큰이 필요합니다!</b>",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공. 배너 정보를 반환합니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류. 조회에 실패했습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<List<BannerDto>>> getBanners(
+            @AuthenticationPrincipal CustomUserDetails user) {
+        if (user == null)
+            throw new CustomException(ErrorType.UN_AUTHENTICATION);
+
+        return ResponseEntity.ok(SuccessRes.from(
+                recommendService.getBanners(UUID.fromString(user.getId()))));
+    }
+
+    @GetMapping("/destinations/{bannerId}")
+    @Operation(
+            summary = "배너에서 추천된 여행지 조회",
+            description = "배너에서 추천된 여행지를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공. 여행지 정보를 반환합니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류. 조회에 실패했습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<Page<DestinationSummaryRes>>> getBannerDestinations(
+            @PathVariable String bannerId,
+            @Parameter(example = "{\n  \"page\": 0,\n  \"size\": 10\n}")
+            @PageableDefault(size = 10, page = 0) Pageable pageable) {
+        return ResponseEntity.ok(SuccessRes.from(
+                recommendService.getBannerDests(bannerId, pageable)));
+    }
+
+    @GetMapping("/destinations")
+    @Operation(
+            summary = "명소 추천 조회",
+            description = "메인페이지의 명소 추천 결과를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공. 여행 명소 정보를 반환합니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류. 조회에 실패했습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<List<RecommendDestDto>>> getDestinations() {
+        return ResponseEntity.ok(SuccessRes.from(
+                recommendService.getRecommendDests()));
+    }
+
+    @GetMapping("/posts")
+    @Operation(
+            summary = "추천 게시글 조회",
+            description = "메인페이지의 추천 게시글을 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "처리 성공. 추천 게시글 정보를 반환합니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류. 조회에 실패했습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+    )
+    public ResponseEntity<SuccessRes<List<RecommendPostDto>>> getPosts() {
+        return ResponseEntity.ok(SuccessRes.from(
+                recommendService.getRecommendPosts()));
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/dto/BannerDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/dto/BannerDto.java
@@ -1,0 +1,39 @@
+package com.se.Tlog.domain.Guide.controller.dto;
+
+import com.se.Tlog.domain.Guide.domain.RecBanner;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class BannerDto {
+    private String id;
+    private String imageUrl;
+    private String title;
+    @Schema(example = "[\"해시\",\"태그\",\"샵(#)은\",\"없습니다\"]")
+    private List<String> hashtags;
+
+    /*
+     * 배너 데이터로는 아직 사용하지 않습니다.
+    @Schema(example = "(관련있는 경우 제공됩니다) https://related.url/")
+    private String relatedUrl;
+    @Schema(example = "(관련있는 경우 제공됩니다) 여행지 id")
+    private List<String> destinationIds;
+    */
+
+    public static BannerDto create(RecBanner banner) {
+        return create(banner, banner.getTitle());
+    }
+
+    public static BannerDto create(RecBanner banner, String title) {
+        return new BannerDto(
+                banner.getId(),
+                banner.getImageUrl(),
+                title,
+                banner.getHashTags()
+        );
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/dto/RecommendDestDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/dto/RecommendDestDto.java
@@ -1,0 +1,44 @@
+package com.se.Tlog.domain.Guide.controller.dto;
+
+import com.se.Tlog.domain.Guide.repository.dto.FullRecDest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class RecommendDestDto {
+    @Schema(example = "https://example.com/image")
+    private String imageUrl;
+    @Schema(example = "이번 가을, 단풍 속에서 인생샷!")
+    private String title;
+    @Schema(example = "가을 풍경 명소 보러가기")
+    private String description;
+    private List<Dest> destinations;
+    @Data
+    @AllArgsConstructor
+    public static class Dest {
+        @Schema(example = "https://example.com/image")
+        private String imageUrl;
+        @Schema(example = "티로그마을 단풍길")
+        private String name;
+        @Schema(example = "여행지id")
+        private String id;
+    }
+
+    public static RecommendDestDto create(FullRecDest recDest) {
+        return new RecommendDestDto(
+                recDest.getImageUrl(),
+                recDest.getTitle(),
+                recDest.getDescription(),
+                recDest.getDestinations().stream()
+                        .map(dest -> new Dest(
+                                dest.getImageUrl(),
+                                dest.getName(),
+                                dest.getId()
+                        )).toList()
+        );
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/dto/RecommendPostDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/dto/RecommendPostDto.java
@@ -1,0 +1,20 @@
+package com.se.Tlog.domain.Guide.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class RecommendPostDto {
+    @Schema(example = "[\"https://example.com/image1\", \"https://example.com/image2\"]")
+    private List<String> imageUrls;
+    @Schema(example = "5월에 가본 여행지~")
+    private String title;
+    @Schema(example = "최근 친적집 방문 겸 ~에 같이 다녀왔어요")
+    private String description;
+    @Schema(example = "게시글ID")
+    private String id;
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/domain/BannerType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/domain/BannerType.java
@@ -1,0 +1,7 @@
+package com.se.Tlog.domain.Guide.domain;
+
+public enum BannerType {
+    TBTI_DEST_RECOMMEND, // ex) TBTI를 위한 4월 여행지
+    DESTINATION_BUNDLE, // ex) 이번 여행은 온천 여행!
+    JUST_INFO // ex) 공지, 동남아 여행경보 등등
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/domain/RecBanner.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/domain/RecBanner.java
@@ -1,0 +1,30 @@
+package com.se.Tlog.domain.Guide.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document(collection = "recommend_banner")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class RecBanner {
+    @Id
+    private String id;
+
+    private String imageUrl;
+
+    private String title;
+
+    private List<String> hashTags;
+
+    private BannerType bannerType;
+
+    // ------ inner data ------
+
+    private String relatedUrl;
+    private List<String> destinationIds;
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/domain/RecDest.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/domain/RecDest.java
@@ -1,0 +1,23 @@
+package com.se.Tlog.domain.Guide.domain;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document(collection = "recommend_destination")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecDest {
+    @Id
+    private String id;
+
+    private String imageUrl;
+
+    private String title;
+
+    private String description;
+
+    private List<String> destinationIds;
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/repository/dto/FullRecDest.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/repository/dto/FullRecDest.java
@@ -1,0 +1,24 @@
+package com.se.Tlog.domain.Guide.repository.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class FullRecDest {
+    private String id;
+
+    private String imageUrl;
+
+    private String title;
+
+    private String description;
+
+    private List<Dest> destinations;
+    @Data
+    public static class Dest {
+        private String imageUrl;
+        private String name;
+        private String id;
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/repository/dto/RecomPost.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/repository/dto/RecomPost.java
@@ -1,0 +1,12 @@
+package com.se.Tlog.domain.Guide.repository.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class RecomPost {
+    private List<String> imageUrls;
+    private String content;
+    private String id;
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/repository/mongo/RecBannerRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/repository/mongo/RecBannerRepository.java
@@ -1,0 +1,71 @@
+package com.se.Tlog.domain.Guide.repository.mongo;
+
+import com.se.Tlog.domain.Guide.domain.RecBanner;
+import com.se.Tlog.domain.Travel.domain.Destination;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.ConvertOperators;
+import org.springframework.data.mongodb.core.aggregation.VariableOperators;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.schema.JsonSchemaObject;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RecBannerRepository {
+    private final MongoTemplate mongoTemplate;
+    private final String COLLECTION_NAME = "recommend_banner";
+
+    public List<RecBanner> findAll() {
+        return mongoTemplate.findAll(RecBanner.class, COLLECTION_NAME);
+    }
+
+    @Data
+    private class DestResults {
+        List<Destination> destinations;
+        int count;
+    }
+
+    public Page<Destination> findAllDestinationsFromBanner(String bannerId, Pageable pageable) {
+        Aggregation query = Aggregation.newAggregation(
+                // 1. id로 배너를 검색합니다.
+                Aggregation.match(Criteria.where("_id").is(new ObjectId(bannerId))),
+                // 2. 문자열 형태인 여행지ID를 ObjectId 타입으로 변환합니다.
+                Aggregation.addFields()
+                        .addField("destIds").withValue(
+                                VariableOperators.Map
+                                        .itemsOf("destinationIds")
+                                        .as("destId")
+                                        .andApply(
+                                                ConvertOperators.Convert
+                                                        .convertValue("$$destId")
+                                                        .to(JsonSchemaObject.Type.objectIdType())))
+                        .build(),
+                // 3. 여행지 데이터를 Join해 가져옵니다.
+                Aggregation.lookup()
+                        .from("destinations")
+                        .localField("destIds")
+                        .foreignField("_id")
+                        .as("destinations"),
+                // 4. 페이징 처리합니다.
+                Aggregation.project()
+                        .and("destinations").size().as("count")
+                        .and("destinations").slice(pageable.getPageSize(), (int)pageable.getOffset()).as("destinations")
+        );
+
+        DestResults result = mongoTemplate.aggregate(query, COLLECTION_NAME, DestResults.class)
+                .getUniqueMappedResult();
+        return new PageImpl<>(
+                result.getDestinations(),
+                pageable,
+                result.getCount());
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/repository/mongo/RecDestRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/repository/mongo/RecDestRepository.java
@@ -1,0 +1,62 @@
+package com.se.Tlog.domain.Guide.repository.mongo;
+
+import com.se.Tlog.domain.Guide.domain.RecDest;
+import com.se.Tlog.domain.Guide.repository.dto.FullRecDest;
+import org.springframework.data.mongodb.repository.Aggregation;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface RecDestRepository extends MongoRepository<RecDest, String> {
+
+    // 1. 무작위 하나의 항목만 검색합니다.
+    static final String QUERY_1_SAMPLE = "{ '$sample': { 'size': ?0 } }";
+
+    // 2. 문자열 형태인 여행지ID를 ObjectId 타입으로 변환합니다.
+    static final String QUERY_2_CONVERT_ID = """
+            {
+              "$addFields": {
+                "destIds": {
+                  "$map": {
+                    "input": "$destinationIds",
+                    "as": "destId",
+                    "in": {
+                      "$convert": {
+                        "input": "$$destId",
+                        "to": "objectId"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+    // 3. 여행지 데이터를 Join해 가져옵니다.
+    static final String QUERY_3_JOIN_WITH_DESTINATION = """
+            {
+              "$lookup": {
+                "from": "destinations",
+                "localField": "destIds",
+                "foreignField": "_id",
+                "pipeline": [
+                  {
+                    "$project": {
+                      "_id": 1,
+                      "imageUrl": 1,
+                      "name": 1
+                    }
+                  }
+                ],
+                "as": "destinations"
+              }
+            }
+            """;
+
+    @Aggregation(pipeline = {
+            QUERY_1_SAMPLE,
+            QUERY_2_CONVERT_ID,
+            QUERY_3_JOIN_WITH_DESTINATION
+    })
+    List<FullRecDest> findSomeWithDestinations(int size);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/repository/mongo/RecPostRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/repository/mongo/RecPostRepository.java
@@ -1,0 +1,32 @@
+package com.se.Tlog.domain.Guide.repository.mongo;
+
+import com.se.Tlog.domain.Guide.repository.dto.RecomPost;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RecPostRepository {
+    private final MongoTemplate mongoTemplate;
+
+    public List<RecomPost> findSome(int size) {
+        Aggregation query = Aggregation.newAggregation(
+                Aggregation.sample(size),
+                Aggregation.project()
+                        .and("_id").as("_id")
+                        .and("content").as("content")
+                        .and("imageUrls").as("imageUrls")
+        );
+        AggregationResults<RecomPost> results = mongoTemplate.aggregate(
+                query,
+                "sns_post",
+                RecomPost.class
+        );
+        return results.getMappedResults();
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/service/RecommendService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/service/RecommendService.java
@@ -1,0 +1,97 @@
+package com.se.Tlog.domain.Guide.service;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Guide.controller.dto.BannerDto;
+import com.se.Tlog.domain.Guide.controller.dto.RecommendDestDto;
+import com.se.Tlog.domain.Guide.controller.dto.RecommendPostDto;
+import com.se.Tlog.domain.Guide.domain.BannerType;
+import com.se.Tlog.domain.Guide.domain.RecBanner;
+import com.se.Tlog.domain.Guide.repository.dto.FullRecDest;
+import com.se.Tlog.domain.Guide.repository.dto.RecomPost;
+import com.se.Tlog.domain.Guide.repository.mongo.RecBannerRepository;
+import com.se.Tlog.domain.Guide.repository.mongo.RecDestRepository;
+import com.se.Tlog.domain.Guide.repository.mongo.RecPostRepository;
+import com.se.Tlog.domain.Travel.application.DestinationService;
+import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+import com.se.Tlog.domain.User.domain.User;
+import com.se.Tlog.domain.User.repository.jpa.UserRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.UUID;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class RecommendService {
+    private final DestinationService destinationService;
+    private final UserRepository userRepository;
+
+    private final RecBannerRepository bannerRepository;
+    private final RecDestRepository destRepository;
+    private final RecPostRepository postRepository;
+
+    private BannerDto makeBannerDto(RecBanner banner, User user) {
+        if (BannerType.JUST_INFO == banner.getBannerType() ||
+            BannerType.DESTINATION_BUNDLE == banner.getBannerType())
+            return BannerDto.create(banner);
+        if (BannerType.TBTI_DEST_RECOMMEND == banner.getBannerType())
+            // 추후 변경 계획 : 이 부분은 추천 알고리즘을 적용해, TBTI 및 계절에 따른 추천 여행지를 표시할 예정입니다.
+            return BannerDto.create(banner, user.getTbtiString() + banner.getTitle());
+        else
+            throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
+    }
+
+    public List<BannerDto> getBanners(UUID userId) {
+        List<RecBanner> banners = bannerRepository.findAll();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
+        return banners.stream()
+                .map(ban -> makeBannerDto(ban, user))
+                .toList();
+    }
+
+    public List<RecommendDestDto> getRecommendDests() {
+        List<FullRecDest> dests = destRepository.findSomeWithDestinations(3);
+        return dests.stream()
+                .map(RecommendDestDto::create)
+                .toList();
+    }
+
+    private RecommendPostDto makePostDto(RecomPost post) {
+        String title = null;
+        String description = null;
+        String rawContent = post.getContent().trim();
+
+        int linefeed = rawContent.indexOf('\n');
+        if (-1 == linefeed) {
+            title = rawContent;
+            description = "";
+        }
+        else {
+            title = rawContent.substring(0, linefeed);
+            description = rawContent.substring(linefeed + 1);
+        }
+
+        return new RecommendPostDto(
+                post.getImageUrls(),
+                title,
+                description,
+                post.getId()
+        );
+    }
+
+    public List<RecommendPostDto> getRecommendPosts() {
+        return postRepository.findSome(5).stream()
+                .map(this::makePostDto)
+                .toList();
+    }
+
+    public Page<DestinationSummaryRes> getBannerDests(String bannerId, Pageable pageable) {
+        return destinationService.convertToDto(
+                bannerRepository.findAllDestinationsFromBanner(bannerId, pageable));
+    }
+}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #263 

## 추가 및 변경사항
- **메인페이지 배너, 추천여행지, 추천게시글 API가 추가되었습니다.**
  <img width="400" src="https://github.com/user-attachments/assets/b503a949-0636-47b2-8108-f6b7bd9291bd" />
- **DB 추가사항**
  - `MongoDB`를 활용합니다 : 배열 필드를 사용하거나, 추후 변경이 발생할 수 있어 NoSQL 방식을 선택했습니다.
  - `recommend_destinations` : 엔티티 `RecDest`에 대응하는 Collection으로, 추천여행지 정보를 표현합니다.
  - `recommend_banner` : 엔티티 `RecBanner`에 대응하는 Collection으로, 메인페이지 배너 정보를 표현합니다.
- **배너**
  - 메인페이지에 표시되는 배너 데이터입니다.
  - 추후 확장성을 위해 `BannerType`에 따른 다양한 배너 형태를 구성했습니다.
  - 배너 id를 사용해 배너가 추천하는 여행지들을 조회할 수 있습니다.
- **추천여행지**
  - 메인페이지에 표시되는 추천여행지 데이터입니다. (명소 추천)
  - DB 단에서 여행지 데이터와 미리 조인해 가져오도록 쿼리가 구성되어있습니다.
- **추천게시글**
  - 별도의 엔티티가 필요 없이,
    이미 존재하는 게시글 Collection으로부터 데이터를 수집해 가져옵니다.

## 테스트 결과
- 이상 무.
  테스트용 데이터가 DB에 일부 존재합니다.

## 📌 기타
