### PR TITLE
Fix: 여행지 생성시 imageUrl과 description이 혼동된 문제 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/Travel/application/DestinationService.java
@@ -43,8 +43,8 @@ public class DestinationService {
                 destinationDto.getDistrict(),
                 destinationDto.isHasParking(),
                 destinationDto.isPetFriendly(),
-                destinationDto.getDescription(),
-                destinationDto.getImageUrl());
+                destinationDto.getImageUrl(),
+                destinationDto.getDescription());
         
         UnapprovedDestination newDestination = UnapprovedDestination.create(
                 destinationDto.getCreater(), destinationData, destinationDto.getCustomTags());


### PR DESCRIPTION
## 작업 동기 및 이슈
- #283 

## 추가 및 변경사항
- **여행지 생성시 imageUrl 필드와 description 필드가 혼동되어 저장되는 문제 발생**
  매개변수 값이 올바르게 전달하도록 수정되었습니다.
  <img width="600" src="https://github.com/user-attachments/assets/32aca6d4-43e1-4dd2-920e-9f2847248d8c" />

## 테스트 결과
- 이상 무.

## 📌 기타
