### PR TITLE
Feature: 여행지 조회시 추천순 정렬 기능 작성

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -15,11 +15,7 @@ import com.se.Tlog.global.response.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 
 @ApplicationService
 @RequiredArgsConstructor
@@ -68,8 +64,8 @@ public class DestinationService {
     }
 
     public Slice<DestinationSummaryRes> getAllDestinations(Pageable pageable, String city,
-                                                          DestinationSortType sortType, String tbti) {
-        List<Destination> destinations = destinationRepoExtension.getDestinations(pageable, city, sortType);
+                                                          DestinationSortType sortType, UUID userId) {
+        List<Destination> destinations = destinationRepoExtension.getDestinations(pageable, city, sortType, userId);
         boolean hasNext = destinations.size() > pageable.getPageSize();
 
         if (hasNext) {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/controller/DestinationController.java
@@ -1,25 +1,28 @@
 package com.se.Tlog.domain.Travel.controller;
 
 import com.se.Tlog.domain.Travel.application.DestinationService;
-import com.se.Tlog.domain.Travel.controller.dto.DestinationByTagDto;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationDetailsRes;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationDto;
 import com.se.Tlog.domain.Travel.controller.dto.DestinationSummaryRes;
 import com.se.Tlog.domain.Travel.domain.DestinationSortType;
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
 import com.se.Tlog.global.response.success.SuccessRes;
 import com.se.Tlog.global.response.success.SuccessType;
+import com.se.Tlog.global.security.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 
-import java.util.List;
+import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -52,8 +55,10 @@ public class DestinationController {
 
     @GetMapping
     @Operation(
-            summary = "전체 여행지 리스트 조회",
-            description = "전체 여행지 정보를 페이지네이션하여 반환합니다.",
+            summary = "전체 여행지 리스트 조회 (인증 토큰 필요)",
+            description = "전체 여행지 정보를 페이지네이션하여 반환합니다."
+                        + "<br>RECOMMEND 정렬을 사용할 경우, city에 <b>지역코드</b>가 입력되어야 합니다!"
+                        + "<br><br><b>인증 토큰이 필요합니다!</b>",
             tags = {"Travel 도메인"},
             security = @SecurityRequirement(name = "JwtAuthScheme"),
             responses = {
@@ -62,13 +67,16 @@ public class DestinationController {
             }
     )
     public ResponseEntity<SuccessRes<Slice<DestinationSummaryRes>>> getAllDestinations(
+            @AuthenticationPrincipal CustomUserDetails user,
             @PageableDefault(size = 10) Pageable pageable,
             @RequestParam String city,
-            @RequestParam(defaultValue = "RECOMMAND") DestinationSortType sortType,
-            @RequestParam(required = false) String tbti) {
+            @RequestParam(defaultValue = "RECOMMAND") DestinationSortType sortType) {
+        if (user == null)
+            throw new CustomException(ErrorType.UN_AUTHENTICATION);
+
         return ResponseEntity
                 .status(SuccessType.DESTINATION_GET_SUCCESS.getStatus())
-                .body(SuccessRes.from(destinationService.getAllDestinations(pageable,city,sortType,tbti)));
+                .body(SuccessRes.from(destinationService.getAllDestinations(pageable,city,sortType, UUID.fromString(user.getId()))));
     }
 
     @GetMapping("/{id}")

--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/DestinationRepositoryExtension.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/repository/mongo/DestinationRepositoryExtension.java
@@ -2,6 +2,7 @@ package com.se.Tlog.domain.Travel.repository.mongo;
 
 import com.mongodb.client.result.UpdateResult;
 import com.se.Tlog.domain.Review.domain.Review;
+import com.se.Tlog.domain.Search.repository.api.AiRecApi;
 import com.se.Tlog.domain.Travel.domain.Destination;
 import com.se.Tlog.domain.Travel.domain.DestinationSortType;
 import com.se.Tlog.domain.Travel.repository.mongo.dto.DestinationOfTagProjection;
@@ -27,6 +28,8 @@ import lombok.RequiredArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 
@@ -34,6 +37,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class DestinationRepositoryExtension {
     private final MongoTemplate mongoTemplate;
+    private final AiRecApi aiRecApi;
 
     public void increaseReviewCountAndRating(String destinationId, int rating, float approximateAverage) {
         Update update = new Update()
@@ -82,7 +86,7 @@ public class DestinationRepositoryExtension {
         }
     }
 
-    public List<Destination> getDestinations(Pageable pageable, String city, DestinationSortType sortType) {
+    private List<Destination> getDestinationsBySortType(Pageable pageable, String city, DestinationSortType sortType) {
         MatchOperation matchStage = Aggregation.match(Criteria.where("city").is(city));
 
         SortOperation sortStage = null;
@@ -108,6 +112,36 @@ public class DestinationRepositoryExtension {
 
         return new ArrayList<>(mongoTemplate.aggregate(aggregation, "destinations", Destination.class)
                 .getMappedResults());
+    }
+
+    private List<Destination> getDestinationsByRecommendType(UUID userId, String regionCode, Pageable pageable) {
+        final int MAX_SIZE = 50;
+
+        int region_code = -1;
+        try {
+            region_code = Integer.parseInt(regionCode);
+        } catch (Exception e) {
+            throw new CustomException(ErrorType.INVALID_REGION_CODE);
+        }
+
+        int last = Math.min(MAX_SIZE, (int)(pageable.getOffset() + pageable.getPageSize()) + 1); // 다음 페이지 존재 여부 확인 위해 +1
+        List<String> ids = aiRecApi.getDestinationIds(userId, region_code, last);
+        if (ids.size() <= pageable.getOffset())
+            return List.of();
+
+        List<String> pagedIds = ids.subList((int)pageable.getOffset(), ids.size());
+
+        Query q = Query.query(Criteria.where("_id").in(pagedIds));
+        Map<String, Destination> destinations = mongoTemplate.find(q, Destination.class)
+                .stream().collect(Collectors.toMap(Destination::getId, Function.identity()));
+        return pagedIds.stream().map(destinations::get).collect(Collectors.toList());
+    }
+
+    public List<Destination> getDestinations(Pageable pageable, String city, DestinationSortType sortType, UUID userId) {
+        if (sortType == DestinationSortType.RECOMMEND)
+            return getDestinationsByRecommendType(userId, city, pageable);
+        else
+            return getDestinationsBySortType(pageable, city, sortType);
     }
     
     public Map<String, Destination> findAllByEachTags(List<String> tagsId) {

--- a/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/response/error/ErrorType.java
@@ -1,5 +1,6 @@
 package com.se.Tlog.global.response.error;
 
+import com.se.Tlog.domain.Travel.domain.DestinationSortType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -51,6 +52,9 @@ public enum ErrorType {
     INVALID_ANSWER_PERCENTAGE(HttpStatus.BAD_REQUEST, "TBTI 응답의 값은 0~99사이여야 합니다."),
     QUESTION_HAS_NO_ANSWER(HttpStatus.BAD_REQUEST, "TBTI 질문에는 응답이 1개 이상 존재해야 합니다."),
     INVALID_QUESTION_WEIGHT(HttpStatus.BAD_REQUEST, "TBTI 질문의 가중치는 1~5사이여야 합니다."),
+
+    // 여행지 추천 관련
+    INVALID_REGION_CODE(HttpStatus.BAD_REQUEST, DestinationSortType.RECOMMEND.name() + "타입 조회를 위해서는 city에 지역코드가 필요합니다."),
 
     // 인증
     // 401


### PR DESCRIPTION
## 작업 동기 및 이슈
- #278 

## 추가 및 변경사항
- **기존 여행지 조회 기능에서 추천순 정렬 기능이 구현되었습니다.**
  - 기존 파라미터 `tbti`가 제거되었고, 인증토큰을 통해 사용자를 식별해 TBTI 및 태그 가중치를 계산합니다.
  - 지역코드 입력을 위해 `city`는 추천순에 대해서만 지역코드 값으로 입력받습니다.
    <img width="500" src="https://github.com/user-attachments/assets/fed3988c-e020-4e33-a24c-075f7ebbb20e" />

## 테스트 결과
- 이상 무.

## 📌 기타
