### PR TITLE
Feature: 배너 추천 여행지 조회시 제목 데이터를 포함하도록 개선

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/RecommendController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/RecommendController.java
@@ -1,10 +1,10 @@
 package com.se.Tlog.domain.Guide.controller;
 
+import com.se.Tlog.domain.Guide.controller.dto.BannerDestinationsDto;
 import com.se.Tlog.domain.Guide.controller.dto.BannerDto;
 import com.se.Tlog.domain.Guide.controller.dto.RecommendDestDto;
 import com.se.Tlog.domain.Guide.controller.dto.RecommendPostDto;
 import com.se.Tlog.domain.Guide.service.RecommendService;
-import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
 import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorRes;
 import com.se.Tlog.global.response.error.ErrorType;
@@ -18,7 +18,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -59,19 +58,24 @@ public class RecommendController {
 
     @GetMapping("/destinations/{bannerId}")
     @Operation(
-            summary = "배너에서 추천된 여행지 조회",
-            description = "배너에서 추천된 여행지를 조회합니다.",
+            summary = "배너에서 추천된 여행지 조회 (인증 토큰 필요)",
+            description = "배너에서 추천된 여행지를 조회합니다."
+                        + "<br><br><b>인증 토큰이 필요합니다!</b>",
             responses = {
                     @ApiResponse(responseCode = "200", description = "처리 성공. 여행지 정보를 반환합니다."),
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류. 조회에 실패했습니다.",
                             content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
     )
-    public ResponseEntity<SuccessRes<Page<DestinationSummaryRes>>> getBannerDestinations(
+    public ResponseEntity<SuccessRes<BannerDestinationsDto>> getBannerDestinations(
+            @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable String bannerId,
             @Parameter(example = "{\n  \"page\": 0,\n  \"size\": 10\n}")
             @PageableDefault(size = 10, page = 0) Pageable pageable) {
+        if (user == null)
+            throw new CustomException(ErrorType.UN_AUTHENTICATION);
+
         return ResponseEntity.ok(SuccessRes.from(
-                recommendService.getBannerDests(bannerId, pageable)));
+                recommendService.getBannerDests(UUID.fromString(user.getId()), bannerId, pageable)));
     }
 
     @GetMapping("/destinations")

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/dto/BannerDestinationsDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/dto/BannerDestinationsDto.java
@@ -1,0 +1,13 @@
+package com.se.Tlog.domain.Guide.controller.dto;
+
+import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.data.domain.Page;
+
+@Data
+@AllArgsConstructor
+public class BannerDestinationsDto {
+    private String title;
+    private Page<DestinationSummaryRes> destinations;
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/dto/BannerDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/controller/dto/BannerDto.java
@@ -24,10 +24,6 @@ public class BannerDto {
     private List<String> destinationIds;
     */
 
-    public static BannerDto create(RecBanner banner) {
-        return create(banner, banner.getTitle());
-    }
-
     public static BannerDto create(RecBanner banner, String title) {
         return new BannerDto(
                 banner.getId(),

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/repository/mongo/RecBannerRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/repository/mongo/RecBannerRepository.java
@@ -24,6 +24,10 @@ public class RecBannerRepository {
     private final MongoTemplate mongoTemplate;
     private final String COLLECTION_NAME = "recommend_banner";
 
+    public RecBanner findById(String id) {
+        return mongoTemplate.findById(id, RecBanner.class);
+    }
+
     public List<RecBanner> findAll() {
         return mongoTemplate.findAll(RecBanner.class, COLLECTION_NAME);
     }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Guide/service/RecommendService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Guide/service/RecommendService.java
@@ -1,6 +1,7 @@
 package com.se.Tlog.domain.Guide.service;
 
 import com.se.Tlog.domain.ApplicationService;
+import com.se.Tlog.domain.Guide.controller.dto.BannerDestinationsDto;
 import com.se.Tlog.domain.Guide.controller.dto.BannerDto;
 import com.se.Tlog.domain.Guide.controller.dto.RecommendDestDto;
 import com.se.Tlog.domain.Guide.controller.dto.RecommendPostDto;
@@ -12,7 +13,7 @@ import com.se.Tlog.domain.Guide.repository.mongo.RecBannerRepository;
 import com.se.Tlog.domain.Guide.repository.mongo.RecDestRepository;
 import com.se.Tlog.domain.Guide.repository.mongo.RecPostRepository;
 import com.se.Tlog.domain.Travel.application.DestinationService;
-import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
+import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.User.domain.User;
 import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.global.exception.CustomException;
@@ -34,13 +35,13 @@ public class RecommendService {
     private final RecDestRepository destRepository;
     private final RecPostRepository postRepository;
 
-    private BannerDto makeBannerDto(RecBanner banner, User user) {
+    private String makeTitle(RecBanner banner, User user) {
         if (BannerType.JUST_INFO == banner.getBannerType() ||
             BannerType.DESTINATION_BUNDLE == banner.getBannerType())
-            return BannerDto.create(banner);
+            return banner.getTitle();
         if (BannerType.TBTI_DEST_RECOMMEND == banner.getBannerType())
             // 추후 변경 계획 : 이 부분은 추천 알고리즘을 적용해, TBTI 및 계절에 따른 추천 여행지를 표시할 예정입니다.
-            return BannerDto.create(banner, user.getTbtiString() + banner.getTitle());
+            return user.getTbtiString() + banner.getTitle();
         else
             throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
     }
@@ -50,7 +51,7 @@ public class RecommendService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
         return banners.stream()
-                .map(ban -> makeBannerDto(ban, user))
+                .map(ban -> BannerDto.create(ban, makeTitle(ban, user)))
                 .toList();
     }
 
@@ -90,8 +91,13 @@ public class RecommendService {
                 .toList();
     }
 
-    public Page<DestinationSummaryRes> getBannerDests(String bannerId, Pageable pageable) {
-        return destinationService.convertToDto(
-                bannerRepository.findAllDestinationsFromBanner(bannerId, pageable));
+    public BannerDestinationsDto getBannerDests(UUID userId, String bannerId, Pageable pageable) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
+        RecBanner banner = bannerRepository.findById(bannerId);
+        Page<Destination> destinations = bannerRepository.findAllDestinationsFromBanner(bannerId, pageable);
+        return new BannerDestinationsDto(
+                makeTitle(banner, user), // 25.11.14 추후 배너 제목 외에, 세부적으로 커스텀된 제목이 사용될 수 있습니다.
+                destinationService.convertToDto(destinations));
     }
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #271 

## 추가 및 변경사항
- **배너 추천 여행지를 조회할 때, 관련 제목 정보가 포함됩니다.**
  - 기존 `Page<DestinationSummayDto>` 반환 타입에서
    제목 정보도 포함한 `BannerDestinationsDto`으로 변경되었습니다.

## 테스트 결과
- 이상 무.
  반환 타입에 title이 포함됩니다.
  <img width="400" src="https://github.com/user-attachments/assets/c452cb7e-45f0-44e3-a976-204f8eec342c" />


## 📌 기타
