### PR TITLE
Feature: TBTI 질문 관리기능 추가 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiManagerService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiManagerService.java
@@ -52,9 +52,8 @@ public class TbtiManagerService {
                 dto.getContent(),
                 dto.getTraitCategory(),
                 dto.getWeight());
-        TbtiQuestion savedEntity = tbtiQuestionRepository.save(tbtiQuestion);
 
-        return RawTbtiQuestionRes.from(savedEntity);
+        return RawTbtiQuestionRes.from(tbtiQuestion);
     }
 
     @Transactional
@@ -90,7 +89,6 @@ public class TbtiManagerService {
     public void deleteAnswer(long id) {
         List<TbtiQuestion> tbtiQuestions = tbtiQuestionRepository.findByAnswerId(id);
 
-        boolean isRemoved = false;
         for (TbtiQuestion question : tbtiQuestions) {
             TbtiAnswer answer = null;
             for (TbtiAnswer a : question.getTbtiAnswers())
@@ -99,14 +97,9 @@ public class TbtiManagerService {
                     break;
                 }
 
-            if (answer != null) {
+            if (answer != null)
                 question.getTbtiAnswers().remove(answer);
-                isRemoved = true;
-            }
         }
-
-        if (isRemoved)
-            tbtiQuestionRepository.saveAll(tbtiQuestions);
     }
 
     @Transactional

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiManagerService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiManagerService.java
@@ -1,0 +1,46 @@
+package com.se.Tlog.domain.Tbti.application;
+
+import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Tbti.controller.dto.TbtiQuestionReq;
+import com.se.Tlog.domain.Tbti.domain.TbtiAnswer;
+import com.se.Tlog.domain.Tbti.domain.TbtiQuestion;
+import com.se.Tlog.domain.Tbti.domain.TraitCategory;
+import com.se.Tlog.domain.Tbti.repository.jpa.TbtiQuestionRepository;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+@ApplicationService
+@RequiredArgsConstructor
+public class TbtiManagerService {
+    private final TbtiQuestionRepository tbtiQuestionRepository;
+
+    @Transactional
+    public void createTbtiQuestion(TbtiQuestionReq tbtiQuestionReq) {
+        if (tbtiQuestionReq.answers() == null || tbtiQuestionReq.answers().size() == 0)
+            throw new CustomException(ErrorType.QUESTION_HAS_NO_ANSWER);
+
+        List<TbtiAnswer> tbtiAnswers = tbtiQuestionReq.answers().stream()
+                .map(dto -> TbtiAnswer.createAnswer(dto.content(), dto.percentage()))
+                .toList();
+        TbtiQuestion tbtiQuestion = TbtiQuestion.create(
+                tbtiQuestionReq.content(),
+                TraitCategory.fromString(tbtiQuestionReq.traitCategory()),
+                tbtiAnswers,
+                tbtiQuestionReq.weight());
+
+        tbtiQuestionRepository.save(tbtiQuestion);
+    }
+
+    @Transactional
+    public void deleteTbtiQuestion(UUID tbtiQuestionId) {
+        TbtiQuestion tbtiQuestion = tbtiQuestionRepository.findById(tbtiQuestionId)
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+
+        tbtiQuestionRepository.delete(tbtiQuestion);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiManagerService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiManagerService.java
@@ -48,9 +48,10 @@ public class TbtiManagerService {
         TbtiQuestion tbtiQuestion = tbtiQuestionRepository.findById(dto.getId())
                 .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
 
-        tbtiQuestion.setContent(dto.getContent());
-        tbtiQuestion.setTraitCategory(dto.getTraitCategory());
-        tbtiQuestion.setAnswerWeight(dto.getWeight());
+        tbtiQuestion.updateQuestion(
+                dto.getContent(),
+                dto.getTraitCategory(),
+                dto.getWeight());
         TbtiQuestion savedEntity = tbtiQuestionRepository.save(tbtiQuestion);
 
         return RawTbtiQuestionRes.from(savedEntity);
@@ -71,13 +72,14 @@ public class TbtiManagerService {
         if (answer == null) {
             answer = TbtiAnswer.createAnswer(
                     dto.getContent(),
-                    dto.getPercentage());
-            answer.setTbtiQuestion(tbtiQuestion);
+                    dto.getPercentage(),
+                    tbtiQuestion);
             tbtiQuestion.getTbtiAnswers().add(answer);
         }
         else {
-            answer.setContent(dto.getContent());
-            answer.setPercentage(dto.getPercentage());
+            answer.updateAnswer(
+                    dto.getContent(),
+                    dto.getPercentage());
         }
 
         TbtiQuestion savedEntity = tbtiQuestionRepository.save(tbtiQuestion);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiManagerService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiManagerService.java
@@ -1,7 +1,7 @@
 package com.se.Tlog.domain.Tbti.application;
 
 import com.se.Tlog.domain.ApplicationService;
-import com.se.Tlog.domain.Tbti.controller.dto.TbtiQuestionReq;
+import com.se.Tlog.domain.Tbti.controller.dto.*;
 import com.se.Tlog.domain.Tbti.domain.TbtiAnswer;
 import com.se.Tlog.domain.Tbti.domain.TbtiQuestion;
 import com.se.Tlog.domain.Tbti.domain.TraitCategory;
@@ -20,7 +20,7 @@ public class TbtiManagerService {
     private final TbtiQuestionRepository tbtiQuestionRepository;
 
     @Transactional
-    public void createTbtiQuestion(TbtiQuestionReq tbtiQuestionReq) {
+    public RawTbtiQuestionRes createTbtiQuestion(TbtiQuestionReq tbtiQuestionReq) {
         if (tbtiQuestionReq.answers() == null || tbtiQuestionReq.answers().size() == 0)
             throw new CustomException(ErrorType.QUESTION_HAS_NO_ANSWER);
 
@@ -33,7 +33,78 @@ public class TbtiManagerService {
                 tbtiAnswers,
                 tbtiQuestionReq.weight());
 
-        tbtiQuestionRepository.save(tbtiQuestion);
+        TbtiQuestion savedEntity = tbtiQuestionRepository.save(tbtiQuestion);
+        return RawTbtiQuestionRes.from(savedEntity);
+    }
+
+    public List<RawTbtiQuestionRes> getAllRawQeustions() {
+        return tbtiQuestionRepository.findAllFetch().stream()
+                .map(RawTbtiQuestionRes::from)
+                .toList();
+    }
+
+    @Transactional
+    public RawTbtiQuestionRes updateQuestion(PutQuestionReq dto) {
+        TbtiQuestion tbtiQuestion = tbtiQuestionRepository.findById(dto.getId())
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+
+        tbtiQuestion.setContent(dto.getContent());
+        tbtiQuestion.setTraitCategory(dto.getTraitCategory());
+        tbtiQuestion.setAnswerWeight(dto.getWeight());
+        TbtiQuestion savedEntity = tbtiQuestionRepository.save(tbtiQuestion);
+
+        return RawTbtiQuestionRes.from(savedEntity);
+    }
+
+    @Transactional
+    public RawTbtiQuestionRes updateOrAddAnswer(PutAnswerReq dto) {
+        TbtiQuestion tbtiQuestion = tbtiQuestionRepository.findById(dto.getQuestionId())
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
+
+        TbtiAnswer answer = null;
+        for (TbtiAnswer a : tbtiQuestion.getTbtiAnswers())
+            if (a.getId() == dto.getAnswerId()) {
+                answer = a;
+                break;
+            }
+
+        if (answer == null) {
+            answer = TbtiAnswer.createAnswer(
+                    dto.getContent(),
+                    dto.getPercentage());
+            answer.setTbtiQuestion(tbtiQuestion);
+            tbtiQuestion.getTbtiAnswers().add(answer);
+        }
+        else {
+            answer.setContent(dto.getContent());
+            answer.setPercentage(dto.getPercentage());
+        }
+
+        TbtiQuestion savedEntity = tbtiQuestionRepository.save(tbtiQuestion);
+        return RawTbtiQuestionRes.from(savedEntity);
+    }
+
+    @Transactional
+    public void deleteAnswer(long id) {
+        List<TbtiQuestion> tbtiQuestions = tbtiQuestionRepository.findByAnswerId(id);
+
+        boolean isRemoved = false;
+        for (TbtiQuestion question : tbtiQuestions) {
+            TbtiAnswer answer = null;
+            for (TbtiAnswer a : question.getTbtiAnswers())
+                if (a.getId() == id) {
+                    answer = a;
+                    break;
+                }
+
+            if (answer != null) {
+                question.getTbtiAnswers().remove(answer);
+                isRemoved = true;
+            }
+        }
+
+        if (isRemoved)
+            tbtiQuestionRepository.saveAll(tbtiQuestions);
     }
 
     @Transactional

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiQuestionService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiQuestionService.java
@@ -2,42 +2,18 @@ package com.se.Tlog.domain.Tbti.application;
 
 import com.se.Tlog.domain.ApplicationService;
 import com.se.Tlog.domain.Tbti.controller.dto.TbtiAnswerDto;
-import com.se.Tlog.domain.Tbti.controller.dto.TbtiQuestionReq;
 import com.se.Tlog.domain.Tbti.controller.dto.TbtiQuestionRes;
-import com.se.Tlog.domain.Tbti.domain.TbtiAnswer;
 import com.se.Tlog.domain.Tbti.domain.TbtiQuestion;
 import com.se.Tlog.domain.Tbti.domain.TraitCategory;
 import com.se.Tlog.domain.Tbti.repository.jpa.TbtiQuestionRepository;
-import com.se.Tlog.global.exception.CustomException;
-import com.se.Tlog.global.response.error.ErrorType;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
-import java.util.UUID;
 
 @ApplicationService
 @RequiredArgsConstructor
 public class TbtiQuestionService {
-
     private final TbtiQuestionRepository tbtiQuestionRepository;
-
-    @Transactional
-    public void createTbtiQuestion(TbtiQuestionReq tbtiQuestionReq) {
-        if (tbtiQuestionReq.answers() == null || tbtiQuestionReq.answers().size() == 0)
-            throw new CustomException(ErrorType.QUESTION_HAS_NO_ANSWER);
-
-        List<TbtiAnswer> tbtiAnswers = tbtiQuestionReq.answers().stream()
-                .map(dto -> TbtiAnswer.createAnswer(dto.content(), dto.percentage()))
-                .toList();
-        TbtiQuestion tbtiQuestion = TbtiQuestion.create(
-                tbtiQuestionReq.content(),
-                TraitCategory.fromString(tbtiQuestionReq.traitCategory()),
-                tbtiAnswers,
-                tbtiQuestionReq.weight());
-
-        tbtiQuestionRepository.save(tbtiQuestion);
-    }
 
     public List<TbtiQuestionRes> getAllTbtiQuestion() {
         List<TbtiQuestion> questions = tbtiQuestionRepository.findAllFetch();
@@ -66,13 +42,5 @@ public class TbtiQuestionService {
                         .map(answer -> new TbtiAnswerDto(answer.getContent(), answer.getPercentage()))
                         .toList())
                 ).toList();
-    }
-
-    @Transactional
-    public void deleteTbtiQuestion(UUID tbtiQuestionId) {
-        TbtiQuestion tbtiQuestion = tbtiQuestionRepository.findById(tbtiQuestionId)
-                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND));
-
-        tbtiQuestionRepository.delete(tbtiQuestion);
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiQuestionService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/application/TbtiQuestionService.java
@@ -17,30 +17,12 @@ public class TbtiQuestionService {
 
     public List<TbtiQuestionRes> getAllTbtiQuestion() {
         List<TbtiQuestion> questions = tbtiQuestionRepository.findAllFetch();
-        return questions.stream().map(question -> new TbtiQuestionRes(
-                question.getId(),
-                question.getContent(),
-                question.getAnswerWeight(),
-                question.getTraitCategory(),
-                question.getTraitCategory().getCategoryInitial(),
-                question.getTbtiAnswers().stream()
-                        .map(answer -> new TbtiAnswerDto(answer.getContent(), answer.getPercentage()))
-                        .toList())
-                ).toList();
+        return questions.stream().map(TbtiQuestionRes::from).toList();
     }
 
     public List<TbtiQuestionRes> getAllTbtiQuestionByTraitCategory(String traitCategory) {
         TraitCategory traitCategoryEnum = TraitCategory.fromString(traitCategory);
         List<TbtiQuestion> questions = tbtiQuestionRepository.findByTraitCategoryFetch(traitCategoryEnum);
-        return questions.stream().map(question -> new TbtiQuestionRes(
-                question.getId(),
-                question.getContent(),
-                question.getAnswerWeight(),
-                question.getTraitCategory(),
-                question.getTraitCategory().getCategoryInitial(),
-                question.getTbtiAnswers().stream()
-                        .map(answer -> new TbtiAnswerDto(answer.getContent(), answer.getPercentage()))
-                        .toList())
-                ).toList();
+        return questions.stream().map(TbtiQuestionRes::from).toList();
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiManageController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiManageController.java
@@ -1,6 +1,6 @@
 package com.se.Tlog.domain.Tbti.controller;
 
-import com.se.Tlog.domain.Tbti.application.TbtiQuestionService;
+import com.se.Tlog.domain.Tbti.application.TbtiManagerService;
 import com.se.Tlog.domain.Tbti.controller.dto.TbtiQuestionReq;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
@@ -24,7 +24,7 @@ import java.util.UUID;
         name = "JwtAuthScheme", // OpenApiConfig에 설정된 Security Scheme 이름일 것
         scopes = {"scope1", "scope2"})
 public class TbtiManageController {
-    private final TbtiQuestionService tbtiService;
+    private final TbtiManagerService tbtiService;
 
     @PostMapping("/user/question")
     @Operation (

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiManageController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/TbtiManageController.java
@@ -1,7 +1,7 @@
 package com.se.Tlog.domain.Tbti.controller;
 
 import com.se.Tlog.domain.Tbti.application.TbtiManagerService;
-import com.se.Tlog.domain.Tbti.controller.dto.TbtiQuestionReq;
+import com.se.Tlog.domain.Tbti.controller.dto.*;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 
@@ -26,22 +27,84 @@ import java.util.UUID;
 public class TbtiManageController {
     private final TbtiManagerService tbtiService;
 
+	@GetMapping("/user/question")
+	@Operation (
+			summary = "전체 TBTI 질문 조회하기",
+			description = "TBTI 질문을 조회합니다."
+					+ "<br> 가중치는 1~5 사이의 값을 갖습니다."
+					+ "<br> Percentage는 0~99 사이의 값을 갖습니다. (TBTI 코드 규칙을 따름)"
+					+ "<br> TBTI 카테고리는 [RISK_TAKING, LOCATION_PREFERENCE, PLANNING_STYLE,  ACTIVITY_LEVEL] 의 값을 갖습니다.",
+			responses = {
+					@ApiResponse( responseCode = "200", description = "성공"),
+					@ApiResponse(responseCode = "505", description = "서버 내부 오류")}
+	)
+	public ResponseEntity<SuccessRes<List<RawTbtiQuestionRes>>> getAllTbtiQuestion(){
+		return ResponseEntity.ok(SuccessRes.from(
+						tbtiService.getAllRawQeustions()));
+	}
+
     @PostMapping("/user/question")
     @Operation (
     		summary = "새 TBTI 질문 등록하기",
     		description = "새 TBTI 질문을 등록합니다."
     		            + "<br> 가중치는 1~5 사이의 값을 갖습니다."
+						+ "<br> Percentage는 0~99 사이의 값을 갖습니다. (TBTI 코드 규칙을 따름)"
     		            + "<br> TBTI 카테고리는 [RISK_TAKING, LOCATION_PREFERENCE, PLANNING_STYLE,  ACTIVITY_LEVEL] 의 값을 갖습니다.",
 			responses = {
 					@ApiResponse( responseCode = "200", description = "성공"), 
 					@ApiResponse(responseCode = "505", description = "서버 내부 오류")}
 	)
-    public ResponseEntity<?> createTbtiQuestion(@RequestBody TbtiQuestionReq tbtiQuestionReq){
-        tbtiService.createTbtiQuestion(tbtiQuestionReq);
-
-        return ResponseEntity.ok()
-                .body(SuccessRes.from(SuccessType.OK));
+    public ResponseEntity<SuccessRes<RawTbtiQuestionRes>> createTbtiQuestion(@RequestBody TbtiQuestionReq tbtiQuestionReq){
+        return ResponseEntity.ok(SuccessRes.from(
+						tbtiService.createTbtiQuestion(tbtiQuestionReq)));
     }
+
+	@PutMapping("/user/question")
+	@Operation (
+			summary = "TBTI 질문 수정하기",
+			description = "기존의 TBTI 질문을 수정합니다."
+					    + "<br> 가중치는 1~5 사이의 값을 갖습니다."
+						+ "<br> TBTI 카테고리는 [RISK_TAKING, LOCATION_PREFERENCE, PLANNING_STYLE,  ACTIVITY_LEVEL] 의 값을 갖습니다."
+					    + "<br> 수정된 후의 질문 데이터가 반환됩니다.",
+			responses = {
+					@ApiResponse(responseCode = "200", description = "성공"),
+					@ApiResponse(responseCode = "505", description = "서버 내부 오류")}
+	)
+	public ResponseEntity<SuccessRes<RawTbtiQuestionRes>> updateTbtiQuestion(@RequestBody PutQuestionReq tbtiQuestionReq){
+		return ResponseEntity.ok(
+				SuccessRes.from(
+						tbtiService.updateQuestion(tbtiQuestionReq)));
+	}
+
+	@PutMapping("/user/answer")
+	@Operation (
+			summary = "TBTI 응답 추가/수정하기",
+			description = "기존의 TBTI 응답을 추가/수정합니다."
+					    + "<br> id를 -1로 기입하면 응답이 추가됩니다."
+						+ "<br> Percentage는 0~99 사이의 값을 갖습니다. (TBTI 코드 규칙을 따름)"
+						+ "<br> 수정된 후의 질문 데이터가 반환됩니다.",
+			responses = {
+					@ApiResponse(responseCode = "200", description = "성공"),
+					@ApiResponse(responseCode = "505", description = "서버 내부 오류")}
+	)
+	public ResponseEntity<SuccessRes<RawTbtiQuestionRes>> updateTbtiAnswer(@RequestBody PutAnswerReq tbtiAnswerReq){
+		return ResponseEntity.ok(
+				SuccessRes.from(
+						tbtiService.updateOrAddAnswer(tbtiAnswerReq)));
+	}
+
+	@DeleteMapping("/user/answer/{tbtiAnswerId}")
+	@Operation (
+			summary = "TBTI 응답 삭제하기",
+			description = "기존의 TBTI 응답을 삭제합니다.",
+			responses = {
+					@ApiResponse(responseCode = "200", description = "성공"),
+					@ApiResponse(responseCode = "505", description = "서버 내부 오류")}
+	)
+	public ResponseEntity<SuccessRes<?>> deleteTbtiAnswer(@PathVariable long tbtiAnswerId){
+		tbtiService.deleteAnswer(tbtiAnswerId);
+		return ResponseEntity.ok(SuccessRes.from(SuccessType.OK));
+	}
     
     @DeleteMapping("/user/question/{tbtiQuestionId}")
     @Operation (

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/PutAnswerReq.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/PutAnswerReq.java
@@ -1,0 +1,16 @@
+package com.se.Tlog.domain.Tbti.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class PutAnswerReq {
+    private UUID questionId;
+    private long answerId;
+    @Schema(example = "아니, 난 도시가 좋아!")
+    private String content;
+    @Schema(example = "99")
+    private int percentage;
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/PutQuestionReq.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/PutQuestionReq.java
@@ -1,0 +1,17 @@
+package com.se.Tlog.domain.Tbti.controller.dto;
+
+import com.se.Tlog.domain.Tbti.domain.TraitCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class PutQuestionReq {
+    private UUID id;
+    @Schema(example = "시골이 좋아 도시가 좋아?")
+    private String content;
+    private TraitCategory traitCategory;
+    @Schema(example = "3")
+    private int weight;
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/RawTbtiQuestionRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/RawTbtiQuestionRes.java
@@ -1,0 +1,55 @@
+package com.se.Tlog.domain.Tbti.controller.dto;
+
+import com.se.Tlog.domain.Tbti.domain.TbtiAnswer;
+import com.se.Tlog.domain.Tbti.domain.TbtiQuestion;
+import com.se.Tlog.domain.Tbti.domain.TraitCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+public class RawTbtiQuestionRes {
+    private UUID id;
+
+    @Schema(example = "분주한 도시와 한산한 자연 풍경 중에서?")
+    private String content;
+
+    @Schema(example = "3")
+    private int weight;
+
+    @Schema(example = "LOCATION_PREFERENCE")
+    private TraitCategory traitCategory;
+
+    private List<RawTbtiAnswer> answers;
+    @Data
+    @AllArgsConstructor
+    public static class RawTbtiAnswer {
+        private long id;
+        @Schema(example = "분주한 도시!")
+        private String content;
+        @Schema(example = "99")
+        private int percentage;
+
+        public static RawTbtiAnswer from(TbtiAnswer answer) {
+            return new RawTbtiAnswer(
+                    answer.getId(),
+                    answer.getContent(),
+                    answer.getPercentage()
+            );
+        }
+    }
+
+    public static RawTbtiQuestionRes from(TbtiQuestion question) {
+        return new RawTbtiQuestionRes(
+                question.getId(),
+                question.getContent(),
+                question.getAnswerWeight(),
+                question.getTraitCategory(),
+                question.getTbtiAnswers().stream().map(RawTbtiAnswer::from).toList()
+        );
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiQuestionRes.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/controller/dto/TbtiQuestionRes.java
@@ -1,5 +1,6 @@
 package com.se.Tlog.domain.Tbti.controller.dto;
 
+import com.se.Tlog.domain.Tbti.domain.TbtiQuestion;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
@@ -21,11 +22,22 @@ public record TbtiQuestionRes(
         
         @Schema(description = "질문지의 TBTI 영역")
         TraitCategory traitCategory,
-        
+
         @Schema(description = "질문지의 TBTI 영역 알파벳")
 	    String categoryIntial,
 	    
 	    @Schema(description = "응답 형식")
 	    List<TbtiAnswerDto> answers) {
-    
+    public static TbtiQuestionRes from(TbtiQuestion question) {
+        return new TbtiQuestionRes(
+                question.getId(),
+                question.getContent(),
+                question.getAnswerWeight(),
+                question.getTraitCategory(),
+                question.getTraitCategory().getCategoryInitial(),
+                question.getTbtiAnswers().stream()
+                        .map(answer -> new TbtiAnswerDto(answer.getContent(), answer.getPercentage()))
+                        .toList()
+        );
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiAnswer.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiAnswer.java
@@ -1,7 +1,6 @@
 package com.se.Tlog.domain.Tbti.domain;
 
 import jakarta.persistence.*;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,11 +8,9 @@ import static lombok.AccessLevel.*;
 
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
-import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor(access = PROTECTED)
 public class TbtiAnswer {
     @Id
@@ -28,22 +25,30 @@ public class TbtiAnswer {
 
     private int percentage;
 
-    @Builder
-    private TbtiAnswer(String content, int percentage) {
+    public void setQuestion(TbtiQuestion question) {
+        this.tbtiQuestion = question;
+    }
+
+    public void updateAnswer(String content, int percentage) {
+        if (content == null)
+            throw new CustomException(ErrorType.CONTENT_NOT_FOUND);
+        if (percentage < 0 || percentage > 99)
+            throw new CustomException(ErrorType.INVALID_ANSWER_PERCENTAGE);
+
         this.content = content;
         this.percentage = percentage;
     }
 
     //응답 생성 메서드
     public static TbtiAnswer createAnswer(String content, int percentage) {
-        if (content == null)
-            throw new CustomException(ErrorType.CONTENT_NOT_FOUND);
-        if (percentage < 0 || percentage > 99)
-            throw new CustomException(ErrorType.INVALID_ANSWER_PERCENTAGE);
-        
-        return TbtiAnswer.builder()
-                .content(content)
-                .percentage(percentage)
-                .build();
+        TbtiAnswer answer = new TbtiAnswer();
+        answer.updateAnswer(content, percentage);
+        return answer;
+    }
+
+    public static TbtiAnswer createAnswer(String content, int percentage, TbtiQuestion question) {
+        TbtiAnswer answer = createAnswer(content, percentage);
+        answer.setQuestion(question);
+        return answer;
     }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiAnswer.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiAnswer.java
@@ -9,9 +9,11 @@ import static lombok.AccessLevel.*;
 
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = PROTECTED)
 public class TbtiAnswer {
     @Id
@@ -25,10 +27,6 @@ public class TbtiAnswer {
     private String content;
 
     private int percentage;
-    
-    public void setQuestion(TbtiQuestion question) {
-        this.tbtiQuestion = question;
-    }
 
     @Builder
     private TbtiAnswer(String content, int percentage) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiQuestion.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiQuestion.java
@@ -5,6 +5,7 @@ import com.se.Tlog.global.response.error.ErrorType;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +15,7 @@ import static lombok.AccessLevel.*;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = PROTECTED)
 public class TbtiQuestion {
     @Id
@@ -35,7 +37,7 @@ public class TbtiQuestion {
         this.content = content;
         this.traitCategory = traitCategory;
         this.tbtiAnswers = new ArrayList<TbtiAnswer>(tbtiAnswers);
-        this.tbtiAnswers.forEach(answer -> answer.setQuestion(this));
+        this.tbtiAnswers.forEach(answer -> answer.setTbtiQuestion(this));
         this.answerWeight = answerWeight;
     }
 

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiQuestion.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/domain/TbtiQuestion.java
@@ -5,7 +5,6 @@ import com.se.Tlog.global.response.error.ErrorType;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +14,6 @@ import static lombok.AccessLevel.*;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor(access = PROTECTED)
 public class TbtiQuestion {
     @Id
@@ -33,23 +31,12 @@ public class TbtiQuestion {
     
     private int answerWeight;
 
-    private TbtiQuestion(String content, TraitCategory traitCategory, List<TbtiAnswer> tbtiAnswers, int answerWeight) {
-        this.content = content;
-        this.traitCategory = traitCategory;
-        this.tbtiAnswers = new ArrayList<TbtiAnswer>(tbtiAnswers);
-        this.tbtiAnswers.forEach(answer -> answer.setTbtiQuestion(this));
-        this.answerWeight = answerWeight;
-    }
-
-    // 질문 생성 메서드
-    public static TbtiQuestion create(String content, TraitCategory traitCategory, List<TbtiAnswer> tbtiAnswers, int answerWeight) {
-        validateContent(content);
+    private void updateAnswers(List<TbtiAnswer> tbtiAnswers) {
         if (tbtiAnswers == null || tbtiAnswers.size() == 0)
             throw new CustomException(ErrorType.QUESTION_HAS_NO_ANSWER);
-        if (answerWeight < 1 || answerWeight > 5)
-            throw new CustomException(ErrorType.INVALID_QUESTION_WEIGHT);
-        
-        return new TbtiQuestion(content, traitCategory, tbtiAnswers, answerWeight);
+
+        this.tbtiAnswers = new ArrayList<TbtiAnswer>(tbtiAnswers);
+        this.tbtiAnswers.forEach(answer -> answer.setQuestion(this));
     }
 
     // 유효성 검사 메서드
@@ -58,6 +45,26 @@ public class TbtiQuestion {
             throw new CustomException(ErrorType.CONTENT_NOT_FOUND);
         }
         // 필요한 검사가 있다면 지속적으로 추가할 예정!
+    }
+
+    public void updateQuestion(String content, TraitCategory traitCategory, int answerWeight) {
+        validateContent(content);
+        if (traitCategory == null)
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        if (answerWeight < 1 || answerWeight > 5)
+            throw new CustomException(ErrorType.INVALID_QUESTION_WEIGHT);
+
+        this.content = content;
+        this.traitCategory = traitCategory;
+        this.answerWeight = answerWeight;
+    }
+
+    // 질문 생성 메서드
+    public static TbtiQuestion create(String content, TraitCategory traitCategory, List<TbtiAnswer> tbtiAnswers, int answerWeight) {
+        TbtiQuestion question = new TbtiQuestion();
+        question.updateAnswers(tbtiAnswers);
+        question.updateQuestion(content, traitCategory, answerWeight);
+        return question;
     }
 
     public void delete(){

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/repository/jpa/TbtiQuestionRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Tbti/repository/jpa/TbtiQuestionRepository.java
@@ -18,4 +18,7 @@ public interface TbtiQuestionRepository extends JpaRepository<TbtiQuestion, UUID
     
     @Query(value = "SELECT q FROM TbtiQuestion q JOIN FETCH q.tbtiAnswers WHERE q.traitCategory = :traitCategory")
     List<TbtiQuestion> findByTraitCategoryFetch(TraitCategory traitCategory);
+
+    @Query(value = "SELECT q FROM TbtiQuestion q JOIN FETCH q.tbtiAnswers a WHERE a.id = :id")
+    List<TbtiQuestion> findByAnswerId(long id);
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #265 

## 추가 및 변경사항
- **TBTI 질문 및 응답의 수정/삭제 기능이 추가되었습니다.**
  <img width="400" src="https://github.com/user-attachments/assets/c4364c8e-4a68-4a7b-9da8-c8bdbc59c003" />
- **리팩토링**
  - 관리 기능이 확장됨에 따라
    기존 `TbtiQuestionService`로부터 관리 기능이 `TbtiManagerService`로 분리되었습니다.
  - 엔티티 수정 기능이 추가됨에 따라 `setter`가 추가되었습니다.
- **기능 추가**
  - 단순한 CRUD 기능 도입이 주요 변경사항입니다.
  - **DTO**
    - `PutAnswerReq` : TBTI 질문 내부의 응답 항목의 수정을 요청하는 규격입니다.
    - `PutQuestionReq` : TBTI 질문 데이터를 수정을 요청하는 규격입니다.
    - `RawTbtiQuestionRes` : TBTI 질문 데이터를 그대로 표시하는 데이터 규격입니다.

## 테스트 결과
- 이상 무.
  1:N 관계 연결에 따른 추가/수정/삭제시 DB 반영 테스트 완료.

## 📌 기타
