### PR TITLE
Feature: 인기 여행지 조회 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/application/DescriptionSearchService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/application/DescriptionSearchService.java
@@ -1,7 +1,11 @@
 package com.se.Tlog.domain.Search.application;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import com.se.Tlog.domain.Search.controller.dto.PopularDestinationDto;
+import com.se.Tlog.domain.Search.repository.mongo.PopularityRepository;
+import com.se.Tlog.domain.Travel.domain.Destination;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -17,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class DescriptionSearchService {
 	private final DestinationSearchRepository searchRepository;
 	private final DestinationService destinationService;
+	private final PopularityRepository popularityRepository;
     
     public List<DestinationSummaryRes> autoCompleteDestinationByAddress(String address) {
         return destinationService.convertToDto(
@@ -37,4 +42,14 @@ public class DescriptionSearchService {
         return destinationService.convertToDto(
                 searchRepository.searchByNameAndCity(name, city, pageable));
     }
+
+	public List<PopularDestinationDto> getPopularDestinations() {List<Destination> popDests = popularityRepository.findPopularDestinations(10);
+		List<PopularDestinationDto> result = popDests.stream()
+				.skip(1)
+				.map(PopularDestinationDto::create)
+				.collect(Collectors.toList());
+		if (!popDests.isEmpty())
+			result.add(0, PopularDestinationDto.create(popDests.get(0), "전국"));
+		return result;
+	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/aspect/DestinationCatchAspect.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/aspect/DestinationCatchAspect.java
@@ -1,0 +1,44 @@
+package com.se.Tlog.domain.Search.aspect;
+
+import com.se.Tlog.domain.Review.controller.dto.ReviewCreateDto;
+import com.se.Tlog.domain.Search.repository.redis.PopularityCacheRepository;
+import com.se.Tlog.domain.Wishlist.domain.UpdateType;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DestinationCatchAspect {
+    private final PopularityCacheRepository popularityCacheRepository;
+
+    private void addDestinationScore(String destinationId, int addScore) {
+        popularityCacheRepository.addScore(destinationId, addScore);
+    }
+
+    private void addDestinationScore(String destinationId) {
+        addDestinationScore(destinationId, 1);
+    }
+
+    // 여행지를 세부 조회한 경우 점수 + 1
+    @AfterReturning("execution(* *..DestinationService.getDestinationById(..)) && args(destinationId)")
+    public void detailedDestination(String destinationId) {
+        addDestinationScore(destinationId);
+    }
+
+    // 장바구니/스크랩에 추가한 경우 점수 + 1
+    @AfterReturning("execution(* *..WishlistService.updateWishlist(..)) && args(updateType, *, *, destinationId)")
+    public void scrappedDestination(UpdateType updateType, String destinationId) {
+        if (updateType == UpdateType.ADD)
+            addDestinationScore(destinationId);
+    }
+
+    // 리뷰에 긍정적인 평가 점수 + 1~3 (별3개: 1, 별4개: 2, 별5개: 3)
+    @AfterReturning("execution(* *..ReviewService.createReview(..)) && args(reviewCreateDto)")
+    public void reviewedDestination(ReviewCreateDto reviewCreateDto) {
+        if (3 <= reviewCreateDto.rating())
+            addDestinationScore(reviewCreateDto.destinationId(), reviewCreateDto.rating() - 2);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/batch/PopularitySyncJob.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/batch/PopularitySyncJob.java
@@ -1,0 +1,40 @@
+package com.se.Tlog.domain.Search.batch;
+
+import com.se.Tlog.domain.Search.domain.DestinationPopularity;
+import com.se.Tlog.domain.Search.repository.mongo.PopularityRepository;
+import com.se.Tlog.domain.Search.repository.redis.PopularityCacheRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PopularitySyncJob {
+    private final PopularityCacheRepository popularityCacheRepository;
+    private final PopularityRepository popularityRepository;
+
+    @Scheduled(fixedRate = 2 * 60 * 1000) // 2분마다 갱신
+    public void syncPopularityToMongo() {
+        Map<String, Long> destinationScores = popularityCacheRepository.popAllCachedScore();
+        int count = destinationScores.size();
+        if (count == 0)
+            return;
+
+        List<DestinationPopularity> popularities = popularityRepository.findAllById(destinationScores.keySet());
+        popularities.forEach(pop -> {
+            pop.updateScore(destinationScores.get(pop.getDestinationId()));
+            destinationScores.remove(pop.getDestinationId());
+        });
+        destinationScores.keySet().forEach(id -> {
+            popularities.add(DestinationPopularity.create(id, destinationScores.get(id)));
+        });
+
+        log.info("Syncing destination's popularity scores (dest cnt : {})", count);
+        popularityRepository.saveAll(popularities);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/controller/SearchDestinationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/controller/SearchDestinationController.java
@@ -2,6 +2,7 @@ package com.se.Tlog.domain.Search.controller;
 
 import java.util.List;
 
+import com.se.Tlog.domain.Search.controller.dto.PopularDestinationDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -104,4 +105,18 @@ public class SearchDestinationController {
         return ResponseEntity.ok(SuccessRes.from(
                 searchService.searchDestinationByCityAndName(pageable, city, name)));
     }
+
+	@GetMapping("/popular-destination")
+	@Operation (
+			summary = "현재 인기 여행지 조회",
+			description = "현재 인기 여행지 정보를 반환합니다.",
+			responses = {
+					@ApiResponse(responseCode = "200", description = "처리 성공, 인기 여행지 리스트를 반환합니다."),
+					@ApiResponse(responseCode = "500", description = "서버 내부 오류. 조회에 실패했습니다.",
+							content = @Content(schema = @Schema(implementation = ErrorRes.class)))}
+	)
+	public ResponseEntity<SuccessRes<List<PopularDestinationDto>>> getPopularDestinations() {
+		return ResponseEntity.ok(SuccessRes.from(
+				searchService.getPopularDestinations()));
+	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/controller/dto/PopularDestinationDto.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/controller/dto/PopularDestinationDto.java
@@ -1,0 +1,22 @@
+package com.se.Tlog.domain.Search.controller.dto;
+
+import com.se.Tlog.domain.Travel.domain.Destination;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "최근 인기있는 여행지 데이터입니다.")
+public record PopularDestinationDto(
+        @Schema(example = "전국/서울 등등 지역이름")
+        String region,
+        @Schema(example = "https://example.com/image")
+        String imageUrl,
+        @Schema(example = "11223344aabbccdd5566eeff")
+        String destinationId
+) {
+        public static PopularDestinationDto create(Destination destination) {
+                return create(destination, destination.getCity());
+        }
+
+        public static PopularDestinationDto create(Destination destination, String customRegionName) {
+                return new PopularDestinationDto(customRegionName, destination.getImageUrl(), destination.getId());
+        }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/domain/DestinationPopularity.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/domain/DestinationPopularity.java
@@ -1,0 +1,28 @@
+package com.se.Tlog.domain.Search.domain;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "destination_popularity")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DestinationPopularity {
+    @Id
+    private String destinationId;
+    private long score;
+
+    public void updateScore(long delta) {
+        score += delta;
+    }
+
+    public static DestinationPopularity create(String destinationId, long score) {
+        if (destinationId == null)
+            throw new CustomException(ErrorType.ILLEGAL_ARGUMENT);
+        return new DestinationPopularity(destinationId, score);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/repository/mongo/PopularityRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/repository/mongo/PopularityRepository.java
@@ -1,0 +1,19 @@
+package com.se.Tlog.domain.Search.repository.mongo;
+
+import com.se.Tlog.domain.Search.domain.DestinationPopularity;
+import com.se.Tlog.domain.Travel.domain.Destination;
+import org.springframework.data.mongodb.repository.Aggregation;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface PopularityRepository extends MongoRepository<DestinationPopularity, String> {
+    @Aggregation(pipeline = {
+            "{ $sort: { score: -1 } }",
+            "{ $limit: ?0 }",
+            "{ $lookup: { from: 'destinations', localField: '_id', foreignField: '_id', as: 'dest' } }",
+            "{ $unwind: { path: '$dest' } }",
+            "{ $replaceWith: '$dest' }"
+    })
+    List<Destination> findPopularDestinations(int size);
+}

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Search/repository/redis/PopularityCacheRepository.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Search/repository/redis/PopularityCacheRepository.java
@@ -1,0 +1,37 @@
+package com.se.Tlog.domain.Search.repository.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class PopularityCacheRepository {
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String KEY_PREFIX = "popular:destination:";
+    private static final String ALL_IDS_KEY = "popular:destination:all";
+
+    public void addScore(String destinationId, int score) {
+        redisTemplate.opsForValue().increment(KEY_PREFIX + destinationId, score);
+        redisTemplate.opsForSet().add(ALL_IDS_KEY, destinationId);
+    }
+
+    private long removeScore(String destinationId) {
+        String value = redisTemplate.opsForValue().getAndDelete(KEY_PREFIX + destinationId);
+        redisTemplate.opsForSet().remove(ALL_IDS_KEY, destinationId);
+        return (value != null ? Long.parseLong(value) : 0);
+    }
+
+    public Map<String, Long> popAllCachedScore() {
+        Set<String> ids = redisTemplate.opsForSet().members(ALL_IDS_KEY);
+        if (ids == null)
+            return Map.of();
+        return ids.stream().collect(Collectors.toMap(Function.identity(), this::removeScore));
+    }
+}


### PR DESCRIPTION
## 작업 동기 및 이슈
- #276 

## 추가 및 변경사항
- **인기 여행지 책정 기능이 추가되었습니다.**
  - **이제 여행지 id마다 인기도를 저장합니다.**
    - `DestinationPopularity` 엔티티가 추가되었습니다.
    - 여행지와의 빠른 매핑 및 조회를 위해 MongoDB의 `destination_popularity` 컬렉션으로 관리합니다.
  - **다음의 상황이 발생하면 인기도(`score`)가 증가합니다. (AOP 방식으로 구현됩니다.)**
    - 여행지 세부 조회가 발생할 경우
    - 리뷰에 3점 이상의 평가가 발생한 경우
    - 장바구니/스크랩에 여행지가 추가된 경우
  - **잦은 인기도 변경에 대비해 캐싱-동기화 방식으로 구현됩니다.**
    - `PopularityCacheRepository` : 인기도 변경을 `Redis`에 캐싱합니다.
    - `PopularitySyncJob` : **2분마다** 캐싱된 인기도를 DB로 반영합니다.
    - 그러나 인기 여행지 조회시에는 캐싱을 무시하고 DB의 값으로 조회합니다.
      - 2분 단위의 짧은 간격으로 동기화가 되며, 인기도는 초 단위의 실시간 특성을 타지 않는다고 판단하여 이렇게 구성되었습니다.
 
- **인기 여행지 조회 기능이 추가되었습니다.**
  - 조회 API가 추가되었습니다.
    <img width="400" src="https://github.com/user-attachments/assets/849b1510-9a3a-429d-8c81-237492b6d3bc" />
  - 지역 이름과 대표 이미지가 함께 반환됩니다.
    <img width="400" src="https://github.com/user-attachments/assets/9d1f4fab-2f08-47b9-ae29-0ad52e719b69" />

## 테스트 결과
- 이상 무.
- 동기화 테스트 결과 :
  - **2분 간격 캐싱 비우기 이상 무**
  - **DB 저장 이상 무**
  - 아래 3개의 여행지에 대해 테스트 :
    - 690a4f7efc42675342b9dd88
    - 690a4f7efc42675342b9ddd9
    - 690a4f7efc42675342b9dd62
  - **1.** `690a4f7efc42675342b9dd62` 에 대해 장바구니 조회 후
    - 동기화 로그 : `2025-11-18T01:17:18.581+09:00  INFO 27588 --- [MessageBroker-2] c.s.T.d.Search.batch.PopularitySyncJob   : Syncing destination's popularity scores (dest cnt : 1)`
    - DB 결과 : 
      <img width="400" src="https://github.com/user-attachments/assets/878c0a9b-117d-42aa-a0ff-b3b911fc1b96" />
  - **2.** `690a4f7efc42675342b9dd62` 에 대해 상세조회 2번 + `690a4f7efc42675342b9ddd9`에 대해 장바구니 추가
    - 동기화 로그 : `2025-11-18T01:19:14.420+09:00  INFO 27588 --- [MessageBroker-1] c.s.T.d.Search.batch.PopularitySyncJob   : Syncing destination's popularity scores (dest cnt : 2)`
    - DB 결과 : 
      <img width="400" src="https://github.com/user-attachments/assets/68bb749f-2d27-4543-b1ad-97e6d8a89cf7" />
  - **3.** 모든 여행지에 대해 1~2회 조회/장바구니추가/리뷰작성 시도
    - 동기화 로그 : `2025-11-18T01:21:14.830+09:00  INFO 27588 --- [MessageBroker-3] c.s.T.d.Search.batch.PopularitySyncJob   : Syncing destination's popularity scores (dest cnt : 3)`
    - DB 결과 : 
      <img width="400" src="https://github.com/user-attachments/assets/58b96304-f3ee-4fff-a735-b6ed3b3510bf" />


## 📌 기타
