### PR TITLE
Feature/FIX: 토큰 갱신 기능 작성, 로그아웃/갱신 시도시 에러 발생하는 문제 수정

### DIFF
--- a/tlog-was/src/main/java/com/se/Tlog/config/security/WebSecurityConfig.java
+++ b/tlog-was/src/main/java/com/se/Tlog/config/security/WebSecurityConfig.java
@@ -7,7 +7,7 @@ import com.se.Tlog.domain.User.repository.jpa.UserRepository;
 import com.se.Tlog.global.security.filter.JwtAuthenticationFilter;
 import com.se.Tlog.global.security.filter.JwtExceptionFilter;
 import com.se.Tlog.global.util.jwt.AccessTokenProvider;
-import com.se.Tlog.global.util.redis.RedisUtil;
+import com.se.Tlog.global.util.redis.RedisTokenUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,7 +34,7 @@ public class WebSecurityConfig {
     private final CorsConfigurationSource corsConfigurationSource;
     private final AccessTokenProvider accessTokenProvider;
     private final ObjectMapper objectMapper;
-    private final RedisUtil redisUtil;
+    private final RedisTokenUtil redisTokenUtil;
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
@@ -69,7 +69,7 @@ public class WebSecurityConfig {
 
 
                 })
-                .addFilterBefore(new JwtAuthenticationFilter(accessTokenProvider,userRepository,adminRepository,redisUtil), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(accessTokenProvider,userRepository,adminRepository,redisTokenUtil), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtExceptionFilter(objectMapper), JwtAuthenticationFilter.class);
 
         return http.build();

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -27,12 +27,14 @@ import com.se.Tlog.global.response.error.ErrorType;
 import com.se.Tlog.global.util.jwt.AccessTokenProvider;
 import com.se.Tlog.global.util.jwt.RefreshTokenProvider;
 import com.se.Tlog.global.util.redis.RedisTokenUtil;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -120,9 +122,33 @@ public class SsoAuthService {
         return loginUser(registerNewUser(ssoUserInfo, registerRequest.userProfile()));
     }
     
-    public void logout(String accessToken,String refreshToken) {
+    public void logout(String accessToken, String refreshToken) {
         redisTokenUtil.disableAccessToken(accessToken);
         redisTokenUtil.disableRefreshToken(refreshToken);
+    }
+
+    public TokenDto refresh(String accessToken, String refreshToken) {
+        boolean isBlacklisted = redisTokenUtil.isRefreshTokenBlackListed(refreshToken);
+        Claims claims = refreshTokenProvider.parseToken(refreshToken);
+        if (isBlacklisted) {
+            String jti = claims.get("jti").toString();
+            log.warn("BLOCKED REFRESH TOKEN (jti = {})", jti);
+            throw new CustomException(ErrorType.TOKEN_EXPIRED);
+        }
+
+        redisTokenUtil.disableAccessToken(accessToken);
+        redisTokenUtil.disableRefreshToken(refreshToken);
+
+        UUID userId = null;
+        try {
+            userId = UUID.fromString(claims.getSubject());
+        } catch (Exception e) {
+            throw new CustomException(ErrorType.TOKEN_EXPIRED);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_REGISTERED));
+        return loginUser(user);
     }
 
     @Deprecated(since = "테스트 환경 전용입니다.")

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -61,7 +61,7 @@ public class SsoAuthService {
     private TokenDto loginUser(User user) {
         String accessToken = accessTokenProvider.generateToken(user.getId().toString(), user.getRole().getValue(), user.getSnsId(), user.getName());
         String refreshToken = refreshTokenProvider.generateToken(user.getId().toString(), user.getRole().getValue());
-        redisTokenUtil.registerRefreshToken(user.getId(), refreshToken);
+        redisTokenUtil.registerRefreshToken(refreshToken);
 
         String customToken = "";
         try {

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -26,9 +26,7 @@ import com.se.Tlog.global.exception.CustomException;
 import com.se.Tlog.global.response.error.ErrorType;
 import com.se.Tlog.global.util.jwt.AccessTokenProvider;
 import com.se.Tlog.global.util.jwt.RefreshTokenProvider;
-import com.se.Tlog.global.util.redis.RedisProperties;
-import com.se.Tlog.global.util.redis.RedisUtil;
-import io.jsonwebtoken.Claims;
+import com.se.Tlog.global.util.redis.RedisTokenUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -49,7 +47,7 @@ public class SsoAuthService {
     private final PreferPhotoRepository preferPhotoRepository;
     private final AccessTokenProvider accessTokenProvider;
     private final RefreshTokenProvider refreshTokenProvider;
-    private final RedisUtil redisUtil;
+    private final RedisTokenUtil redisTokenUtil;
     
     private SsoUserInfo getSsoUserInfo(SsoType type, String accessToken) {
         SsoService ssoService = Optional.ofNullable(ssoServiceMap.get(type))
@@ -63,16 +61,12 @@ public class SsoAuthService {
     private TokenDto loginUser(User user) {
         String accessToken = accessTokenProvider.generateToken(user.getId().toString(), user.getRole().getValue(), user.getSnsId(), user.getName());
         String refreshToken = refreshTokenProvider.generateToken(user.getId().toString(), user.getRole().getValue());
-
-        String jti = refreshTokenProvider.parseToken(refreshToken).get("jti").toString();
-        String refreshKey = RedisProperties.REFRESH_TOKEN_PREFIX + user.getId() + ":" + jti;
-
-        redisUtil.save(refreshKey, refreshToken, refreshTokenProvider.getRefreshTokenDuration());
+        redisTokenUtil.registerRefreshToken(user.getId(), refreshToken);
 
         String customToken = "";
-        try{
+        try {
             customToken = FirebaseAuth.getInstance().createCustomToken(user.getId().toString());
-        }catch (FirebaseAuthException e) {
+        } catch (FirebaseAuthException e) {
             throw new CustomException(ErrorType.FIREBASE_CUSTOM_TOKEN_ISSUE_FAIL);
         }
 
@@ -127,26 +121,8 @@ public class SsoAuthService {
     }
     
     public void logout(String accessToken,String refreshToken) {
-        Claims accessClaims = accessTokenProvider.parseToken(accessToken);
-        String accessJti = accessClaims.get("jti").toString();
-
-        long remainingTime = accessClaims.getExpiration().getTime() - System.currentTimeMillis();
-
-        Claims refreshClaims = refreshTokenProvider.parseToken(refreshToken);
-        String refreshJti = refreshClaims.get("jti").toString();
-        String refreshKey = RedisProperties.REFRESH_TOKEN_PREFIX + refreshClaims.getSubject() + ":" + refreshJti;
-
-        try {
-            redisUtil.setBlacklistToken(RedisProperties.ACCESS_TOKEN_PREFIX + accessJti, remainingTime);
-        } catch (Exception e) {
-            log.error("블랙리스트 등록 실패: {}", accessJti, e);
-            throw new CustomException(ErrorType.BLACKLIST_SAVE_FAILED);
-        }
-
-        boolean isDeleted = redisUtil.delete(refreshKey);
-        if (!isDeleted) {
-            log.warn("Refresh token 삭제 실패: {}", refreshKey);
-        }
+        redisTokenUtil.disableAccessToken(accessToken);
+        redisTokenUtil.disableRefreshToken(refreshToken);
     }
 
     @Deprecated(since = "테스트 환경 전용입니다.")

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/application/SsoAuthService.java
@@ -128,9 +128,10 @@ public class SsoAuthService {
     }
 
     public TokenDto refresh(String accessToken, String refreshToken) {
-        boolean isBlacklisted = redisTokenUtil.isRefreshTokenBlackListed(refreshToken);
-        Claims claims = refreshTokenProvider.parseToken(refreshToken);
-        if (isBlacklisted) {
+        boolean isInvalid = redisTokenUtil.isRefreshTokenBlackListed(refreshToken)
+                || refreshTokenProvider.isTokenExpired(refreshToken);
+        Claims claims = refreshTokenProvider.parseTokenIgnoringExpiration(refreshToken);
+        if (isInvalid) {
             String jti = claims.get("jti").toString();
             log.warn("BLOCKED REFRESH TOKEN (jti = {})", jti);
             throw new CustomException(ErrorType.TOKEN_EXPIRED);

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
@@ -166,4 +166,29 @@ public class AuthController {
 		return ResponseEntity.ok()
 					.body(SuccessRes.from(SuccessType.LOGOUT_SUCCESS));
 	}
+
+	@PostMapping("/refresh")
+	@Operation(
+			summary = "토큰 갱신 요청",
+			description = "사용자의 기존 accessToken과 refreshToken으로부터 토큰을 갱신합니다.",
+			tags = {"SSO Authentication"},
+			responses = {
+					@ApiResponse(responseCode = "200", description = "갱신 성공 (갱신된 새 토큰 발급)"),
+					@ApiResponse(responseCode = "401", description = "갱신 실패 (RefreshToken 만료)"),
+					@ApiResponse(responseCode = "500", description = "갱신 실패")
+			}
+	)
+	public ResponseEntity<?> refreshJwt(
+			@RequestHeader("Authorization") String authorizationHeader,
+			@CookieValue(value = "refreshToken") String refreshToken) {
+		String accessToken = jwtUtil.resolveToken(authorizationHeader);
+		TokenDto tokenDto = ssoAuthService.refresh(accessToken, refreshToken);
+
+		return ResponseEntity.ok()
+				.header("Authorization",tokenDto.accessToken())
+				.header("Set-Cookie",tokenDto.refreshToken())
+				.body(SuccessRes.of(SuccessType.LOGIN_SSO_SUCCESS, Map.of(
+						"firebaseCustomToken", tokenDto.firebaseCustomToken()
+				)));
+	}
 }

--- a/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
+++ b/tlog-was/src/main/java/com/se/Tlog/domain/User/controller/AuthController.java
@@ -149,8 +149,9 @@ public class AuthController {
 
 	@PostMapping("/logout")
 	@Operation(
-			summary = "SSO 로그아웃 요청",
-			description = "사용자 accessToken 과 refreshToken을 쿠키로 받아 처리합니다.",
+			summary = "SSO 로그아웃 요청 (Postman에서 가능)",
+			description = "사용자 accessToken 과 refreshToken을 쿠키로 받아 처리합니다."
+					+ "<br><b>Swagger의 한계로 인해 Header와 Cookie 설정이 불가합니다. Postman에서 요청해주세요.<b>",
 			tags = {"SSO Authentication"},
 			responses = {
 					@ApiResponse(responseCode = "200", description = "로그아웃 성공 (토큰 블랙리스트 처리 완료)"),
@@ -169,8 +170,9 @@ public class AuthController {
 
 	@PostMapping("/refresh")
 	@Operation(
-			summary = "토큰 갱신 요청",
-			description = "사용자의 기존 accessToken과 refreshToken으로부터 토큰을 갱신합니다.",
+			summary = "토큰 갱신 요청 (Postman에서 가능)",
+			description = "사용자의 기존 accessToken(헤더)과 refreshToken(쿠키)으로부터 토큰을 갱신합니다."
+					+ "<br><b>Swagger의 한계로 인해 Header와 Cookie 설정이 불가합니다. Postman에서 요청해주세요.<b>",
 			tags = {"SSO Authentication"},
 			responses = {
 					@ApiResponse(responseCode = "200", description = "갱신 성공 (갱신된 새 토큰 발급)"),

--- a/tlog-was/src/main/java/com/se/Tlog/global/security/filter/JwtAuthenticationFilter.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/security/filter/JwtAuthenticationFilter.java
@@ -20,6 +20,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -36,8 +38,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final AdminRepository adminRepository;
     private final RedisTokenUtil redisTokenUtil;
 
+    private static final RequestMatcher AUTH_REQUEST_MATCHER = new AntPathRequestMatcher("/api/auth/**");
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // auth 관련 로직(로그인/로그아웃 등)은 jwt 검증 처리가 필요하지 않습니다.
+        if (AUTH_REQUEST_MATCHER.matches(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
 
         if (authorization == null || !authorization.startsWith("Bearer ")) {

--- a/tlog-was/src/main/java/com/se/Tlog/global/security/filter/JwtAuthenticationFilter.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/security/filter/JwtAuthenticationFilter.java
@@ -7,8 +7,7 @@ import com.se.Tlog.global.response.error.ErrorType;
 import com.se.Tlog.global.security.dto.AdminDetails;
 import com.se.Tlog.global.security.dto.AppUserDetails;
 import com.se.Tlog.global.util.jwt.AccessTokenProvider;
-import com.se.Tlog.global.util.redis.RedisProperties;
-import com.se.Tlog.global.util.redis.RedisUtil;
+import com.se.Tlog.global.util.redis.RedisTokenUtil;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -35,7 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final AccessTokenProvider accessTokenProvider;
     private final UserRepository userRepository;
     private final AdminRepository adminRepository;
-    private final RedisUtil redisUtil;
+    private final RedisTokenUtil redisTokenUtil;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -47,12 +46,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String accessToken = authorization.split(" ")[1];
 
             Claims claims = accessTokenProvider.parseToken(accessToken);
-            String jti = claims.get("jti").toString();
-            String accessKey = RedisProperties.ACCESS_TOKEN_PREFIX + jti;
-
-            boolean isBlacklisted = redisUtil.isTokenBlacklisted(accessKey);
+            boolean isBlacklisted = redisTokenUtil.isAccessTokenBlackListed(accessToken);
 
             if (isBlacklisted) {
+                String jti = claims.get("jti").toString();
                 log.warn("BLOCKED TOKEN (jti = {})", jti);
                 response.setStatus(ErrorType.UN_AUTHORIZATION.getStatusCode());
                 response.setContentType("application/json");

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/AccessTokenProvider.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/AccessTokenProvider.java
@@ -53,6 +53,11 @@ public class AccessTokenProvider implements JwtTokenProvider {
     }
 
     @Override
+    public Claims parseTokenIgnoringExpiration(String token) {
+        return jwtUtil.parseTokenIgnoringExpiration(token);
+    }
+
+    @Override
     public Claims parseAndValidate(String token) {
         Claims claims = parseToken(token);
         if (claims.getExpiration().before(new Date())) {

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/JwtTokenProvider.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/JwtTokenProvider.java
@@ -10,6 +10,8 @@ public interface JwtTokenProvider {
 
     Claims parseToken(String token);
 
+    Claims parseTokenIgnoringExpiration(String token);
+
     Claims parseAndValidate(String token);
 
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/JwtUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/JwtUtil.java
@@ -1,6 +1,7 @@
 package com.se.Tlog.global.util.jwt;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -42,6 +43,19 @@ public class JwtUtil {
                 .parseSignedClaims(token)   //jwt 토큰 전체
                 .getPayload();
     }
+
+    public Claims parseTokenIgnoringExpiration(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)   //jwt 토큰 전체
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
     private Date createExpire(Long expiration){
         return new Date(System.currentTimeMillis() + expiration);
     }

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/RefreshTokenProvider.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/jwt/RefreshTokenProvider.java
@@ -45,6 +45,11 @@ public class RefreshTokenProvider implements JwtTokenProvider{
     }
 
     @Override
+    public Claims parseTokenIgnoringExpiration(String token) {
+        return jwtUtil.parseTokenIgnoringExpiration(token);
+    }
+
+    @Override
     public Claims parseAndValidate(String token) {
         Claims claims = parseToken(token);
         if (claims.getExpiration().before(new Date())) {

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisTokenUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisTokenUtil.java
@@ -87,4 +87,9 @@ public class RedisTokenUtil {
         String accessKey = getAccessTokenKey(accessToken);
         return redisUtil.isTokenBlacklisted(accessKey);
     }
+
+    public boolean isRefreshTokenBlackListed(String refreshToken) {
+        String refreshKey = getRefreshTokenKey(refreshToken);
+        return null == redisUtil.get(refreshKey);
+    }
 }

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisTokenUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisTokenUtil.java
@@ -22,12 +22,9 @@ public class RedisTokenUtil {
 
     private String getAccessTokenKey(String accessToken) {
         try {
-            Claims accessClaims = accessTokenProvider.parseToken(accessToken);
+            Claims accessClaims = accessTokenProvider.parseTokenIgnoringExpiration(accessToken);
             String accessJti = accessClaims.get("jti").toString();
             return RedisProperties.ACCESS_TOKEN_PREFIX + accessJti;
-        } catch (ExpiredJwtException e) {
-            log.error("token expired");
-            throw new CustomException(ErrorType.TOKEN_EXPIRED);
         } catch (JwtException e) {
             log.error("token authentication failed : " + e.getMessage());
             throw new CustomException(ErrorType.UN_AUTHENTICATION);
@@ -36,12 +33,9 @@ public class RedisTokenUtil {
 
     private String getRefreshTokenKey(String refreshToken) {
         try {
-            Claims refreshClaims = refreshTokenProvider.parseToken(refreshToken);
-            String jti = refreshTokenProvider.parseToken(refreshToken).get("jti").toString();
+            Claims refreshClaims = refreshTokenProvider.parseTokenIgnoringExpiration(refreshToken);
+            String jti = refreshClaims.get("jti").toString();
             return RedisProperties.REFRESH_TOKEN_PREFIX + refreshClaims.getSubject() + ":" + jti;
-        } catch (ExpiredJwtException e) {
-            log.error("refresh token expired");
-            throw new CustomException(ErrorType.TOKEN_EXPIRED);
         } catch (JwtException e) {
             log.error("refresh token authentication failed : " + e.getMessage());
             throw new CustomException(ErrorType.UN_AUTHENTICATION);
@@ -63,11 +57,12 @@ public class RedisTokenUtil {
      */
     public void disableAccessToken(String accessToken) throws CustomException {
         String accessKey = getAccessTokenKey(accessToken);
-        Claims accessClaims = accessTokenProvider.parseToken(accessToken);
+        Claims accessClaims = accessTokenProvider.parseTokenIgnoringExpiration(accessToken);
         long remainingTime = accessClaims.getExpiration().getTime() - System.currentTimeMillis();
 
         try {
-            redisUtil.setBlacklistToken(accessKey, remainingTime);
+            if (0 < remainingTime)
+                redisUtil.setBlacklistToken(accessKey, remainingTime);
         } catch (Exception e) {
             String accessJti = accessClaims.get("jti").toString();
             log.error("블랙리스트 등록 실패: {}", accessJti, e);

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisTokenUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisTokenUtil.java
@@ -1,0 +1,69 @@
+package com.se.Tlog.global.util.redis;
+
+import com.se.Tlog.global.exception.CustomException;
+import com.se.Tlog.global.response.error.ErrorType;
+import com.se.Tlog.global.util.jwt.AccessTokenProvider;
+import com.se.Tlog.global.util.jwt.RefreshTokenProvider;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Slf4j
+
+@Component
+@RequiredArgsConstructor
+public class RedisTokenUtil {
+    private final RedisUtil redisUtil;
+    private final AccessTokenProvider accessTokenProvider;
+    private final RefreshTokenProvider refreshTokenProvider;
+
+    public void registerRefreshToken(UUID userId, String refreshToken) {
+        String jti = refreshTokenProvider.parseToken(refreshToken).get("jti").toString();
+        String refreshKey = RedisProperties.REFRESH_TOKEN_PREFIX + userId + ":" + jti;
+
+        redisUtil.save(refreshKey, refreshToken, refreshTokenProvider.getRefreshTokenDuration());
+    }
+
+    /**
+     *
+     * @throws CustomException
+     * 블랙리스트 설정에 실패할 경우 에러가 발생합니다.
+     */
+    public void disableAccessToken(String accessToken) throws CustomException {
+        Claims accessClaims = accessTokenProvider.parseToken(accessToken);
+
+        String accessJti = accessClaims.get("jti").toString();
+        String accessKey = RedisProperties.ACCESS_TOKEN_PREFIX + accessJti;
+        long remainingTime = accessClaims.getExpiration().getTime() - System.currentTimeMillis();
+
+        try {
+            redisUtil.setBlacklistToken(accessKey, remainingTime);
+        } catch (Exception e) {
+            log.error("블랙리스트 등록 실패: {}", accessJti, e);
+            throw new CustomException(ErrorType.BLACKLIST_SAVE_FAILED);
+        }
+    }
+
+    public void disableRefreshToken(String refreshToken) {
+        Claims refreshClaims = refreshTokenProvider.parseToken(refreshToken);
+
+        String refreshJti = refreshClaims.get("jti").toString();
+        String refreshKey = RedisProperties.REFRESH_TOKEN_PREFIX + refreshClaims.getSubject() + ":" + refreshJti;
+
+        boolean isDeleted = redisUtil.delete(refreshKey);
+        if (!isDeleted) {
+            log.warn("Refresh token 삭제 실패: {}", refreshKey);
+        }
+    }
+
+    public boolean isAccessTokenBlackListed(String accessToken) {
+        Claims claims = accessTokenProvider.parseToken(accessToken);
+        String jti = claims.get("jti").toString();
+        String accessKey = RedisProperties.ACCESS_TOKEN_PREFIX + jti;
+
+        return redisUtil.isTokenBlacklisted(accessKey);
+    }
+}

--- a/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisTokenUtil.java
+++ b/tlog-was/src/main/java/com/se/Tlog/global/util/redis/RedisTokenUtil.java
@@ -5,11 +5,11 @@ import com.se.Tlog.global.response.error.ErrorType;
 import com.se.Tlog.global.util.jwt.AccessTokenProvider;
 import com.se.Tlog.global.util.jwt.RefreshTokenProvider;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-
-import java.util.UUID;
 
 @Slf4j
 
@@ -20,11 +20,40 @@ public class RedisTokenUtil {
     private final AccessTokenProvider accessTokenProvider;
     private final RefreshTokenProvider refreshTokenProvider;
 
-    public void registerRefreshToken(UUID userId, String refreshToken) {
-        String jti = refreshTokenProvider.parseToken(refreshToken).get("jti").toString();
-        String refreshKey = RedisProperties.REFRESH_TOKEN_PREFIX + userId + ":" + jti;
+    private String getAccessTokenKey(String accessToken) {
+        try {
+            Claims accessClaims = accessTokenProvider.parseToken(accessToken);
+            String accessJti = accessClaims.get("jti").toString();
+            return RedisProperties.ACCESS_TOKEN_PREFIX + accessJti;
+        } catch (ExpiredJwtException e) {
+            log.error("token expired");
+            throw new CustomException(ErrorType.TOKEN_EXPIRED);
+        } catch (JwtException e) {
+            log.error("token authentication failed : " + e.getMessage());
+            throw new CustomException(ErrorType.UN_AUTHENTICATION);
+        }
+    }
 
-        redisUtil.save(refreshKey, refreshToken, refreshTokenProvider.getRefreshTokenDuration());
+    private String getRefreshTokenKey(String refreshToken) {
+        try {
+            Claims refreshClaims = refreshTokenProvider.parseToken(refreshToken);
+            String jti = refreshTokenProvider.parseToken(refreshToken).get("jti").toString();
+            return RedisProperties.REFRESH_TOKEN_PREFIX + refreshClaims.getSubject() + ":" + jti;
+        } catch (ExpiredJwtException e) {
+            log.error("refresh token expired");
+            throw new CustomException(ErrorType.TOKEN_EXPIRED);
+        } catch (JwtException e) {
+            log.error("refresh token authentication failed : " + e.getMessage());
+            throw new CustomException(ErrorType.UN_AUTHENTICATION);
+        }
+    }
+
+
+    public void registerRefreshToken(String refreshToken) {
+        redisUtil.save(
+                getRefreshTokenKey(refreshToken),
+                refreshToken,
+                refreshTokenProvider.getRefreshTokenDuration());
     }
 
     /**
@@ -33,26 +62,21 @@ public class RedisTokenUtil {
      * 블랙리스트 설정에 실패할 경우 에러가 발생합니다.
      */
     public void disableAccessToken(String accessToken) throws CustomException {
+        String accessKey = getAccessTokenKey(accessToken);
         Claims accessClaims = accessTokenProvider.parseToken(accessToken);
-
-        String accessJti = accessClaims.get("jti").toString();
-        String accessKey = RedisProperties.ACCESS_TOKEN_PREFIX + accessJti;
         long remainingTime = accessClaims.getExpiration().getTime() - System.currentTimeMillis();
 
         try {
             redisUtil.setBlacklistToken(accessKey, remainingTime);
         } catch (Exception e) {
+            String accessJti = accessClaims.get("jti").toString();
             log.error("블랙리스트 등록 실패: {}", accessJti, e);
             throw new CustomException(ErrorType.BLACKLIST_SAVE_FAILED);
         }
     }
 
     public void disableRefreshToken(String refreshToken) {
-        Claims refreshClaims = refreshTokenProvider.parseToken(refreshToken);
-
-        String refreshJti = refreshClaims.get("jti").toString();
-        String refreshKey = RedisProperties.REFRESH_TOKEN_PREFIX + refreshClaims.getSubject() + ":" + refreshJti;
-
+        String refreshKey = getRefreshTokenKey(refreshToken);
         boolean isDeleted = redisUtil.delete(refreshKey);
         if (!isDeleted) {
             log.warn("Refresh token 삭제 실패: {}", refreshKey);
@@ -60,10 +84,7 @@ public class RedisTokenUtil {
     }
 
     public boolean isAccessTokenBlackListed(String accessToken) {
-        Claims claims = accessTokenProvider.parseToken(accessToken);
-        String jti = claims.get("jti").toString();
-        String accessKey = RedisProperties.ACCESS_TOKEN_PREFIX + jti;
-
+        String accessKey = getAccessTokenKey(accessToken);
         return redisUtil.isTokenBlacklisted(accessKey);
     }
 }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #295 
- #296 

## 추가 및 변경사항
### [REFACT] **토큰 관련 Redis 조작 분리**
  - 토큰 관리(블랙리스트 등)를 위해 Redis에 캐싱하는 로직이 존재합니다.
    그러나 여러 위치에서 해당 기능이 복잡하게 흩어져 있어,
    공통 부분을 별도의 `RedisTokenUtil` 클래스로 분리하였습니다.
### [FEAT] **토큰 갱신 기능 추가**
  - **API URI** : `/api/auth/refresh`
  - **요청** : AccessToken(header) + RefreshToken(cookie)
  - **응답** : 로그인 응답과 완전히 동일 -> AccessToken + RefreshToken + FirebaseToken
  - **기능 세부** : 
    - 요청된 토큰들은 모두 **무효화 처리됩니다.** (같은 토큰으로 다시 요청하면 블랙리스트 처리로 거부)
    - 갱신 토큰이 만료되었다면 무조건 거부됩니다.
 ### [DOCS] **Swagger에서의 헤더/쿠키 처리 한계 알림**
   - 로그아웃/갱신 요청은 HTTP 헤더/브라우저 쿠키를 사용합니다.
   - 그러나 Swagger에서는 헤더/쿠키를 지원하지 않습니다.
   - 해당 안내가 Swagger API 명세에 추가되었습니다.
 ### [FIX] 액세스 토큰 만료시 로그아웃/갱신이 항상 거부되는 문제 수정
 
  <img width="400" src="https://github.com/user-attachments/assets/0132a20b-1bbd-4090-9023-c5269bf185c3" />

   - **문제 상황** :  AccessToken이 만료된 경우, 로그아웃과 갱신은 가능해야 하지만,
     죄다 무조건 토큰 만료 에러로 거부되는 문제가 발생합니다.
   - **원인** : 모든 요청이 무조건 토큰을 파싱하는 `JwtAuthenticationFilter`를 거치고 있어,
     심지어는 만료 토큰을 갱신하고자 하는 요청까지 거부하게 됩니다.
   - **해결방향** :
     - 토큰을 발급/갱신/무효화 하는 `/api/auth/**` 경로에 대해서는 토큰 검사 필터를 거치지 않도록 조정합니다.
     - 갱신 과정에서 만료된 토큰에 관해서도 정보가 필요하므로 `parseTokenIgnoringExpiration()` 메서드를 도입합니다.

## 테스트 결과
갱신시 이전 토큰의 무효화 (블랙리스트) -> **이상 무.**
<img width="500" src="https://github.com/user-attachments/assets/1f64fb2d-39b7-45d9-b265-8bbfe4be60d8" />

갱신시 RefreshToken이 만료 -> **에러 (토큰 만료) 발생 확인**
갱신시 AccessToken만 만료 -> **정상 갱신**
갱신시 두 토큰 모두 유효 -> **정상 갱신**
<img width="500" src="https://github.com/user-attachments/assets/d4b38b4c-aa56-4e81-80d8-4413dbde0502" />

## 📌 기타
- #297